### PR TITLE
rune/libcontainer: Clean up enclave exit path on error

### DIFF
--- a/rune/libcontainer/setns_init_linux.go
+++ b/rune/libcontainer/setns_init_linux.go
@@ -106,8 +106,7 @@ func (l *linuxSetnsInit) Init() error {
 
 		exitCode, err := libenclave.StartInitialization(l.config.Args, cfg)
 		if err != nil {
-			logrus.Fatal(err)
-			os.Exit(1)
+			return err
 		}
 		logrus.Debugf("enclave payload exit code: %d", exitCode)
 		os.Exit(int(exitCode))

--- a/rune/libcontainer/standard_init_linux.go
+++ b/rune/libcontainer/standard_init_linux.go
@@ -197,8 +197,7 @@ func (l *linuxStandardInit) Init() error {
 
 		exitCode, err := libenclave.StartInitialization(l.config.Args, cfg)
 		if err != nil {
-			logrus.Fatal(err)
-			os.Exit(1)
+			return err
 		}
 		logrus.Debugf("init enclave runtime exit code: %d", exitCode)
 		os.Exit(int(exitCode))


### PR DESCRIPTION
The final error message will be sent back to the parent so there is
no need to log it.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>