### PR TITLE
rune/libenclave/skeleton: 

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -14,7 +14,11 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 25
 #include <sys/types.h>
+#else
+#include <sys/sysmacros.h>
+#endif
 #include "defines.h"
 #include "sgx_call.h"
 


### PR DESCRIPTION
In the GNU C Library, "major" is defined by <sys/sysmacros.h>
starting from glibc-2.25, the macros major and minor are only available in <sys/sysmacros.h>.
This fix is for historical compatibility.

Signed-off-by: Liang Yang <liang3.yang@intel.com>