### PR TITLE
rune/libenclave: using `oneof` to distinguish default value and missing value in pb3.

### DIFF
--- a/rune/libenclave/intelsgx/aesmd.go
+++ b/rune/libenclave/intelsgx/aesmd.go
@@ -303,12 +303,12 @@ func GetQuote(report []byte, spid string, linkable bool) ([]byte, error) {
 
 	req := pb.AesmServiceRequest{}
 	req.GetQuote = &pb.AesmServiceRequest_GetQuote{
-		Report:    report,
-		QuoteType: t,
-		Spid:      s,
-		BufSize:   SgxMaxQuoteLength,
-		QeReport:  false,
-		Timeout:   10000,
+		Report:           report,
+		QuoteTypePresent: &pb.AesmServiceRequest_GetQuote_QuoteType{QuoteType: t},
+		Spid:             s,
+		BufSize:          SgxMaxQuoteLength,
+		QeReportPresent:  &pb.AesmServiceRequest_GetQuote_QeReport{QeReport: false},
+		Timeout:          10000,
 	}
 
 	rdata, err := transmitAesmd(conn, &req)

--- a/rune/libenclave/intelsgx/proto/aesm-service.proto
+++ b/rune/libenclave/intelsgx/proto/aesm-service.proto
@@ -12,12 +12,16 @@ message AesmServiceRequest {
 
     message GetQuote {
         bytes report      = 1;
-        uint32 quote_type = 2;
+        oneof quote_type_present {
+                uint32 quote_type = 2;
+        }
         bytes spid        = 3;
         bytes nonce       = 4;
         bytes sig_rl      = 5;
         uint32 buf_size   = 6;
-        bool qe_report    = 7;
+        oneof qe_report_present {
+                bool qe_report = 7;
+        }
         uint32 timeout    = 9;
     }
 


### PR DESCRIPTION
If not distinguish default value and missing value in pb3, pb3 will drop default value
in protobuf requests.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>