### PR TITLE
rune: Add optional remote attestation annotation fields in config.json.

### DIFF
--- a/rune/libcontainer/configs/enclave.go
+++ b/rune/libcontainer/configs/enclave.go
@@ -7,7 +7,11 @@ const (
 )
 
 type Enclave struct {
-	Type string `json:"type"`
-	Path string `json:"path"`
-	Args string `json:"args,omitempty"`
+	Type                  string `json:"type"`
+	Path                  string `json:"path"`
+	Args                  string `json:"args,omitempty"`
+	RaType                string `json:"ra_type,omitempty"`
+	RaEpidSpid            string `json:"ra_epid_spid,omitempty"`
+	RaEpidSubscriptionKey string `json:"ra_epid_subscription_key,omitempty"`
+	RaEpidQuoteType       string `json:"ra_epid_quote_type,omitempty"`
 }

--- a/rune/libcontainer/process_linux.go
+++ b/rune/libcontainer/process_linux.go
@@ -141,9 +141,13 @@ func (p *setnsProcess) start() (err error) {
 				return newSystemErrorWithCause(nil, "received syncT 'EnclaveConfigReq'")
 			}
 			config := &enclave_configs.InitEnclaveConfig{
-				Type: p.config.Config.Enclave.Type,
-				Path: p.config.Config.Enclave.Path,
-				Args: p.config.Config.Enclave.Args,
+				Type:                  p.config.Config.Enclave.Type,
+				Path:                  p.config.Config.Enclave.Path,
+				Args:                  p.config.Config.Enclave.Args,
+				RaType:                p.config.Config.Enclave.RaType,
+				RaEpidSpid:            p.config.Config.Enclave.RaEpidSpid,
+				RaEpidSubscriptionKey: p.config.Config.Enclave.RaEpidSubscriptionKey,
+				RaEpidQuoteType:       p.config.Config.Enclave.RaEpidQuoteType,
 			}
 			err := utils.WriteJSON(p.messageSockPair.parent, config)
 			if err != nil {
@@ -471,9 +475,13 @@ func (p *initProcess) start() (retErr error) {
 				return newSystemErrorWithCause(nil, "received syncT 'EnclaveConfigReq'")
 			}
 			config := &enclave_configs.InitEnclaveConfig{
-				Type: p.config.Config.Enclave.Type,
-				Path: p.config.Config.Enclave.Path,
-				Args: p.config.Config.Enclave.Args,
+				Type:                  p.config.Config.Enclave.Type,
+				Path:                  p.config.Config.Enclave.Path,
+				Args:                  p.config.Config.Enclave.Args,
+				RaType:                p.config.Config.Enclave.RaType,
+				RaEpidSpid:            p.config.Config.Enclave.RaEpidSpid,
+				RaEpidSubscriptionKey: p.config.Config.Enclave.RaEpidSubscriptionKey,
+				RaEpidQuoteType:       p.config.Config.Enclave.RaEpidQuoteType,
 			}
 			err := utils.WriteJSON(p.messageSockPair.parent, config)
 			if err != nil {

--- a/rune/libcontainer/specconv/spec_linux.go
+++ b/rune/libcontainer/specconv/spec_linux.go
@@ -332,11 +332,35 @@ func createEnclaveConfig(spec *specs.Spec, config *configs.Config) {
 		args = strings.Join(a, " ")
 	}
 
+	ra_type := filterOut(env, "ENCLAVE_RA_TYPE")
+	if ra_type == "" {
+		ra_type = libcontainerUtils.SearchLabels(config.Labels, "ra_type")
+	}
+
+	ra_epid_spid := filterOut(env, "ENCLAVE_RA_EPID_SPID")
+	if ra_epid_spid == "" {
+		ra_epid_spid = libcontainerUtils.SearchLabels(config.Labels, "ra_epid_spid")
+	}
+
+	ra_epid_subscription_key := filterOut(env, "ENCLAVE_RA_EPID_SUB_KEY")
+	if ra_epid_subscription_key == "" {
+		ra_epid_subscription_key = libcontainerUtils.SearchLabels(config.Labels, "ra_epid_subscription_key")
+	}
+
+	ra_epid_quote_type := filterOut(env, "ENCLAVE_RA_EPID_SIGNATURE_TYPE")
+	if ra_epid_quote_type == "" {
+		ra_epid_quote_type = libcontainerUtils.SearchLabels(config.Labels, "ra_epid_quote_type")
+	}
+
 	if etype != "" {
 		config.Enclave = &configs.Enclave{
-			Type: etype,
-			Path: path,
-			Args: args,
+			Type:                  etype,
+			Path:                  path,
+			Args:                  args,
+			RaType:                ra_type,
+			RaEpidSpid:            ra_epid_spid,
+			RaEpidSubscriptionKey: ra_epid_subscription_key,
+			RaEpidQuoteType:       ra_epid_quote_type,
 		}
 	}
 }

--- a/rune/libenclave/configs/config.go
+++ b/rune/libenclave/configs/config.go
@@ -1,7 +1,11 @@
 package configs // import "github.com/opencontainers/runc/libenclave/configs"
 
 type InitEnclaveConfig struct {
-	Type string   `json:"type"`
-	Path string   `json:"path"`
-	Args string   `json:"args"`
+	Type                  string `json:"type"`
+	Path                  string `json:"path"`
+	Args                  string `json:"args"`
+	RaType                string `json:"ra_type"`
+	RaEpidSpid            string `json:"ra_epid_spid"`
+	RaEpidSubscriptionKey string `json:"ra_epid_subscription_key"`
+	RaEpidQuoteType       string `json:"ra_epid_quote_type"`
 }


### PR DESCRIPTION
1. Add optional remote attestation annotation fields in config.json.
2. Pass remote attestation configs to Enclave Containers.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>