### PR TITLE
Unified palapi

### DIFF
--- a/rune/libcontainer/factory_linux.go
+++ b/rune/libcontainer/factory_linux.go
@@ -346,6 +346,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		envLogPipe     = os.Getenv("_LIBCONTAINER_LOGPIPE")
 		envLogLevel    = os.Getenv("_LIBCONTAINER_LOGLEVEL")
 		envAgentPipe   = os.Getenv("_LIBCONTAINER_AGENTPIPE")
+		envDetached    = os.Getenv("_LIBCONTAINER_DETACHED")
 	)
 
 	// Get the INITPIPE.
@@ -417,7 +418,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		}
 	}()
 
-	i, err := newContainerInit(it, pipe, consoleSocket, fifofd, logPipe, envLogLevel, agentPipe)
+	i, err := newContainerInit(it, pipe, consoleSocket, fifofd, logPipe, envLogLevel, agentPipe, envDetached)
 	if err != nil {
 		return err
 	}

--- a/rune/libcontainer/init_linux.go
+++ b/rune/libcontainer/init_linux.go
@@ -73,7 +73,7 @@ type initer interface {
 	Init() error
 }
 
-func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd int, logPipe *os.File, logLevel string, agentPipe *os.File) (initer, error) {
+func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd int, logPipe *os.File, logLevel string, agentPipe *os.File, detached string) (initer, error) {
 	var config *initConfig
 	if err := json.NewDecoder(pipe).Decode(&config); err != nil {
 		return nil, err
@@ -90,6 +90,7 @@ func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd 
 			logPipe:       logPipe,
 			logLevel:      logLevel,
 			agentPipe:     agentPipe,
+			detached:      detached,
 		}, nil
 	case initStandard:
 		return &linuxStandardInit{
@@ -101,6 +102,7 @@ func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd 
 			logPipe:       logPipe,
 			logLevel:      logLevel,
 			agentPipe:     agentPipe,
+			detached:      detached,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown init type %q", t)

--- a/rune/libcontainer/nsenter/loader.go
+++ b/rune/libcontainer/nsenter/loader.go
@@ -17,7 +17,7 @@ struct pal_stdio_fds {
 	int stdin, stdout, stderr;
 };
 
-extern int *pal_version;
+extern int (*fptr_pal_get_version)(void);
 extern int (*fptr_pal_init)(const struct pal_attr_t *attr);
 extern int (*fptr_pal_exec)(const char *path, const char * const argv[],
 			const struct pal_stdio_fds *stdio, int *exit_code);
@@ -31,7 +31,7 @@ import (
 )
 
 func SymAddrPalVersion() unsafe.Pointer {
-	return unsafe.Pointer(C.pal_version)
+	return unsafe.Pointer(C.fptr_pal_get_version)
 }
 
 func SymAddrPalInit() unsafe.Pointer {

--- a/rune/libcontainer/process.go
+++ b/rune/libcontainer/process.go
@@ -81,6 +81,8 @@ type Process struct {
 
 	// Provide agent service hosted by main runelet for child runelet.
 	AgentPipe *os.File
+
+	Detached int
 }
 
 // Wait waits for the process to exit.

--- a/rune/libcontainer/setns_init_linux.go
+++ b/rune/libcontainer/setns_init_linux.go
@@ -28,6 +28,7 @@ type linuxSetnsInit struct {
 	logPipe       *os.File
 	logLevel      string
 	agentPipe     *os.File
+	detached      string
 }
 
 func (l *linuxSetnsInit) getSessionRingName() string {
@@ -94,7 +95,7 @@ func (l *linuxSetnsInit) Init() error {
 		}
 	}
 	if l.config.Config.Enclave != nil {
-		err := libenclave.StartBootstrap(l.pipe, l.logPipe, l.logLevel, -1, l.agentPipe)
+		err := libenclave.StartBootstrap(l.pipe, l.logPipe, l.logLevel, -1, l.agentPipe, l.detached)
 		if err != nil {
 			return newSystemErrorWithCause(err, "libenclave bootstrap")
 		}

--- a/rune/libcontainer/standard_init_linux.go
+++ b/rune/libcontainer/standard_init_linux.go
@@ -31,6 +31,7 @@ type linuxStandardInit struct {
 	logPipe       *os.File
 	logLevel      string
 	agentPipe     *os.File
+	detached      string
 }
 
 func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {
@@ -179,7 +180,7 @@ func (l *linuxStandardInit) Init() error {
 		return unix.Kill(unix.Getpid(), unix.SIGKILL)
 	}
 	if l.config.Config.Enclave != nil {
-		err := libenclave.StartBootstrap(l.pipe, l.logPipe, l.logLevel, l.fifoFd, l.agentPipe)
+		err := libenclave.StartBootstrap(l.pipe, l.logPipe, l.logLevel, l.fifoFd, l.agentPipe, l.detached)
 		if err != nil {
 			return err
 		}

--- a/rune/libenclave/bootstrap.go
+++ b/rune/libenclave/bootstrap.go
@@ -10,7 +10,7 @@ import (
 // environment variable must be staged and then recovered after re-exec. This
 // process is so called as libenclave bootstrapping, and the resulting process
 // is so called as runelet.
-func StartBootstrap(initPipe *os.File, logPipe *os.File, logLevel string, fifoFd int, agentPipe *os.File) (err error) {
+func StartBootstrap(initPipe *os.File, logPipe *os.File, logLevel string, fifoFd int, agentPipe *os.File, detached string) (err error) {
 	logrus.Debug("bootstrapping libenclave ...")
 
 	if err = stageFd("_LIBENCLAVE_INITPIPE", initPipe); err != nil {
@@ -60,5 +60,7 @@ func StartBootstrap(initPipe *os.File, logPipe *os.File, logLevel string, fifoFd
 		}
 	}()
 
+	os.Setenv("_LIBENCLAVE_DETACHED", detached)
+	
 	return nil
 }

--- a/rune/libenclave/internal/runtime/enclave_runtime.go
+++ b/rune/libenclave/internal/runtime/enclave_runtime.go
@@ -10,7 +10,6 @@ import (
 )
 
 type EnclaveRuntime interface {
-	Name() string
 	Load(path string) error
 	Init(args string, logLevel string) error
 	Attest() error
@@ -43,9 +42,8 @@ func StartInitialization(config *configs.InitEnclaveConfig, logLevel string) (*E
 	if err != nil {
 		return nil, err
 	}
-	name := runtime.Name()
 
-	logrus.Infof("Initializing enclave runtime %s", name)
+	logrus.Infof("Initializing enclave runtime")
 	err = runtime.Init(config.Args, logLevel)
 	if err != nil {
 		return nil, err
@@ -58,13 +56,13 @@ func StartInitialization(config *configs.InitEnclaveConfig, logLevel string) (*E
 }
 
 func (rt *EnclaveRuntimeWrapper) LaunchAttestation() error {
-	logrus.Debugf("attesting enclave runtime %s", rt.runtime.Name())
+	logrus.Debugf("attesting enclave runtime")
 
 	return rt.runtime.Attest()
 }
 
 func (rt *EnclaveRuntimeWrapper) ExecutePayload(cmd []string, envp []string, stdio [3]*os.File) (int32, error) {
-	logrus.Debugf("enclave runtime %s executing payload with commandline %s", rt.runtime.Name(), cmd)
+	logrus.Debugf("enclave runtime %s executing payload with commandline", cmd)
 
 	// The executable may not exist in container at all according
 	// to the design of enclave runtime, such as Occlum, which uses
@@ -78,16 +76,16 @@ func (rt *EnclaveRuntimeWrapper) ExecutePayload(cmd []string, envp []string, std
 
 func (rt *EnclaveRuntimeWrapper) KillPayload(sig int, pid int) error {
 	if pid != -1 {
-		logrus.Debugf("enclave runtime %s killing payload %d with signal %d", rt.runtime.Name(), pid, sig)
+		logrus.Debugf("enclave runtime killing payload %d with signal %d", pid, sig)
 	} else {
-		logrus.Debugf("enclave runtime %s killing all payloads with signal %d", rt.runtime.Name(), sig)
+		logrus.Debugf("enclave runtime killing all payloads with signal %d", sig)
 	}
 
 	return rt.runtime.Kill(sig, pid)
 }
 
 func (rt *EnclaveRuntimeWrapper) DestroyInstance() error {
-	logrus.Debugf("Destroying enclave runtime %s", rt.runtime.Name())
+	logrus.Debugf("Destroying enclave runtime")
 
 	return rt.runtime.Destroy()
 }

--- a/rune/libenclave/internal/runtime/pal/api_linux.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux.go
@@ -3,6 +3,11 @@ package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave
 /*
 #include <stdlib.h>
 
+static int palGetVersion(void *sym)
+{
+	return ((int (*)(void))sym)();
+}
+
 static int palInitV1(void *sym, const char *args, const char *log_level)
 {
 	typedef struct {
@@ -65,7 +70,7 @@ func (pal *enclaveRuntimePalApiV1) get_version() uint32 {
 	logrus.Debugf("pal get_version() called")
 	sym := nsenter.SymAddrPalVersion()
 	if sym != nil {
-		return *(*uint32)(sym)
+		return uint32(C.palGetVersion(sym))
 	} else {
 		return palApiVersion
 	}

--- a/rune/libenclave/internal/runtime/pal/pal.go
+++ b/rune/libenclave/internal/runtime/pal/pal.go
@@ -5,7 +5,6 @@ import (
 )
 
 type enclaveRuntimePal struct {
-	name    string
 	version uint32
 }
 

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -3,27 +3,9 @@ package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave
 import (
 	"fmt"
 	"os"
-	"path"
-	"strings"
-)
-
-const (
-	palPrefix = "liberpal-"
-	palSuffix = ".so"
 )
 
 func (pal *enclaveRuntimePal) Load(palPath string) (err error) {
-	bp := path.Base(palPath)
-	if !strings.HasPrefix(bp, palPrefix) {
-		return fmt.Errorf("not found pal prefix pattern in pal %s\n", palPath)
-	}
-	if !strings.HasSuffix(bp, palSuffix) {
-		return fmt.Errorf("not found pal suffix pattern in pal %s\n", palPath)
-	}
-	palName := strings.TrimSuffix(strings.TrimPrefix(bp, palPrefix), palSuffix)
-
-	pal.name = palName
-
 	if err = pal.getPalApiVersion(); err != nil {
 		return err
 	}
@@ -38,10 +20,6 @@ func (pal *enclaveRuntimePal) getPalApiVersion() error {
 	}
 	pal.version = ver
 	return nil
-}
-
-func (pal *enclaveRuntimePal) Name() string {
-	return fmt.Sprintf("%s (API version %d)", pal.name, pal.version)
 }
 
 func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {

--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"strconv"
@@ -95,6 +96,14 @@ func StartInitialization() (exitCode int32, err error) {
 			return 1, err
 		}
 	}
+
+	// If runelet run as detach mode, close logrus before initpipe closed.
+	envDetach := os.Getenv("_LIBENCLAVE_DETACHED")
+	detach, err := strconv.Atoi(envDetach)
+	if detach != 0 {
+		logrus.SetOutput(ioutil.Discard)
+	}
+	os.Unsetenv("_LIBENCLAVE_DETACHED")
 
 	// Close the init pipe to signal that we have completed our init.
 	// So `rune create` or the upper half part of `rune run` can return.

--- a/rune/utils_linux.go
+++ b/rune/utils_linux.go
@@ -305,6 +305,11 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	var (
 		detach = r.detach || (r.action == CT_ACT_CREATE)
 	)
+
+	if detach {
+		process.Detached = 1
+	}
+
 	// Setting up IO is a two stage process. We need to modify process to deal
 	// with detaching containers, and then we get a tty after the container has
 	// started.


### PR DESCRIPTION
1. If rune create is running in detach mode, then runelet does not use logpipe.
2. Use unified pal api interface.