### PR TITLE
README: Add the contents about reference container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ For more information about Enclave Runtime PAL API, please refer to [Enclave Run
 
 ### Run OCI bundle
 Please refer to [this guide](https://github.com/alibaba/inclavare-containers/blob/master/docs/running_rune_with_occlum_bundle.md) to run `occlum bundle` with `rune`.
+
+---
+
+## Reference container image
+[The reference container images](https://hub.docker.com/u/inclavarecontainers) are available for the demonstration purpose to show how a Confidential Computing Kubernetes Cluster with Inclavare Containers works. Currently, web application demos based on OpenJDK 11 and Golang are provided.


### PR DESCRIPTION
For demonstration purpose, the reference container images are
availbale. Currently, web application demos based on OpenJDK 11
and Golang are provided.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>