### PR TITLE
rune/libcontainer: Fix LD_LIBRARY_PATH invalid in dlopen()

### DIFF
--- a/rune/libcontainer/container_linux.go
+++ b/rune/libcontainer/container_linux.go
@@ -531,11 +531,16 @@ func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, chi
 				fmt.Sprintf("_LIBCONTAINER_AGENTPIPE=%d", stdioFdCount+len(cmd.ExtraFiles)-1))
 		}
 
-		if c.config.Enclave.Path != "" {
-			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_PATH=" + string(c.config.Enclave.Path))
-		}
 		if c.config.Enclave.Signer != "server" {
-			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_ROOTFS=" + string(c.config.Rootfs))
+			rootfs := c.config.Rootfs
+			// LD_LIBRARY_PATH must be set before the process starts to be valid
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("LD_LIBRARY_PATH=%s/usr/lib:%s/usr/lib64:%s/lib:%s/lib64",
+					rootfs, rootfs, rootfs, rootfs));
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("_LIBCONTAINER_PAL_PATH=%s/%s", rootfs, c.config.Enclave.Path))
+		} else if c.config.Enclave.Path != "" {
+			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_PATH=" + c.config.Enclave.Path)
 		}
 
 		if detached {


### PR DESCRIPTION
It is found in the experiment that LD_LIBRARY_PATH must be set
before the process starts, which may be caused by the internal
cache. Therefore, the LD_LIBRARY_PATH environment setting is
moved to before bootstrap starts.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>