### PR TITLE
rune: fix statically make error.

### DIFF
--- a/rune/Makefile
+++ b/rune/Makefile
@@ -47,7 +47,7 @@ skeleton: libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.so
 libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.so:
 	make -C libenclave/internal/runtime/pal/skeleton
 
-static:
+static: $(PROTOS)
 	$(GO_BUILD_STATIC) -o rune .
 	$(GO_BUILD_STATIC) -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 


### PR DESCRIPTION
make statically dependent PROTOS to *.pb.go files.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>