### PR TITLE
rune: revise remote attestation optional configurations type.

### DIFF
--- a/rune/libcontainer/configs/enclave.go
+++ b/rune/libcontainer/configs/enclave.go
@@ -10,8 +10,8 @@ type Enclave struct {
 	Type                  string `json:"type"`
 	Path                  string `json:"path"`
 	Args                  string `json:"args,omitempty"`
-	RaType                string `json:"ra_type,omitempty"`
+	RaType                uint32 `json:"ra_type,omitempty"`
 	RaEpidSpid            string `json:"ra_epid_spid,omitempty"`
 	RaEpidSubscriptionKey string `json:"ra_epid_subscription_key,omitempty"`
-	RaEpidQuoteType       string `json:"ra_epid_quote_type,omitempty"`
+	RaEpidIsLinkable      uint32 `json:"ra_epid_is_linkable,omitempty"`
 }

--- a/rune/libcontainer/configs/validate/validator.go
+++ b/rune/libcontainer/configs/validate/validator.go
@@ -9,6 +9,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/intelrdt"
 	"github.com/opencontainers/runc/libenclave"
+	"github.com/opencontainers/runc/libenclave/attestation/sgx"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -224,6 +226,13 @@ func (v *ConfigValidator) enclave(config *configs.Config) error {
 		return err
 	}
 
+	if config.Enclave.RaType == sgx.InvalidRaType {
+		return fmt.Errorf("Unsupported ra_type Configuration %v!\n", config.Enclave.RaType)
+	}
+
+	if config.Enclave.RaEpidIsLinkable == intelsgx.InvalidQuoteSignatureType {
+		return fmt.Errorf("Unsupported ra_epid_is_linkable Configuration %v!\n", config.Enclave.RaEpidIsLinkable)
+	}
 	return nil
 }
 

--- a/rune/libcontainer/process_linux.go
+++ b/rune/libcontainer/process_linux.go
@@ -147,7 +147,7 @@ func (p *setnsProcess) start() (err error) {
 				RaType:                p.config.Config.Enclave.RaType,
 				RaEpidSpid:            p.config.Config.Enclave.RaEpidSpid,
 				RaEpidSubscriptionKey: p.config.Config.Enclave.RaEpidSubscriptionKey,
-				RaEpidQuoteType:       p.config.Config.Enclave.RaEpidQuoteType,
+				RaEpidIsLinkable:      p.config.Config.Enclave.RaEpidIsLinkable,
 			}
 			err := utils.WriteJSON(p.messageSockPair.parent, config)
 			if err != nil {
@@ -481,7 +481,7 @@ func (p *initProcess) start() (retErr error) {
 				RaType:                p.config.Config.Enclave.RaType,
 				RaEpidSpid:            p.config.Config.Enclave.RaEpidSpid,
 				RaEpidSubscriptionKey: p.config.Config.Enclave.RaEpidSubscriptionKey,
-				RaEpidQuoteType:       p.config.Config.Enclave.RaEpidQuoteType,
+				RaEpidIsLinkable:      p.config.Config.Enclave.RaEpidIsLinkable,
 			}
 			err := utils.WriteJSON(p.messageSockPair.parent, config)
 			if err != nil {

--- a/rune/libenclave/attestation/sgx/attest.go
+++ b/rune/libenclave/attestation/sgx/attest.go
@@ -1,0 +1,8 @@
+package sgx // import "github.com/opencontainers/runc/libenclave/attestation/sgx"
+
+// RA Type
+const (
+	InvalidRaType = iota
+	EPID
+	DCAP
+)

--- a/rune/libenclave/configs/config.go
+++ b/rune/libenclave/configs/config.go
@@ -4,8 +4,8 @@ type InitEnclaveConfig struct {
 	Type                  string `json:"type"`
 	Path                  string `json:"path"`
 	Args                  string `json:"args"`
-	RaType                string `json:"ra_type"`
+	RaType                uint32 `json:"ra_type"`
 	RaEpidSpid            string `json:"ra_epid_spid"`
 	RaEpidSubscriptionKey string `json:"ra_epid_subscription_key"`
-	RaEpidQuoteType       string `json:"ra_epid_quote_type"`
+	RaEpidIsLinkable      uint32 `json:"ra_epid_is_linkable"`
 }

--- a/rune/libenclave/intelsgx/arch.go
+++ b/rune/libenclave/intelsgx/arch.go
@@ -115,6 +115,7 @@ type Quote struct {
 const (
 	QuoteSignatureTypeUnlinkable = iota
 	QuoteSignatureTypeLinkable
+	InvalidQuoteSignatureType
 )
 
 const (


### PR DESCRIPTION
1. transfer config.RaType from string type to uint32 type.
2. rename config.RaEpidQuoteType as config.RaEpidIsLinkable.
3. set config.RaEpidIsLinkable type as uint32.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>