### PR TITLE
fix the issue that /dev is mounted abnormally in the scratch image

### DIFF
--- a/shim/runtime/carrier/constants/constants.go
+++ b/shim/runtime/carrier/constants/constants.go
@@ -11,7 +11,6 @@ const (
 	EnclaveRuntimePathKeyName = "ENCLAVE_RUNTIME_PATH"
 	EnclaveRuntimeArgsKeyName = "ENCLAVE_RUNTIME_ARGS"
 	DefaultEnclaveRuntimeArgs = ".occlum"
-	OcclumConfigPathKeyName   = "OCCLUM_CONFIG_PATH"
 )
 
 const (

--- a/shim/runtime/carrier/occlum/occlum.go
+++ b/shim/runtime/carrier/occlum/occlum.go
@@ -346,10 +346,6 @@ func (c *occlum) initBundleConfig() error {
 		carr_const.EnclaveTypeKeyName:        string(carr_const.IntelSGX),
 		carr_const.EnclaveRuntimeArgsKeyName: carr_const.DefaultEnclaveRuntimeArgs,
 	}
-	occlumConfigPath, ok := config.GetEnv(spec, carr_const.OcclumConfigPathKeyName)
-	if ok {
-		c.configPath = occlumConfigPath
-	}
 	c.spec = spec
 	if err := config.UpdateEnvs(spec, envs, false); err != nil {
 		return err

--- a/shim/runtime/v2/rune/v2/rune.go
+++ b/shim/runtime/v2/rune/v2/rune.go
@@ -57,13 +57,6 @@ func (s *service) carrierMain(req *taskAPI.CreateTaskRequest) (carrier.Carrier, 
 			return carr, err
 		}
 
-		// mount oci defined mounts
-		err = mountOCIOnRootfs(req.Bundle)
-		defer unmountOCIOnRootfs(req.Bundle)
-		if err != nil {
-			return carr, err
-		}
-
 	case rune.Graphene:
 		carr, err = graphene.NewGrapheneCarrier()
 	case rune.Empty:
@@ -232,19 +225,6 @@ func mountOCIOnRootfs(bundle string) error {
 			Options: rm.Options,
 		}
 		target := filepath.Clean(filepath.Join(bundle, "rootfs", rm.Destination))
-		s, err := os.Stat(rm.Source)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return err
-		}
-		if s.IsDir() {
-			os.MkdirAll(target, s.Mode())
-		} else {
-			os.MkdirAll(path.Dir(target), 0644)
-			os.Create(target)
-		}
 		if err := m.Mount(target); err != nil {
 			return errors.Wrapf(err, "failed to mount rootfs component %v, err: %++v", m, err)
 		}


### PR DESCRIPTION
fix the issue that /dev is mounted abnormally in the scratch image, and delete the code that mount directories in config.json on the rootfs.