### PR TITLE
rune && runectl && shim: Add global Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: all install clean uninstall
+
+all:
+	$(MAKE) -C rune
+	$(MAKE) -C runectl
+	$(MAKE) -C shim
+
+install:
+	$(MAKE) -C rune install
+	$(MAKE) -C runectl install
+	$(MAKE) -C shim install
+
+clean:
+	$(MAKE) -C rune clean
+	$(MAKE) -C runectl clean
+	$(MAKE) -C shim clean
+
+uninstall:
+	$(MAKE) -C rune uninstall
+	$(MAKE) -C runectl uninstall
+	$(MAKE) -C shim uninstall

--- a/rune/Makefile
+++ b/rune/Makefile
@@ -128,6 +128,9 @@ clean:
 	rm -f $(PROTOS)
 	make -C libenclave/internal/runtime/pal/skeleton clean
 
+uninstall:
+	rm -f $(BINDIR)/rune
+
 validate:
 	script/validate-gofmt
 	script/validate-c
@@ -161,5 +164,5 @@ localcross:
 .PHONY: rune all recvtty static release dbuild lint man runcimage \
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \
-	install-man clean validate ci \
+	install-man clean uninstall validate ci \
 	vendor verify-dependencies cross localcross skeleton


### PR DESCRIPTION
1. add global Makefile for all components. 
2. add make uninstall for rune/Makefile.  

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>