### PR TITLE
rune/libcontainer: Mount aesm.socket from /var/run/aesmd/

### DIFF
--- a/rune/libcontainer/specconv/example.go
+++ b/rune/libcontainer/specconv/example.go
@@ -175,9 +175,9 @@ func Example() *specs.Spec {
 		}
 		spec.Mounts = append(spec.Mounts,
 			specs.Mount{
-				Destination: "/run/aesmd",
+				Destination: "/var/run/aesmd",
 				Type:        "bind",
-				Source:      "/run/aesmd",
+				Source:      "/var/run/aesmd",
 				Options:     []string{"rbind", "rprivate"},
 			})
 	}

--- a/rune/libcontainer/specconv/spec_linux.go
+++ b/rune/libcontainer/specconv/spec_linux.go
@@ -461,8 +461,8 @@ func createLibcontainerMount(cwd string, m specs.Mount) *configs.Mount {
 func createLibenclaveMount(cwd string) *configs.Mount {
 	return &configs.Mount{
 		Device:           "bind",
-		Source:           "/run/aesmd",
-		Destination:      "/run/aesmd",
+		Source:           "/var/run/aesmd",
+		Destination:      "/var/run/aesmd",
 		Flags:            unix.MS_BIND | unix.MS_REC,
 		PropagationFlags: []int{unix.MS_PRIVATE | unix.MS_REC},
 	}


### PR DESCRIPTION
/run is usally a symbol link to /var/run but it is not always true.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>