### PR TITLE
rune: support to IAS remote attestation when enclave runtime started and rune attest command.

### DIFF
--- a/rune/attest.go
+++ b/rune/attest.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runc/libenclave/attestation/sgx"
+	_ "github.com/opencontainers/runc/libenclave/attestation/sgx/ias"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli"
+)
+
+const (
+	envSeparator = "="
+)
+
+var attestCommand = cli.Command{
+	Name:  "attest",
+	Usage: "attest generates a remote attestation to the corresponding enclave container",
+	ArgsUsage: `<container-id> [command options]
+Where "<container-id>" is the name for the instance of the container`,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "product",
+			Usage: "specify whether using production attestation service",
+		},
+		cli.StringFlag{
+			Name:  "spid",
+			Usage: "specify SPID",
+		},
+		cli.StringFlag{
+			Name:  "subscription-key, -key",
+			Usage: "specify the subscription key",
+		},
+		cli.BoolFlag{
+			Name:  "linkable",
+			Usage: "specify the EPID signatures policy type",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		if err := revisePidFile(context); err != nil {
+			return err
+		}
+		status, err := attestProcess(context)
+		if err == nil {
+			os.Exit(status)
+		}
+		return fmt.Errorf("attest failed: %v", err)
+	},
+	SkipArgReorder: true,
+}
+
+func attestProcess(context *cli.Context) (int, error) {
+	container, err := getContainer(context)
+	if err != nil {
+		return -1, err
+	}
+	status, err := container.Status()
+	if err != nil {
+		return -1, err
+	}
+	if status == libcontainer.Stopped {
+		return -1, fmt.Errorf("cannot attest a container that has stopped")
+	}
+
+	config := container.Config()
+	if config.Enclave == nil {
+		return -1, fmt.Errorf("Attest command: container.Config.Enclave is null")
+	}
+
+	state, err := container.State()
+	if err != nil {
+		return -1, err
+	}
+	bundle := utils.SearchLabels(state.Config.Labels, "bundle")
+	p, err := getAttestProcess(context, bundle)
+	if err != nil {
+		return -1, err
+	}
+
+	logLevel := "info"
+	if context.GlobalBool("debug") {
+		logLevel = "debug"
+	}
+
+	r := &runner{
+		enableSubreaper: false,
+		shouldDestroy:   false,
+		container:       container,
+		consoleSocket:   context.String("console-socket"),
+		detach:          false,
+		action:          CT_ACT_RUN,
+		init:            false,
+		preserveFDs:     context.Int("preserve-fds"),
+		logLevel:        logLevel,
+	}
+	return r.run(p)
+}
+
+func getAttestProcess(context *cli.Context, bundle string) (*specs.Process, error) {
+	// process via cli flags
+	if err := os.Chdir(bundle); err != nil {
+		return nil, err
+	}
+	spec, err := loadSpec(specConfig)
+	if err != nil {
+		return nil, err
+	}
+	p := spec.Process
+	p.Args = context.Args()[1:]
+	// override the cwd, if passed
+	if context.String("cwd") != "" {
+		p.Cwd = context.String("cwd")
+	}
+	if ap := context.String("apparmor"); ap != "" {
+		p.ApparmorProfile = ap
+	}
+	if l := context.String("process-label"); l != "" {
+		p.SelinuxLabel = l
+	}
+	if caps := context.StringSlice("cap"); len(caps) > 0 {
+		for _, c := range caps {
+			p.Capabilities.Bounding = append(p.Capabilities.Bounding, c)
+			p.Capabilities.Inheritable = append(p.Capabilities.Inheritable, c)
+			p.Capabilities.Effective = append(p.Capabilities.Effective, c)
+			p.Capabilities.Permitted = append(p.Capabilities.Permitted, c)
+			p.Capabilities.Ambient = append(p.Capabilities.Ambient, c)
+		}
+	}
+	// append the passed env variables
+	p.Env = append(p.Env, "SPID"+envSeparator+context.String("spid"))
+	p.Env = append(p.Env, "SUBSCRIPTION_KEY"+envSeparator+context.String("subscription-key"))
+
+	isProductEnclave := strconv.Itoa(int(sgx.DebugEnclave))
+	if context.Bool("product") {
+		isProductEnclave = strconv.Itoa(int(sgx.ProductEnclave))
+	}
+	p.Env = append(p.Env, "PRODUCT"+envSeparator+isProductEnclave)
+
+	quoteType := strconv.Itoa(int(intelsgx.QuoteSignatureTypeUnlinkable))
+	if context.Bool("linkable") {
+		quoteType = strconv.Itoa(int(intelsgx.QuoteSignatureTypeLinkable))
+	}
+	p.Env = append(p.Env, "QUOTE_TYPE"+envSeparator+quoteType)
+
+	var AttestCommand string = "true"
+	p.Env = append(p.Env, "AttestCommand"+envSeparator+AttestCommand)
+
+	// set the tty
+	p.Terminal = false
+	if context.IsSet("tty") {
+		p.Terminal = context.Bool("tty")
+	}
+	if context.IsSet("no-new-privs") {
+		p.NoNewPrivileges = context.Bool("no-new-privs")
+	}
+	// override the user, if passed
+	if context.String("user") != "" {
+		u := strings.SplitN(context.String("user"), ":", 2)
+		if len(u) > 1 {
+			gid, err := strconv.Atoi(u[1])
+			if err != nil {
+				return nil, fmt.Errorf("parsing %s as int for gid failed: %v", u[1], err)
+			}
+			p.User.GID = uint32(gid)
+		}
+		uid, err := strconv.Atoi(u[0])
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s as int for uid failed: %v", u[0], err)
+		}
+		p.User.UID = uint32(uid)
+	}
+	for _, gid := range context.Int64Slice("additional-gids") {
+		if gid < 0 {
+			return nil, fmt.Errorf("additional-gids must be a positive number %d", gid)
+		}
+		p.User.AdditionalGids = append(p.User.AdditionalGids, uint32(gid))
+	}
+	return p, validateAttestProcessSpec(p)
+}

--- a/rune/libcontainer/nsenter/enclave.c
+++ b/rune/libcontainer/nsenter/enclave.c
@@ -28,6 +28,7 @@ void *fptr_pal_exec;
 void *fptr_pal_kill;
 void *fptr_pal_destroy;
 void *fptr_pal_create_process;
+void *fptr_pal_get_local_report;
 
 bool enclave_configured(void)
 {
@@ -78,6 +79,7 @@ int load_enclave_runtime(void)
 	DLSYM(exec);
 	DLSYM(kill);
 	DLSYM(destroy);
+	DLSYM(get_local_report);
 #undef DLSYM
 
 	return 0;

--- a/rune/libcontainer/nsenter/loader.go
+++ b/rune/libcontainer/nsenter/loader.go
@@ -14,6 +14,7 @@ extern void *fptr_pal_exec;
 extern void *fptr_pal_kill;
 extern void *fptr_pal_destroy;
 extern void *fptr_pal_create_process;
+extern void *fptr_pal_get_local_report;
 */
 import "C"
 
@@ -39,6 +40,10 @@ func SymAddrPalKill() unsafe.Pointer {
 
 func SymAddrPalDestroy() unsafe.Pointer {
 	return unsafe.Pointer(C.fptr_pal_destroy)
+}
+
+func SymAddrPalGetLocalReport() unsafe.Pointer {
+	return unsafe.Pointer(C.fptr_pal_get_local_report)
 }
 
 func SymAddrPalCreateProcess() unsafe.Pointer {

--- a/rune/libenclave/internal/runtime/core/core.go
+++ b/rune/libenclave/internal/runtime/core/core.go
@@ -25,7 +25,7 @@ func (pal *enclaveRuntimeCore) Init(args string, logLevel string) (err error) {
 	return fmt.Errorf("enclave runtime core Init() unimplemented")
 }
 
-func (pal *enclaveRuntimeCore) Attest() (err error) {
+func (pal *enclaveRuntimeCore) Attest(string, string, uint32, uint32) (err error) {
 	return fmt.Errorf("enclave runtime core Attest() unimplemented")
 }
 

--- a/rune/libenclave/internal/runtime/enclave_runtime.go
+++ b/rune/libenclave/internal/runtime/enclave_runtime.go
@@ -13,7 +13,7 @@ import (
 type EnclaveRuntime interface {
 	Load(path string) error
 	Init(args string, logLevel string) error
-	Attest() error
+	Attest(string, string, uint32, uint32) error
 	Exec(cmd []string, envp []string, stdio [3]*os.File) (int32, error)
 	Kill(sig int, pid int) error
 	Destroy() error
@@ -56,10 +56,10 @@ func StartInitialization(config *configs.InitEnclaveConfig, logLevel string) (*E
 	return rt, nil
 }
 
-func (rt *EnclaveRuntimeWrapper) LaunchAttestation() error {
+func (rt *EnclaveRuntimeWrapper) LaunchAttestation(spid string, subscriptionKey string, product uint32, quoteType uint32) error {
 	logrus.Debugf("attesting enclave runtime")
 
-	return rt.runtime.Attest()
+	return rt.runtime.Attest(spid, subscriptionKey, product, quoteType)
 }
 
 func (rt *EnclaveRuntimeWrapper) ExecutePayload(cmd []string, envp []string, stdio [3]*os.File) (int32, error) {

--- a/rune/libenclave/internal/runtime/pal/api_linux_v1.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux_v1.go
@@ -46,12 +46,11 @@ import "C"
 
 import (
 	"fmt"
+	"github.com/opencontainers/runc/libcontainer/nsenter"
 	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"unsafe"
-
-	"github.com/opencontainers/runc/libcontainer/nsenter"
 )
 
 type enclaveRuntimePalApiV1 struct {

--- a/rune/libenclave/internal/runtime/pal/api_linux_v3.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux_v3.go
@@ -1,0 +1,46 @@
+package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+
+/*
+#include <stdlib.h>
+#include <errno.h>
+
+static int palGetLocalReport(void *sym, void *target_info, int target_info_len,
+							void *report, int* report_len)
+{
+	return ((int (*)(void *, int, void*, int*))sym)(target_info, target_info_len,
+								report, report_len);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"github.com/opencontainers/runc/libcontainer/nsenter"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
+	"unsafe"
+)
+
+type enclaveRuntimePalApiV3 struct {
+}
+
+func (pal *enclaveRuntimePalApiV3) getLocalReport(targetInfo []byte) ([]byte, error) {
+	var ret C.int
+	reportBufSize := int32(intelsgx.ReportLength)
+	sym := nsenter.SymAddrPalGetLocalReport()
+
+	report := make([]byte, reportBufSize)
+	var pTargetInfo unsafe.Pointer = nil
+	if len(targetInfo) > 0 {
+		pTargetInfo = unsafe.Pointer(&targetInfo[0])
+	}
+
+	ret = C.palGetLocalReport(sym, pTargetInfo,
+		C.int(len(targetInfo)),
+		unsafe.Pointer(&report[0]),
+		(*C.int)(unsafe.Pointer(&reportBufSize)))
+	if ret == 0 {
+		return report, nil
+	}
+
+	return nil, fmt.Errorf("C.palGetLocalReport() failed, return %d.\n", ret)
+}

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -1,7 +1,16 @@
 package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
 
+import "C"
+
 import (
+	"encoding/binary"
 	"fmt"
+	"github.com/go-restruct/restruct"
+	"github.com/opencontainers/runc/libenclave/attestation"
+	"github.com/opencontainers/runc/libenclave/attestation/sgx"
+	_ "github.com/opencontainers/runc/libenclave/attestation/sgx/ias"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
+	"log"
 	"os"
 )
 
@@ -29,10 +38,6 @@ func (pal *enclaveRuntimePal) getPalApiVersion() error {
 func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {
 	api := &enclaveRuntimePalApiV1{}
 	return api.init(args, logLevel)
-}
-
-func (pal *enclaveRuntimePal) Attest() (err error) {
-	return nil
 }
 
 func (pal *enclaveRuntimePal) Exec(cmd []string, envp []string, stdio [3]*os.File) (int32, error) {
@@ -66,4 +71,80 @@ func (pal *enclaveRuntimePal) GetLocalReport(targetInfo []byte) ([]byte, error) 
 	}
 
 	return nil, fmt.Errorf("unsupported pal api version %d", pal.version)
+}
+
+func parseAttestParameters(spid string, subscriptionKey string, product uint32) map[string]string {
+	p := make(map[string]string)
+
+	p["spid"] = spid
+	p["subscription-key"] = subscriptionKey
+	if product == sgx.ProductEnclave {
+		p["service-class"] = "product"
+	} else if product == sgx.DebugEnclave {
+		p["service-class"] = "dev"
+	}
+
+	return p
+}
+
+func (pal *enclaveRuntimePal) Attest(spid string, subscriptionKey string, product uint32, quoteType uint32) (err error) {
+	if pal.GetLocalReport == nil {
+		return nil
+	}
+
+	targetInfo, err := intelsgx.GetQeTargetInfo()
+	if err != nil {
+		return err
+	}
+
+	if len(targetInfo) != intelsgx.TargetinfoLength {
+		return fmt.Errorf("len(targetInfo) is not %d, but %d", intelsgx.TargetinfoLength, len(targetInfo))
+	}
+
+	// get local report of SGX
+	report, err := pal.GetLocalReport(targetInfo)
+	if err != nil {
+		return err
+	}
+	if len(report) != intelsgx.ReportLength {
+		return fmt.Errorf("len(report) is not %d, but %d", intelsgx.ReportLength, len(report))
+	}
+
+	// get quote from QE(aesmd)
+	linkable := false
+	if quoteType == intelsgx.QuoteSignatureTypeLinkable {
+		linkable = true
+	}
+	quote, err := intelsgx.GetQuote(report, spid, linkable)
+	if err != nil {
+		return err
+	}
+
+	q := &intelsgx.Quote{}
+	if err := restruct.Unpack(quote, binary.LittleEndian, &q); err != nil {
+		return err
+	}
+
+	// get IAS remote attestation report
+	var verbose bool = true
+	p := parseAttestParameters(spid, subscriptionKey, product)
+	svc, err := attestation.NewService(p, verbose)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+
+	if err = svc.Check(quote); err != nil {
+		log.Fatal(err)
+		return err
+	}
+
+	status := svc.Verify(quote)
+	if status.ErrorMessage != "" {
+		return fmt.Errorf("%s", status.ErrorMessage)
+	}
+
+	svc.ShowStatus(status)
+
+	return nil
 }

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -58,3 +58,12 @@ func (pal *enclaveRuntimePal) Destroy() error {
 	api := &enclaveRuntimePalApiV1{}
 	return api.destroy()
 }
+
+func (pal *enclaveRuntimePal) GetLocalReport(targetInfo []byte) ([]byte, error) {
+	if pal.version >= 3 {
+		api := &enclaveRuntimePalApiV3{}
+		return api.getLocalReport(targetInfo)
+	}
+
+	return nil, fmt.Errorf("unsupported pal api version %d", pal.version)
+}

--- a/rune/libenclave/proto/agent-service.proto
+++ b/rune/libenclave/proto/agent-service.proto
@@ -12,8 +12,16 @@ message AgentServiceRequest{
         int32 sig = 1;
     }
 
+    message Attest {
+	string spid       	= 1;
+	string subscriptionKey 	= 2;
+	uint32 product    	= 3;
+	uint32 quoteType	= 4;
+    }
+
     Execute exec = 1;
     Kill kill = 2;
+    Attest attest = 3;
 }
 
 message AgentServiceResponse {
@@ -22,5 +30,11 @@ message AgentServiceResponse {
         string error = 2;
     }
 
+    message Attest {
+	int32 exitCode = 1;
+	string error = 2;
+    }
+
     Execute exec = 1;
+    Attest attest = 2;
 }

--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -6,14 +6,17 @@ import (
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/opencontainers/runc/libenclave/attestation/sgx"
 	"github.com/opencontainers/runc/libenclave/configs"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
 	"github.com/opencontainers/runc/libenclave/internal/runtime"
 	pb "github.com/opencontainers/runc/libenclave/proto"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -100,13 +103,26 @@ func StartInitialization(cmd []string, cfg *RuneletConfig) (exitCode int32, err 
 	notifySignal := make(chan os.Signal, signalBufferSize)
 
 	if fifoFd == -1 {
-		exitCode, err = remoteExec(agentPipe, cmd, notifySignal)
-		if err != nil {
+		AttestCommand := os.Getenv("AttestCommand")
+		if AttestCommand == "true" {
+			logrus.Infof("Get an attest command")
+			exitCode, err = remoteAttest(agentPipe, config, notifySignal)
+			if err != nil {
+				return exitCode, err
+			}
+			logrus.Debugf("remote attest normally exits")
+
+			return exitCode, err
+		} else {
+			logrus.Infof("Get an exec command")
+			exitCode, err = remoteExec(agentPipe, cmd, notifySignal)
+			if err != nil {
+				return exitCode, err
+			}
+			logrus.Debug("remote exec normally exits")
+
 			return exitCode, err
 		}
-		logrus.Debug("remote exec normally exits")
-
-		return exitCode, err
 	}
 
 	notifyExit := make(chan struct{})
@@ -199,6 +215,105 @@ func finalizeInitialization(fifoFd int) error {
 	unix.Close(fifoFd)
 	unix.Close(fd)
 	return nil
+}
+
+func remoteAttest(agentPipe *os.File, config *configs.InitEnclaveConfig, notifySignal chan os.Signal) (exitCode int32, err error) {
+	logrus.Infof("preparing to remote Attest")
+	c, err := net.FileConn(agentPipe)
+	if err != nil {
+		return 1, err
+	}
+	defer c.Close()
+	conn, ok := c.(*net.UnixConn)
+	if !ok {
+		return 1, fmt.Errorf("casting to UnixConn faild")
+	}
+
+	sgxEnclaveType := os.Getenv("PRODUCT")
+	isProductEnclave, err := strconv.ParseUint(sgxEnclaveType, 10, 32)
+	if err != nil {
+		return 1, fmt.Errorf("Invalid sgxEnclaveType Configuration, error = %v!\n", err)
+	}
+	if isProductEnclave != sgx.DebugEnclave && isProductEnclave != sgx.ProductEnclave {
+		return 1, fmt.Errorf("Unsupported is_product_enclave Configuration %v!\n", sgxEnclaveType)
+	}
+
+	quoteType := os.Getenv("QUOTE_TYPE")
+	raEpidQuoteType, err := strconv.ParseUint(quoteType, 10, 32)
+	if err != nil {
+		return 1, fmt.Errorf("Invalid Quote Type Configuration, error = %v!\n", err)
+	}
+	if raEpidQuoteType != (intelsgx.QuoteSignatureTypeUnlinkable) && raEpidQuoteType != (intelsgx.QuoteSignatureTypeLinkable) {
+		return 1, fmt.Errorf("Unsupported Quote Type Configuration %v!\n", raEpidQuoteType)
+	}
+
+	req := &pb.AgentServiceRequest{}
+	req.Attest = &pb.AgentServiceRequest_Attest{
+		Spid:            os.Getenv("SPID"),
+		SubscriptionKey: os.Getenv("SUBSCRIPTION_KEY"),
+		Product:         (uint32)(isProductEnclave),
+		QuoteType:       (uint32)(raEpidQuoteType),
+	}
+
+	if err = protoBufWrite(conn, req); err != nil {
+		return 1, err
+	}
+
+	agentFile, err := conn.File()
+	if err != nil {
+		return 1, err
+	}
+	defer agentFile.Close()
+
+	// Send signal notification pipe.
+	childSignalPipe, parentSignalPipe, err := os.Pipe()
+	agentFile, err = conn.File()
+	if err != nil {
+		return 1, err
+	}
+	defer agentFile.Close()
+
+	// Send signal notification pipe.
+	childSignalPipe, parentSignalPipe, err = os.Pipe()
+	if err != nil {
+		return 1, err
+	}
+	defer func() {
+		if err != nil {
+			childSignalPipe.Close()
+		}
+		parentSignalPipe.Close()
+	}()
+
+	if err = utils.SendFd(agentFile, childSignalPipe.Name(), childSignalPipe.Fd()); err != nil {
+		return 1, err
+	}
+
+	// Close the child signal pipe in parent side **after** sending all stdio fds to
+	// make sure the parent runelet has retrieved the child signal pipe.
+	childSignalPipe.Close()
+
+	signal.Notify(notifySignal)
+
+	notifyExit := make(chan struct{})
+	sigForwarderExit := forwardSignalToParent(parentSignalPipe, notifySignal, notifyExit)
+
+	resp := &pb.AgentServiceResponse{}
+	if err = protoBufRead(conn, resp); err != nil {
+		return 1, err
+	}
+
+	notifyExit <- struct{}{}
+	logrus.Debug("awaiting for signal forwarder exiting ...")
+	<-sigForwarderExit
+	logrus.Debug("signal forwarder exited")
+
+	if resp.Attest.Error == "" {
+		err = nil
+	} else {
+		err = fmt.Errorf(resp.Attest.Error)
+	}
+	return resp.Attest.ExitCode, err
 }
 
 func remoteExec(agentPipe *os.File, cmd []string, notifySignal chan os.Signal) (exitCode int32, err error) {

--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/opencontainers/runc/libenclave/attestation/sgx"
 	"github.com/opencontainers/runc/libenclave/configs"
 	"github.com/opencontainers/runc/libenclave/internal/runtime"
 	pb "github.com/opencontainers/runc/libenclave/proto"
@@ -68,8 +69,10 @@ func StartInitialization(cmd []string, cfg *RuneletConfig) (exitCode int32, err 
 		}
 
 		// Launch a remote attestation to the enclave runtime.
-		if err = rt.LaunchAttestation(); err != nil {
-			return 1, err
+		if config.RaType == sgx.EPID {
+			if err = rt.LaunchAttestation(config.RaEpidSpid, config.RaEpidSubscriptionKey, config.IsProductEnclave, config.RaEpidIsLinkable); err != nil {
+				return 1, err
+			}
 		}
 		if err = readSync(initPipe, procEnclaveReady); err != nil {
 			return 1, err

--- a/rune/main.go
+++ b/rune/main.go
@@ -130,6 +130,7 @@ func main() {
 		startCommand,
 		stateCommand,
 		updateCommand,
+		attestCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if !context.IsSet("root") && xdgRuntimeDir != "" {

--- a/rune/utils_linux.go
+++ b/rune/utils_linux.go
@@ -399,6 +399,19 @@ func validateProcessSpec(spec *specs.Process) error {
 	return nil
 }
 
+func validateAttestProcessSpec(spec *specs.Process) error {
+	if spec.Cwd == "" {
+		return fmt.Errorf("Cwd property must not be empty")
+	}
+	if !filepath.IsAbs(spec.Cwd) {
+		return fmt.Errorf("Cwd must be an absolute path")
+	}
+	if spec.SelinuxLabel != "" && !selinux.GetEnabled() {
+		return fmt.Errorf("selinux label is specified in config, but selinux is disabled or not supported")
+	}
+	return nil
+}
+
 type CtAct uint8
 
 const (

--- a/sgx-tools/gen-quote.go
+++ b/sgx-tools/gen-quote.go
@@ -34,7 +34,7 @@ For example, generate the quote file according to the given local report file:
 		},
 		cli.BoolFlag{
 			Name:  "linkable",
-			Usage: "linkable",
+			Usage: "specify the EPID signatures policy type",
 		},
 	},
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
1. Add GetSgxReport PAL API.
2. Support to IAS remote attestation when Enclave Runtime started.
3. Support `rune attest` command.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>