### PR TITLE
rune && runectl: Minor fixes in the attestation package.

### DIFF
--- a/rune/Makefile
+++ b/rune/Makefile
@@ -22,7 +22,7 @@ ifeq ($(DEBUG),1)
 	GCFLAGS=-gcflags "-N -l"
 endif
 
-PROTO_DIR := libenclave/proto libenclave/intelsgx/proto
+PROTO_DIR := libenclave/proto libenclave/intelsgx/proto libenclave/attestation/proto
 PROTOS := $(foreach dir,$(PROTO_DIR),$(patsubst %.proto,%.pb.go,$(wildcard $(dir)/*.proto)))
 
 GO_BUILD := $(GO) build $(MOD_VENDOR) -buildmode=pie $(GCFLAGS) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \

--- a/rune/libenclave/intelsgx/aesmd.go
+++ b/rune/libenclave/intelsgx/aesmd.go
@@ -355,5 +355,5 @@ func GetQuote(report []byte, spid string, linkable bool) ([]byte, error) {
 	logrus.Debugf("  Signature Length:                     %d\n",
 		q.SigLen)
 
-	return resp.GetQuote.GetQuote(), nil
+	return quote[0 : q.SigLen+QuoteLength], nil
 }

--- a/runectl/vendor/github.com/opencontainers/runc/libenclave/intelsgx/aesmd.go
+++ b/runectl/vendor/github.com/opencontainers/runc/libenclave/intelsgx/aesmd.go
@@ -328,7 +328,7 @@ func GetQuote(report []byte, spid string, linkable bool) ([]byte, error) {
 	}
 
 	quote := resp.GetQuote.GetQuote()
-	if len(quote) < QuoteLength || len(quote) > SgxMaxQuoteLength {
+	if len(quote) < QuoteLength || len(quote) != SgxMaxQuoteLength {
 		return nil, fmt.Errorf("invalid length of quote: (returned %d, expected %d)",
 			len(quote), QuoteLength)
 	}
@@ -355,6 +355,5 @@ func GetQuote(report []byte, spid string, linkable bool) ([]byte, error) {
 	logrus.Debugf("  Signature Length:                     %d\n",
 		q.SigLen)
 
-	validQuote := quote[0 : q.SigLen+QuoteLength]
-	return validQuote, nil
+	return quote[0 : q.SigLen+QuoteLength], nil
 }


### PR DESCRIPTION
1. rune: Add libenclave/attestation/proto in Makefile.
2. rune/libenclave: Drop invalid fields in Quote to avoid invalid Attestation Evidence Payload error(ErrorCode: 400).
3. runectl: Minor fixes to sync up with the attestation package from rune/libenclave.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>