### PR TITLE
rune/libenclave: Fix processing LD_LIBRARY_PATH #2

### DIFF
--- a/rune/libcontainer/container_linux.go
+++ b/rune/libcontainer/container_linux.go
@@ -531,16 +531,12 @@ func (c *linuxContainer) commandTemplate(p *Process, childInitPipe *os.File, chi
 				fmt.Sprintf("_LIBCONTAINER_AGENTPIPE=%d", stdioFdCount+len(cmd.ExtraFiles)-1))
 		}
 
+		if c.config.Enclave.Path != "" {
+			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_PATH="+string(c.config.Enclave.Path))
+		}
+
 		if c.config.Enclave.Signer != "server" {
-			rootfs := c.config.Rootfs
-			// LD_LIBRARY_PATH must be set before the process starts to be valid
-			cmd.Env = append(cmd.Env,
-				fmt.Sprintf("LD_LIBRARY_PATH=%s/usr/lib:%s/usr/lib64:%s/lib:%s/lib64",
-					rootfs, rootfs, rootfs, rootfs));
-			cmd.Env = append(cmd.Env,
-				fmt.Sprintf("_LIBCONTAINER_PAL_PATH=%s/%s", rootfs, c.config.Enclave.Path))
-		} else if c.config.Enclave.Path != "" {
-			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_PATH=" + c.config.Enclave.Path)
+			cmd.Env = append(cmd.Env, "_LIBCONTAINER_PAL_ROOTFS="+string(c.config.Rootfs))
 		}
 
 		if detached {

--- a/rune/libcontainer/nsenter/loader.c
+++ b/rune/libcontainer/nsenter/loader.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <linux/limits.h>
 
 /* Defined in nsexec.c. */
 
@@ -37,18 +38,28 @@ int is_enclave(void)
 
 int load_enclave_runtime(void)
 {
-	const char *file;
+	char pal_full_path[PATH_MAX+1];
+	char *pal_path;
+	const char *rootfs;
 	void *dl;
 
-	file = getenv("_LIBCONTAINER_PAL_PATH");
-	if (file == NULL || *file == '\0') {
+	pal_path = getenv("_LIBCONTAINER_PAL_PATH");
+	if (pal_path == NULL || *pal_path == '\0') {
 		write_log(DEBUG, "invalid environment _LIBCONTAINER_PAL_PATH");
 		return 0;
 	}
-	write_log(DEBUG, "_LIBCONTAINER_PAL_PATH = %s", file);
+
+	write_log(DEBUG, "_LIBCONTAINER_PAL_PATH = %s", pal_path);
 	write_log(DEBUG, "LD_LIBRARY_PATH = %s", getenv("LD_LIBRARY_PATH"));
 
-	dl = dlopen(file, RTLD_NOW);
+	rootfs = getenv("_LIBCONTAINER_PAL_ROOTFS");
+	if (rootfs && *rootfs != '\0') {
+		snprintf(pal_full_path, sizeof(pal_full_path) - 1, "%s/%s", rootfs, pal_path);
+		pal_path = pal_full_path;
+	}
+
+	dl = dlopen(pal_path, RTLD_NOW);
+	unsetenv("LD_LIBRARY_PATH");
 	if (dl == NULL) {
 		write_log(DEBUG, "dlopen(): %s", dlerror());
 		/* set errno correctly, make bail() work better */


### PR DESCRIPTION
Instead of inheriting LD_LIBRARY_PATH by bootstrap, make it available
only for boostrap's child process.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>