### PR TITLE
rune/libcontainer: Fix the path to /run/rune

### DIFF
--- a/rune/libcontainer/specconv/example.go
+++ b/rune/libcontainer/specconv/example.go
@@ -166,11 +166,11 @@ func Example() *specs.Spec {
 
 	if libenclave.IsEnclaveHwEnabled(configs.EnclaveHwIntelSgx) {
 		spec.Hostname = "rune"
-		spec.Process.Cwd = "/run/rune"
+		spec.Process.Cwd = "/var/run/rune"
 		spec.Root.Readonly = false
 		spec.Annotations = map[string]string{
 			"enclave.type":         "intelSgx",
-			"enclave.runtime.path": "/run/rune/liberpal-skeleton.so",
+			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton.so",
 			"enclave.runtime.args": "skeleton,debug",
 		}
 		spec.Mounts = append(spec.Mounts,


### PR DESCRIPTION
This path doesn't always exist in a container.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>