### PR TITLE
rune/libenclave: Implement the general sgx entry point for skeleton

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -7,7 +7,7 @@ HOST_CFLAGS := -Wall -Werror -g -fPIC -z noexecstack \
 		-Wno-unused-const-variable
 ENCL_CFLAGS := -Wall -Werror -static -nostdlib -nostartfiles -fPIC \
 	       -fno-stack-protector -mrdrnd
-HOST_LDFLAGS := -fPIC -shared
+HOST_LDFLAGS := -fPIC -shared -Wl,-Bsymbolic
 
 TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton.so $(OUTPUT)/signing_key.pem $(OUTPUT)/encl.token
 

--- a/rune/libenclave/internal/runtime/pal/skeleton/defines.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/defines.h
@@ -10,6 +10,7 @@
 
 #define __aligned(x) __attribute__((__aligned__(x)))
 #define __packed __attribute__((packed))
+#define static_assert _Static_assert
 
 #include "arch.h"
 #include "sgx.h"

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.c
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 #include "defines.h"
+#include "arch.h"
+#include "sgx_call.h"
 
 static void *memcpy(void *dest, const void *src, size_t n)
 {
@@ -14,7 +16,15 @@ static void *memcpy(void *dest, const void *src, size_t n)
 	return dest;
 }
 
-void encl_body(void *rdi, void *rsi)
+static int encl_init(void *dst)
 {
-	memcpy(rsi, rdi, 8);
+	static uint64_t magic = INIT_MAGIC;
+
+	memcpy(dst, &magic, 8);
+
+	return 0;
 }
+
+unsigned long enclave_call_table[MAX_ECALLS] = {
+        (unsigned long)encl_init,
+};

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl_bootstrap.S
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl_bootstrap.S
@@ -3,9 +3,7 @@
  * Copyright(c) 2016-18 Intel Corporation.
  */
 
-	.macro ENCLU
-	.byte 0x0f, 0x01, 0xd7
-	.endm
+#include "sgx_call.h"
 
 	.section ".tcs", "a"
 	.balign	4096
@@ -25,30 +23,54 @@
 
 	.text
 
+	# At this moment, the register context is:
+	# - R10: the ecall number
+	# - RDI, RSI, RDX, R8 and R9: function parameters
+	# - R11: the backup of fouth parameter originated from RCX
+	# - RAX: the CSSA of current TCS
+	# - RBX: the base of TCS page
+	# - RCX: the return address after EENTER
 encl_entry:
+	cmp	$MAX_ECALLS, %r10
+	jge	err
+
 	# RBX contains the base address for TCS, which is also the first address
 	# inside the enclave. By adding the value of le_stack_end to it, we get
 	# the absolute address for the stack.
-	lea	(encl_stack)(%rbx), %rax
-	xchg	%rsp, %rax
-	push	%rax
+	lea	(encl_stack)(%rbx), %r12
+	xchg	%rsp, %r12
 
-	push	%rcx # push the address after EENTER
-	push	%rbx # push the enclave base address
+	# Save the return address after EENTER to be consumed by EEXIT.
+	mov	%rcx, %r13
 
-	call	encl_body
+	# Recover the fouth parameter.
+	mov	%r11, %rcx
 
-	pop	%rbx # pop the enclave base address
+	# Call ecall function according to R10.
+	lea	enclave_call_table(%rip), %r14
+	mov	(%r14, %r10, 8), %r14
+	call	1f
+1:
+	pop	%r15
+	sub	$1b, %r15
+	add	%r15, %r14
+	call	*%r14
+
+	# Return the result of ecall function in RDX.
+	mov	%rax, %rdx
 
 	# Restore XSAVE registers to a synthetic state.
-	mov     $0xFFFFFFFF, %rax
-	mov     $0xFFFFFFFF, %rdx
 	lea	(xsave_area)(%rbx), %rdi
 	fxrstor	(%rdi)
 
+	# Prepare EEXIT target after EENTER.
+	mov	%r13, %rbx
+
+	# Restore the caller stack.
+	mov	%r12, %rsp
+
 	# Clear GPRs.
-	xor     %rcx, %rcx
-	xor     %rdx, %rdx
+	xor     %rbp, %rbp
 	xor     %rdi, %rdi
 	xor     %rsi, %rsi
 	xor     %r8, %r8
@@ -61,19 +83,19 @@ encl_entry:
 	xor     %r15, %r15
 
 	# Reset status flags.
-	add     %rdx, %rdx # OF = SF = AF = CF = 0; ZF = PF = 1
+	add     %r15, %r15 # OF = SF = AF = CF = 0; ZF = PF = 1
 
-	# Prepare EEXIT target by popping the address of the instruction after
-	# EENTER to RBX.
-	pop	%rbx
-
-	# Restore the caller stack.
-	pop	%rax
-	mov	%rax, %rsp
-
-	# EEXIT
-	mov	$4, %rax
-	enclu
+2:
+	# EEXIT ABI:
+	# - [IN] RAX contains the EEXIT leaf number 4
+	# - [IN] RBX points to the return address of EEXIT
+	mov	$EEXIT, %rax
+	ENCLU
+	# Never return
+3:	jmp	3b
+err:
+	mov	%rcx, %rbx
+	jmp	2b
 
 	.section ".data", "aw"
 

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.S
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.S
@@ -3,33 +3,44 @@
 * Copyright(c) 2016-18 Intel Corporation.
 */
 
-	.text
-
-	.macro ENCLU
-	.byte 0x0f, 0x01, 0xd7
-	.endm
+#include "sgx_call.h"
 
 	.text
 
-	.global sgx_call_eenter
-sgx_call_eenter:
+	# sgx ecall ABI:
+	# - RDI, RSI, RDX, RCX, R8 and R9 are parameters
+	# - R10 contains the ecall number
+	# - R11 contains the base of TCS
+	.global sgx_ecall
+	.type sgx_ecall, @function
+sgx_ecall:
 	push	%rbx
+	push	%rbp
 	push	%rdi
 	push	%rsi
 	push    %r12
 	push    %r13
 	push    %r14
 	push    %r15
+	# EENTER ABI:
+	# - [IN] RAX contains the EENTER leaf number 2
+	# - [IN] RBX points to target TCS page
+	# - [IN] RCX points to AEP
 	mov	$0x02, %rax
-	mov	%rdx, %rbx
+	mov	%r11, %rbx
+	# RCX is used to hold AEP so back up it with R11
+	mov	%rcx, %r11
 	lea	sgx_async_exit(%rip), %rcx
 sgx_async_exit:
 	ENCLU
+	# Return value is saved in RAX.
+	mov	%rdx, %rax
 	pop	%r15
 	pop	%r14
 	pop	%r13
 	pop	%r12
 	pop	%rsi
 	pop	%rdi
+	pop	%rbp
 	pop	%rbx
 	ret

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.h
@@ -6,6 +6,36 @@
 #ifndef SGX_CALL_H
 #define SGX_CALL_H
 
-void sgx_call_eenter(void *rdi, void *rsi, void *entry);
+#define ECALL_MAGIC		0
+#define MAX_ECALLS		1
+
+#define EEXIT			4
+
+#define INIT_MAGIC		0xdeadfacedeadbeefUL
+
+#ifndef __ASSEMBLER__
+
+#define SGX_ENTER_1_ARG(ecall_num, tcs, a0) \
+	({      \
+		int __ret; \
+		asm volatile( \
+			"mov %1, %%r10\n\t" \
+			"mov %2, %%r11\n\t" \
+			"call sgx_ecall\n\t" \
+			: "=a" (__ret) \
+			: "r" ((uint64_t)ecall_num), "r" (tcs), \
+			  "D" (a0) \
+			: "r10", "r11" \
+		); \
+		__ret; \
+	})
+
+#define ENCLU			".byte 0x0f, 0x01, 0xd7"
+
+#else
+
+#define ENCLU			.byte 0x0f, 0x01, 0xd7
+
+#endif
 
 #endif /* SGX_CALL_H */


### PR DESCRIPTION
In order to implement more ecall functions, it is necessary to
implement a general sgx entry point with ecall number to
corresponding ecall handler.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>