### PR TITLE
rune/nsenter: Compatible with runc when PAL path is not specified

### DIFF
--- a/rune/libcontainer/nsenter/loader.c
+++ b/rune/libcontainer/nsenter/loader.c
@@ -54,7 +54,7 @@ int load_enclave_runtime(void)
 	file = getenv("_LIBCONTAINER_PAL_PATH");
 	if (file == NULL || *file == '\0') {
 		write_log(DEBUG, "invalid environment _LIBCONTAINER_PAL_PATH");
-		return -EINVAL;
+		return 0;
 	}
 	write_log(DEBUG, "_LIBCONTAINER_PAL_PATH = %s", file);
 


### PR DESCRIPTION
If rune is used as runc, PAL path will not be specified, runc logic
should be followed.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>