### PR TITLE
runelet: use fexecve instead of exec self

### DIFF
--- a/rune/libcontainer/setns_init_linux.go
+++ b/rune/libcontainer/setns_init_linux.go
@@ -27,6 +27,7 @@ type linuxSetnsInit struct {
 	logPipe       *os.File
 	logLevel      string
 	agentPipe     *os.File
+	runeletFd     int
 }
 
 func (l *linuxSetnsInit) getSessionRingName() string {
@@ -97,7 +98,7 @@ func (l *linuxSetnsInit) Init() error {
 		if err != nil {
 			return newSystemErrorWithCause(err, "libenclave bootstrap")
 		}
-		return system.Execv("/proc/self/exe", []string{"runelet", "enclave"}, os.Environ())
+		return fexecve(l.runeletFd, []string{"runelet", "enclave"}, os.Environ())
 	}
 	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }


### PR DESCRIPTION
Use fexecve() instead of exec("/proc/self/exe"), This is to prepare
to runelet independently.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>