### PR TITLE
rune && shim: Add centos rpms spec.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,30 @@
-.PHONY: all install clean uninstall
+.PHONY: all install clean uninstall rpm
+
+export INCLAVARE_CONTAINERS_VERSION := $(shell cat ./VERSION)
+components := rune shim runectl
+rpm_release_components := rune shim
 
 all:
-	$(MAKE) -C rune
-	$(MAKE) -C runectl
-	$(MAKE) -C shim
+	for name in $(components); do \
+		$(MAKE) -C $$name; \
+	done
 
 install:
-	$(MAKE) -C rune install
-	$(MAKE) -C runectl install
-	$(MAKE) -C shim install
+	for name in $(components); do \
+		$(MAKE) -C $$name install; \
+	done
 
 clean:
-	$(MAKE) -C rune clean
-	$(MAKE) -C runectl clean
-	$(MAKE) -C shim clean
+	for name in $(components); do \
+		$(MAKE) -C $$name clean; \
+	done
 
 uninstall:
-	$(MAKE) -C rune uninstall
-	$(MAKE) -C runectl uninstall
-	$(MAKE) -C shim uninstall
+	for name in $(components); do \
+		$(MAKE) -C $$name uninstall; \
+	done
+
+rpm:
+	for name in $(rpm_release_components); do \
+		$(MAKE) -C $$name rpm; \
+	done

--- a/rune/Makefile
+++ b/rune/Makefile
@@ -161,8 +161,11 @@ localcross:
 	CGO_ENABLED=1 GOARCH=arm64 CC=aarch64-linux-gnu-gcc         $(GO_BUILD) -o runc-arm64 .
 	CGO_ENABLED=1 GOARCH=ppc64le CC=powerpc64le-linux-gnu-gcc   $(GO_BUILD) -o runc-ppc64le .
 
+rpm:
+	$(MAKE) -C dist rpm
+
 .PHONY: rune all recvtty static release dbuild lint man runcimage \
 	test localtest unittest localunittest integration localintegration \
 	rootlessintegration localrootlessintegration shell install install-bash \
 	install-man clean uninstall validate ci \
-	vendor verify-dependencies cross localcross skeleton
+	vendor verify-dependencies cross localcross skeleton rpm

--- a/rune/dist/Makefile
+++ b/rune/dist/Makefile
@@ -1,0 +1,16 @@
+RPMBUILD_DIR := $(shell mktemp -u /tmp/rpmbuild.XXXX)
+RELEASE_TARBALL_URL := https://github.com/alibaba/inclavare-containers/archive/v$(INCLAVARE_CONTAINERS_VERSION).tar.gz
+RELEASE_TARBALL_FILE := $(RPMBUILD_DIR)/SOURCES/v$(INCLAVARE_CONTAINERS_VERSION).tar.gz
+RELEASE_TARBALL_EXIST := $(shell if [ -f $(RELEASE_TARBALL_FILE) ]; then echo "y"; else echo "n"; fi;)
+
+release-tarball:
+ifneq ($(RELEASE_TARBALL_EXIST), y)
+	@mkdir -p $(RPMBUILD_DIR)/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+	@wget -P $(RPMBUILD_DIR)/SOURCES $(RELEASE_TARBALL_URL)
+endif
+
+rpm: release-tarball
+	@rpmbuild -D "_topdir $(RPMBUILD_DIR)" -ba centos/rune.spec
+	@echo "the rpms of rune located in $(RPMBUILD_DIR)/RPMS"
+
+.PHONY: release-tarball rpm

--- a/rune/dist/centos/rune.spec
+++ b/rune/dist/centos/rune.spec
@@ -1,0 +1,63 @@
+%define centos_base_release 1
+
+%global PROTOBUF_VERSION 1.3.5
+%global PROJECT inclavare-containers
+
+Name: rune
+Version: 0.2.0
+Release: %{centos_base_release}%{?dist}
+Summary: CLI tool for spawning and running enclaves in containers according to the OCI specification.  
+
+Group: Development/Tools
+License: Apache License 2.0
+URL: https://github.com/alibaba/%{PROJECT}
+Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
+
+BuildRequires: protobuf >= 3
+BuildRequires: protobuf-compiler
+BuildRequires: libseccomp-devel
+ExclusiveArch: x86_64
+
+%description
+rune is a CLI tool for spawning and running enclaves in containers according to the OCI specification. The codebase of rune is a fork of runc, so rune can be used as runc if enclave is not configured or available.
+
+%prep
+%setup -q -n %{PROJECT}-%{version}
+
+%build
+# we cann't download go1.14 through 'yum install' in centos, so that wo check the go version in the '%build' section rather than in the 'BuildRequires' section.
+if ! [ -x "$(command -v go)" ]; then
+  echo 'Error: go is not installed. Please install Go 1.14 and above'
+  exit 1
+fi
+
+NEED_GO_VERSION=14
+CURRENT_GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//g' | sed 's/\./ /g' | awk '{print $2}')
+if [ $CURRENT_GO_VERSION -lt $NEED_GO_VERSION  ]; then
+  echo 'Error: go version is less than 1.14.0. Please install Go 1.14 and above'
+  exit 1
+fi
+
+export GOPATH=${RPM_BUILD_DIR}/%{PROJECT}-%{version}
+export GOPROXY="https://mirrors.aliyun.com/goproxy,direct"
+export PATH=$PATH:${GOPATH}/bin
+export GO111MODULE=on
+go get github.com/golang/protobuf/protoc-gen-go@v%{PROTOBUF_VERSION}
+pushd %{name}
+make
+popd
+
+%install
+install -d -p %{buildroot}%{_bindir}
+install -p -m 755 %{name}/%{name} %{buildroot}%{_bindir}
+
+install -d -p %{buildroot}%{_defaultlicensedir}/%{name}-%{version}
+install -p -m 644 %{name}/LICENSE %{buildroot}%{_defaultlicensedir}/%{name}-%{version}
+
+%files
+%{_defaultlicensedir}/%{name}-%{version}/LICENSE
+%{_bindir}/%{name}
+
+%changelog
+* Fri Jul 10 2020 Yilin Li <YiLin.Li@linux.alibaba.com> - 0.2.0
+- Package init.

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -4,11 +4,6 @@ ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Base path used to install.
 DESTDIR ?= /usr/local
 
-# Variables for building rpm
-VERSION ?= 0.2.0
-RELEASE_TARBALL_URL ?= https://github.com/alibaba/inclavare-containers/archive/v$(VERSION).tar.gz
-RPMBUILD_DIR ?= /tmp/inclavare-containers/shim/rpmbuild
-
 ifneq "$(strip $(shell command -v go 2>/dev/null))" ""
 	GOOS ?= $(shell go env GOOS)
 	GOARCH ?= $(shell go env GOARCH)
@@ -59,14 +54,9 @@ binaries: clean $(BINARIES) ## build binaries
 clean: ## clean up binaries
 	@echo "$@"
 	@rm -f $(BINARIES)
-	@rm -fr ${RPMBUILD_DIR}
 
 rpm:
-	@mkdir -p $(RPMBUILD_DIR)
-	@echo "%_topdir $(RPMBUILD_DIR)" >> ~/.rpmmacros
-	@mkdir -p $(RPMBUILD_DIR)/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-	@wget -P $(RPMBUILD_DIR)/SOURCES $(RELEASE_TARBALL_URL)
-	$(MAKE) -C dist/centos rpm RPMBUILD_DIR=$(RPMBUILD_DIR)
+	$(MAKE) -C dist rpm
 
 install: ## install binaries
 	@echo "$@ $(BINARIES)"

--- a/shim/dist/Makefile
+++ b/shim/dist/Makefile
@@ -1,0 +1,17 @@
+# Variables for building rpm
+RPMBUILD_DIR := $(shell mktemp -u /tmp/rpmbuild.XXXX)
+RELEASE_TARBALL_URL := https://github.com/alibaba/inclavare-containers/archive/v$(INCLAVARE_CONTAINERS_VERSION).tar.gz
+RELEASE_TARBALL_FILE := $(RPMBUILD_DIR)/SOURCES/v$(INCLAVARE_CONTAINERS_VERSION).tar.gz
+RELEASE_TARBALL_EXIST := $(shell if [ -f $(RELEASE_TARBALL_FILE) ]; then echo "y"; else echo "n"; fi;)
+
+release-tarball:
+ifneq ($(RELEASE_TARBALL_EXIST), y)
+	@mkdir -p $(RPMBUILD_DIR)/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+	@wget -P $(RPMBUILD_DIR)/SOURCES $(RELEASE_TARBALL_URL)
+endif
+
+rpm: release-tarball
+	@rpmbuild -D "_topdir $(RPMBUILD_DIR)" -ba centos/shim-rune.spec
+	@echo "the rpms of shim-rune located in $(RPMBUILD_DIR)/RPMS"
+
+.PHONY: release-tarball rpm

--- a/shim/dist/centos/shim-rune.spec
+++ b/shim/dist/centos/shim-rune.spec
@@ -1,0 +1,75 @@
+%define centos_base_release 1
+
+%global PROJECT inclavare-containers
+%global SHIM_BIN_DIR /usr/local/bin
+%global SHIM_CONFIG_DIR /etc/inclavare-containers
+# to skip no build id error
+%undefine _missing_build_ids_terminate_build
+
+Name: shim-rune
+Version: 0.2.0
+Release: %{centos_base_release}%{?dist}
+Summary: shim for Inclavare Containers(runE)
+Group: Development/Tools
+License: Apache License 2.0
+URL: https://github.com/alibaba/%{PROJECT}
+Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
+
+ExclusiveArch: x86_64
+
+%description
+containerd-shim-rune-v2 is a shim for Inclavare Containers(runE).
+
+%prep
+%setup -q -n %{PROJECT}-%{version}
+
+%build
+# we cann't download go1.13 through 'yum install' in centos, so that wo check the go version in the '%build' section rather than in the 'BuildRequires' section.
+if ! [ -x "$(command -v go)" ]; then
+  echo 'Error: go is not installed. Please install Go 1.13 and above'
+  exit 1
+fi
+
+NEED_GO_VERSION=13
+CURRENT_GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//g' | sed 's/\./ /g' | awk '{print $2}')
+if [ $CURRENT_GO_VERSION -lt $NEED_GO_VERSION  ]; then
+  echo 'Error: go version is less than 1.13.0. Please install Go 1.13 and above'
+  exit 1
+fi
+
+export GOPATH=${RPM_BUILD_DIR}/%{PROJECT}-%{version}
+export GOPROXY="https://mirrors.aliyun.com/goproxy,direct"
+cd shim
+GOOS=linux make binaries
+
+%install
+install -d -p %{buildroot}%{SHIM_BIN_DIR}
+install -p -m 755 shim/bin/containerd-shim-rune-v2 %{buildroot}%{SHIM_BIN_DIR}
+
+install -d -p %{buildroot}%{_defaultlicensedir}/%{name}
+install -p -m 644 shim/LICENSE %{buildroot}%{_defaultlicensedir}/%{name}
+
+%post
+mkdir -p %{SHIM_CONFIG_DIR}
+cat << EOF > %{SHIM_CONFIG_DIR}/config.toml
+log_level = "info" # "debug" "info" "warn" "error"
+sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
+[containerd]
+    socket = "/run/containerd/containerd.sock"
+[enclave_runtime]
+    [enclave_runtime.occlum]
+        build_image = "docker.io/occlum/occlum:0.13.0-ubuntu18.04"
+        enclave_runtime_path = "/usr/lib64/libocclum-pal.so"
+    [enclave_runtime.graphene]
+EOF
+
+%postun
+rm -f %{SHIM_CONFIG_DIR}/config.toml
+
+%files
+%{_defaultlicensedir}/%{name}/LICENSE
+%{SHIM_BIN_DIR}/containerd-shim-rune-v2
+
+%changelog
+* Fri Jul 10 2020 Zhiguang Jia <Zhiguang.Jia@linux.alibaba.com> - 0.2.0
+- Package init.


### PR DESCRIPTION
1. Add Global make rpm for building rpms of rune and shim.
2. Add rpm specs  for rune/dist/centos and shim/dist/centos.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>
Signed-off-by: Zhiguang Jia <Zhiguang.Jia@linux.alibaba.com>