### PR TITLE
rune/libenclave: Optimize the way of passing parameters

### DIFF
--- a/rune/libcontainer/container_linux.go
+++ b/rune/libcontainer/container_linux.go
@@ -494,7 +494,7 @@ func (c *linuxContainer) newParentProcess(p *Process) (parentProcess, error) {
 	return c.newInitProcess(p, cmd, messageSockPair, logFilePair)
 }
 
-func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, childLogPipe *os.File, agentPipe *os.File, detached int) *exec.Cmd {
+func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, childLogPipe *os.File, agentPipe *os.File, detached bool) *exec.Cmd {
 	cmd := exec.Command(c.initPath, c.initArgs[1:]...)
 	cmd.Args[0] = c.initArgs[0]
 	cmd.Stdin = p.Stdin
@@ -538,8 +538,13 @@ func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, chi
 			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_ROOTFS=" + string(c.config.Rootfs))
 		}
 
-		cmd.Env = append(cmd.Env,
-				fmt.Sprintf("_LIBCONTAINER_DETACHED=%d", detached))
+		if detached {
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("_LIBCONTAINER_DETACHED=%d", 1))
+		} else {
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("_LIBCONTAINER_DETACHED=%d", 0))
+		}
 	}
 
 	// NOTE: when running a container with no PID namespace and the parent process spawning the container is

--- a/rune/libcontainer/factory_linux.go
+++ b/rune/libcontainer/factory_linux.go
@@ -340,6 +340,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		consoleSocket  *os.File
 		logPipe        *os.File
 		agentPipe      *os.File
+		detached       = false
 		envInitPipe    = os.Getenv("_LIBCONTAINER_INITPIPE")
 		envFifoFd      = os.Getenv("_LIBCONTAINER_FIFOFD")
 		envConsole     = os.Getenv("_LIBCONTAINER_CONSOLE")
@@ -396,6 +397,16 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		defer agentPipe.Close()
 	}
 
+	if envDetached != "" {
+		tmpDetached, err := strconv.Atoi(envDetached)
+		if err != nil {
+			return fmt.Errorf("unable to convert _LIBCONTAINER_DETACHED=%s to int: %s", envDetached, err)
+		}
+		if tmpDetached != 0 {
+			detached = true
+		}
+	}
+
 	// clear the current process's environment to clean any libcontainer
 	// specific env vars.
 	os.Clearenv()
@@ -418,7 +429,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		}
 	}()
 
-	i, err := newContainerInit(it, pipe, consoleSocket, fifofd, logPipe, envLogLevel, agentPipe, envDetached)
+	i, err := newContainerInit(it, pipe, consoleSocket, fifofd, logPipe, envLogLevel, agentPipe, detached)
 	if err != nil {
 		return err
 	}

--- a/rune/libcontainer/init_linux.go
+++ b/rune/libcontainer/init_linux.go
@@ -73,7 +73,7 @@ type initer interface {
 	Init() error
 }
 
-func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd int, logPipe *os.File, logLevel string, agentPipe *os.File, detached string) (initer, error) {
+func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd int, logPipe *os.File, logLevel string, agentPipe *os.File, detached bool) (initer, error) {
 	var config *initConfig
 	if err := json.NewDecoder(pipe).Decode(&config); err != nil {
 		return nil, err

--- a/rune/libcontainer/process.go
+++ b/rune/libcontainer/process.go
@@ -82,7 +82,7 @@ type Process struct {
 	// Provide agent service hosted by main runelet for child runelet.
 	AgentPipe *os.File
 
-	Detached int
+	Detached bool
 }
 
 // Wait waits for the process to exit.

--- a/rune/libcontainer/setns_init_linux.go
+++ b/rune/libcontainer/setns_init_linux.go
@@ -28,7 +28,7 @@ type linuxSetnsInit struct {
 	logPipe       *os.File
 	logLevel      string
 	agentPipe     *os.File
-	detached      string
+	detached      bool
 }
 
 func (l *linuxSetnsInit) getSessionRingName() string {

--- a/rune/libcontainer/standard_init_linux.go
+++ b/rune/libcontainer/standard_init_linux.go
@@ -31,7 +31,7 @@ type linuxStandardInit struct {
 	logPipe       *os.File
 	logLevel      string
 	agentPipe     *os.File
-	detached      string
+	detached      bool
 }
 
 func (l *linuxStandardInit) getSessionRingParams() (string, uint32, uint32) {

--- a/rune/libenclave/bootstrap.go
+++ b/rune/libenclave/bootstrap.go
@@ -11,7 +11,7 @@ type enclaveRuntimeEnv struct {
 	logLevel string
 	fifoFd int
 	agentPipe *os.File
-	detached string
+	detached bool
 }
 
 var enclaveEnv enclaveRuntimeEnv
@@ -25,7 +25,7 @@ func GetEnclaveRunetimeEnv() *enclaveRuntimeEnv {
 // environment variable must be staged and then recovered after re-exec. This
 // process is so called as libenclave bootstrapping, and the resulting process
 // is so called as runelet.
-func StartBootstrap(initPipe *os.File, logPipe *os.File, logLevel string, fifoFd int, agentPipe *os.File, detached string) (err error) {
+func StartBootstrap(initPipe *os.File, logPipe *os.File, logLevel string, fifoFd int, agentPipe *os.File, detached bool) (err error) {
 	logrus.Debug("bootstrapping libenclave ...")
 
 	enclaveEnv.initPipe = initPipe

--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 )
@@ -71,8 +70,7 @@ func StartInitialization() (exitCode int32, err error) {
 	}
 
 	// If runelet run as detach mode, close logrus before initpipe closed.
-	detach, err := strconv.Atoi(env.detached)
-	if detach != 0 {
+	if env.detached {
 		logrus.SetOutput(ioutil.Discard)
 	}
 

--- a/rune/utils_linux.go
+++ b/rune/utils_linux.go
@@ -307,7 +307,7 @@ func (r *runner) run(config *specs.Process) (int, error) {
 	)
 
 	if detach {
-		process.Detached = 1
+		process.Detached = true
 	}
 
 	// Setting up IO is a two stage process. We need to modify process to deal


### PR DESCRIPTION
Because there is no re-exec operation, there is no need to use
environment variables to pass parameters between bootstrap and
runelet, use global variables instead of environment variables.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>