### PR TITLE
rune/libenclave: Fix spelling mistakes in skeleton README.md.

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -11,7 +11,7 @@ Refer to [this guide](https://github.com/alibaba/inclavare-containers/tree/maste
 ```shell
 cd "${path_to_inclavare_containers}/rune/libenclave/internal/runtime/pal/skeleton"
 make
-cp liberpal-skeletion.so /usr/lib
+cp liberpal-skeleton.so /usr/lib
 ```
 
 ---


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>