### PR TITLE
make the shim-rune adapt to occlum 0.14

### DIFF
--- a/shim/config/config.go
+++ b/shim/config/config.go
@@ -4,6 +4,10 @@ type Containerd struct {
 	Socket string `toml:"socket"`
 }
 
+type Signature struct {
+	ServerAddress string `toml:"server_address"`
+}
+
 type Occlum struct {
 	BuildImage         string `toml:"build_image"`
 	EnclaveRuntimePath string `toml:"enclave_runtime_path"`
@@ -21,5 +25,6 @@ type Config struct {
 	LogLevel       string         `toml:"log_level"`
 	SgxToolSign    string         `toml:"sgx_tool_sign"`
 	Containerd     Containerd     `toml:"containerd"`
+	Signature      Signature      `toml:"signature"`
 	EnclaveRuntime EnclaveRuntime `toml:"enclave_runtime"`
 }

--- a/shim/runtime/carrier/constants/constants.go
+++ b/shim/runtime/carrier/constants/constants.go
@@ -169,6 +169,13 @@ function buildUnsignedEnclave(){
   /bin/bash ${base_dir}/replace_occlum_image.sh ${rootfs} image
   # occlum build
   occlum build
+  if [ ! -f .occlum/build/lib/libocclum-libos.so ]; then
+    if [ -f .occlum/build/lib/libocclum-libos.so.0 ]; then
+      pushd .occlum/build/lib/
+      ln -s libocclum-libos.so.0 libocclum-libos.so
+      popd
+    fi
+  fi
   mkdir -p ${rootfs}/${work_dir} || true
   /bin/cp -fr .occlum ${rootfs}/${work_dir}
   /bin/cp -f Enclave.xml ${rootfs}/${work_dir}

--- a/shim/runtime/carrier/constants/constants.go
+++ b/shim/runtime/carrier/constants/constants.go
@@ -162,7 +162,7 @@ function buildUnsignedEnclave(){
     /bin/cp -f ${occlum_config_path} Occlum.json
   fi
   # set occlum entrypoint
-  sed -i "s#/bin#${entry_point}#g" Occlum.json
+  # sed -i "s#/bin#${entry_point}#g" Occlum.json
   # generate the configuration file Enclave.xml that used by enclave from Occlum.json
   /opt/occlum/build/bin/gen_enclave_conf -i Occlum.json -o Enclave.xml
   # build occlum image
@@ -179,6 +179,7 @@ function buildUnsignedEnclave(){
   mkdir -p ${rootfs}/${work_dir} || true
   /bin/cp -fr .occlum ${rootfs}/${work_dir}
   /bin/cp -f Enclave.xml ${rootfs}/${work_dir}
+  /bin/cp -f Occlum.json ${rootfs}/${work_dir}
   popd
 }
 

--- a/shim/runtime/carrier/occlum/config.go
+++ b/shim/runtime/carrier/occlum/config.go
@@ -8,16 +8,18 @@ import (
 )
 
 const (
-	EnvUserSpaceSize        = "OCCLUM_USER_SPACE_SIZE"
-	EnvKernelSpaceHeapSize  = "OCCLUM_KERNEL_SPACE_HEAP_SIZE"
-	EnvKernelSpaceStackSize = "OCCLUM_KERNEL_SPACE_STACK_SIZE"
-	EnvMaxNumOfThreads      = "OCCLUM_MAX_NUM_OF_THREADS"
-	EnvDefaultStackSize     = "OCCLUM_DEFAULT_STACK_SIZE"
-	EnvDefaultHeapSize      = "OCCLUM_DEFAULT_HEAP_SIZE"
-	EnvDefaultMmapSize      = "OCCLUM_DEFAULT_MMAP_SIZE"
-	EnvProductId            = "OCCLUM_PRODUCT_ID"
-	EnvVersionNumber        = "OCCLUM_VERSION_NUMBER"
-	EnvDebuggable           = "OCCLUM_DEBUGGABLE"
+	UserSpaceSize           = "OCCLUM_USER_SPACE_SIZE"
+	KernelSpaceHeapSize     = "OCCLUM_KERNEL_SPACE_HEAP_SIZE"
+	KernelSpaceStackSize    = "OCCLUM_KERNEL_SPACE_STACK_SIZE"
+	MaxNumOfThreads         = "OCCLUM_MAX_NUM_OF_THREADS"
+	ProcessDefaultStackSize = "OCCLUM_PROCESS_DEFAULT_STACK_SIZE"
+	ProcessDefaultHeapSize  = "OCCLUM_PROCESS_DEFAULT_HEAP_SIZE"
+	ProcessDefaultMmapSize  = "OCCLUM_PROCESS_DEFAULT_MMAP_SIZE"
+	ProductId               = "OCCLUM_PRODUCT_ID"
+	VersionNumber           = "OCCLUM_VERSION_NUMBER"
+	Debuggable              = "OCCLUM_DEBUGGABLE"
+	DefalutEnv              = "OCCLUM_DEFAULT_ENV"
+	UntrustedEnv            = "OCCLUM_UNTRUSTED_ENV"
 )
 
 type OcclumConfig struct {
@@ -69,54 +71,68 @@ func (c *OcclumConfig) ApplyEnvs(envs []string) {
 		k := items[0]
 		v := items[1]
 		switch k {
-		case EnvUserSpaceSize:
+		case UserSpaceSize:
 			c.ResourceLimits.UserSpaceSize = v
 			break
-		case EnvKernelSpaceHeapSize:
+		case KernelSpaceHeapSize:
 			c.ResourceLimits.KernelSpaceHeapSize = v
 			break
-		case EnvKernelSpaceStackSize:
+		case KernelSpaceStackSize:
 			c.ResourceLimits.KernelSpaceStackSize = v
 			break
-		case EnvMaxNumOfThreads:
+		case MaxNumOfThreads:
 			i, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
 				logrus.Error("ApplyEnvs: parse environment variable %s failed. error: %++v", k, err)
 			}
 			c.ResourceLimits.MaxNumOfThreads = i
 			break
-		case EnvDefaultStackSize:
+		case ProcessDefaultStackSize:
 			c.Process.DefaultStackSize = v
 			break
-		case EnvDefaultHeapSize:
+		case ProcessDefaultHeapSize:
 			c.Process.DefaultHeapSize = v
 			break
-		case EnvDefaultMmapSize:
+		case ProcessDefaultMmapSize:
 			c.Process.DefaultMmapSize = v
 			break
-		case EnvProductId:
+		case ProductId:
 			i, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
 				logrus.Error("ApplyEnvs: parse environment variable %s failed. error: %++v", k, err)
 			}
 			c.Metadata.ProductId = i
 			break
-		case EnvVersionNumber:
+		case VersionNumber:
 			i, err := strconv.ParseInt(v, 10, 64)
 			if err != nil {
 				logrus.Error("ApplyEnvs: parse environment variable %s failed. error: %++v", k, err)
 			}
 			c.Metadata.VersionNumber = i
 			break
-		case EnvDebuggable:
+		case Debuggable:
 			i, err := strconv.ParseBool(v)
 			if err != nil {
 				logrus.Error("ApplyEnvs: parse environment variable %s failed. error: %++v", k, err)
 			}
 			c.Metadata.Debuggable = i
 			break
+		case DefalutEnv:
+			if len(v) > 0 {
+				c.Env.Default = strings.Split(v, ",")
+			}
+			break
+		case UntrustedEnv:
+			if len(v) > 0 {
+				c.Env.Untrusted = strings.Split(v, ",")
+			}
+			break
 		}
 	}
+}
+
+func (c *OcclumConfig) ApplyEntrypoints(entrypoints []string) {
+	c.EntryPoints = entrypoints
 }
 
 func GetDefaultOcclumConfig() *OcclumConfig {

--- a/shim/runtime/carrier/occlum/occlum.go
+++ b/shim/runtime/carrier/occlum/occlum.go
@@ -359,6 +359,7 @@ func (o *occlum) saveOcclumConfig(path string) error {
 	}
 	cfg := GetDefaultOcclumConfig()
 	cfg.ApplyEnvs(o.spec.Process.Env)
+	cfg.ApplyEntrypoints([]string{o.entryPoints[0]})
 	bytes, err := json.Marshal(cfg)
 	if err != nil {
 		return err

--- a/shim/runtime/signature/client/client.go
+++ b/shim/runtime/signature/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -91,7 +92,12 @@ func (c *pkcs1Client) Sign(data []byte) (signature []byte, publicKey []byte, err
 		glog.Errorf("failed to unmarshal sign response,%v", err)
 		return nil, nil, err
 	}
-	return []byte(payload.Signature), []byte(payload.PublicKey), nil
+	decode, err := base64.StdEncoding.DecodeString(payload.Signature)
+	if err != nil {
+		glog.Errorf("failed to decode signature,%v", err)
+		return nil, nil, err
+	}
+	return decode, []byte(payload.PublicKey), nil
 }
 
 func (c *pkcs1Client) GetStandard() SignStandard {

--- a/shim/runtime/signature/server/api/api.go
+++ b/shim/runtime/signature/server/api/api.go
@@ -18,11 +18,12 @@ func (s *ApiServer) installRoutes() {
 		{
 			g.POST("/pkcs1", s.pkcs1Handler)
 		}
+		r.Use(loggerHandleFunc).GET("/api/v1/publickey", s.publicKeyHandler)
 	}
 }
 
 func (s ApiServer) installHealthz() {
 	r := s.router
-	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "ping") })
 	r.GET("/healthz", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
 }

--- a/shim/runtime/signature/server/api/handler.go
+++ b/shim/runtime/signature/server/api/handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"encoding/base64"
 	"io/ioutil"
 	"net/http"
 
@@ -34,7 +35,7 @@ func (s *ApiServer) pkcs1Handler(c *gin.Context) {
 		return
 	}
 
-	payload.Signature = string(signedBytes)
+	payload.Signature = base64.StdEncoding.EncodeToString(signedBytes)
 	bytes, err := ioutil.ReadFile(s.publicKeyFilePath)
 	if err != nil {
 		glog.Errorf("failed to parse public key, public key path: %s, err:%v", s.publicKeyFilePath, err.Error())

--- a/shim/runtime/signature/server/api/server.go
+++ b/shim/runtime/signature/server/api/server.go
@@ -10,11 +10,13 @@ import (
 )
 
 type ApiServer struct {
-	router      *gin.Engine
-	listenAddr  string
-	privateKey  *rsa.PrivateKey
-	publicKey   *rsa.PublicKey
-	certificate *x509.Certificate
+	router             *gin.Engine
+	listenAddr         string
+	privateKey         *rsa.PrivateKey
+	publicKey          *rsa.PublicKey
+	certificate        *x509.Certificate
+	publicKeyFilePath  string
+	privateKeyFilePath string
 }
 
 func NewApiServer(listenAddr string, conf *conf.Config) (*ApiServer, error) {
@@ -27,10 +29,12 @@ func NewApiServer(listenAddr string, conf *conf.Config) (*ApiServer, error) {
 		return nil, err
 	}
 	s := &ApiServer{
-		router:     gin.Default(),
-		listenAddr: listenAddr,
-		privateKey: privateKey,
-		publicKey:  publicKey,
+		router:             gin.Default(),
+		listenAddr:         listenAddr,
+		privateKey:         privateKey,
+		publicKey:          publicKey,
+		publicKeyFilePath:  conf.PublicKeyPath,
+		privateKeyFilePath: conf.PrivateKeyPath,
 	}
 	s.installRoutes()
 	return s, nil


### PR DESCRIPTION
1. Make the shim-rune adapt to occlum 0.14
2. Base64 encode the signatrue when sending signature body from server and base64 decode signature when retriving signature  bodyfrom client
3. Update the variable names of occlum process settings