### PR TITLE
docs: fix the url error of terminology doc in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In addition, you can write your own enclave runtime with any programming languag
 ---
 
 ## Terminology 
-Please refer to [this doc] for the details.
+Please refer to [this doc](https://github.com/alibaba/inclavare-containers/blob/master/docs/terminology.md) for the details.
 
 ---
 


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>