### PR TITLE
rune/libenclave/skeleton: Support pal api v2 with SGX in-tree driver

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -12,7 +12,7 @@ HOST_LDFLAGS := -fPIC -shared -Wl,-Bsymbolic
 IS_OOT_DRIVER := $(shell [ ! -e /dev/isgx ])
 IS_SGX_FLC := $(shell lscpu | grep -q sgx_lc)
 
-TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton-v1.so $(OUTPUT)/signing_key.pem
+TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton-v1.so $(OUTPUT)/liberpal-skeleton-v2.so $(OUTPUT)/signing_key.pem
 
 ifeq ($(IS_OOT_DRIVER),1)
     TEST_CUSTOM_PROGS += $(OUTPUT)/encl.token
@@ -26,6 +26,12 @@ $(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skele
 	$(CC) $(HOST_LDFLAGS) -o $@ $^
 
 $(OUTPUT)/liberpal-skeleton-v1.o: liberpal-skeleton-v1.c liberpal-skeleton.c
+	$(CC) $(HOST_CFLAGS) -c $< -o $@
+
+$(OUTPUT)/liberpal-skeleton-v2.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v2.o $(OUTPUT)/liberpal-skeleton.o
+	$(CC) $(HOST_LDFLAGS) -o $@ $^
+
+$(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/liberpal-skeleton.o: liberpal-skeleton.c

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include "liberpal-skeleton.h"
+
+int pal_get_version(void)
+{
+	return 2;
+}
+
+int pal_init(pal_attr_t *attr)
+{
+	if (is_oot_driver) {
+		fprintf(stderr, "Skeleton PAL API v2 doesn't support SGX OOT driver!\n");
+		return -1;
+	}
+
+	return __pal_init(attr);
+}
+
+int pal_create_process(pal_create_process_args *args)
+{
+	if (args == NULL || args->path == NULL || args->argv == NULL || args->pid == NULL || args->stdio == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	int pid;
+	if ((pid = fork()) < 0)
+		return -1;
+	else if (pid == 0) {
+		int exit_code, ret;
+
+		ret = __pal_exec(args->path, args->argv, args->stdio, &exit_code);
+		exit(ret ? ret : exit_code);
+	} else
+		*args->pid = pid;
+
+	return 0;
+}
+
+int pal_exec(pal_exec_args *attr)
+{
+	if (attr == NULL || attr->exit_value == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	int status;
+	waitpid(attr->pid, &status, 0);
+
+	if (WIFEXITED(status) || WIFSIGNALED(status))
+		*attr->exit_value = WEXITSTATUS(status);
+
+	return 0;
+}
+
+int pal_kill(int pid, int sig)
+{
+	/* No implementation */
+	return 0;
+}
+
+int pal_destroy(void)
+{
+	return __pal_destory();
+}

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -4,7 +4,6 @@
 #include <elf.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -36,9 +35,9 @@
 static struct sgx_secs secs;
 static bool initialized = false;
 static char *sgx_dev_path;
-static bool is_oot_driver;
 static bool no_sgx_flc = false;
 static bool fork_test = false;
+bool is_oot_driver;
 /*
  * For SGX in-tree driver, dev_fd cannot be closed until an enclave instance
  * intends to exit.
@@ -60,7 +59,7 @@ static bool is_sgx_device(const char *dev)
 	return false;
 }
 
-static void detect_driver_type(void)
+__attribute__((constructor)) static void detect_driver_type(void)
 {
 	if (is_sgx_device("/dev/isgx")) {
 		sgx_dev_path = "/dev/isgx";
@@ -409,8 +408,6 @@ int __pal_init(pal_attr_t *attr)
 	void *bin;
 
 	parse_args(attr->args);
-
-	detect_driver_type();
 
 	tcs_busy = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
 			MAP_SHARED | MAP_ANONYMOUS, -1, 0);

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -1,6 +1,10 @@
 #ifndef LIBERPAL_SKELETON_H
 #define LIBERPAL_SKELETON_H
 
+#include <stdbool.h>
+
+extern bool is_oot_driver;
+
 typedef struct {
         const char *args;
         const char *log_level;
@@ -9,6 +13,19 @@ typedef struct {
 typedef struct {
         int stdin, stdout, stderr;
 } pal_stdio_fds;
+
+typedef struct {
+        char *path;
+        char **argv;
+        char **env;
+        pal_stdio_fds *stdio;
+        int *pid;
+} pal_create_process_args;
+
+typedef struct {
+	int pid;
+	int *exit_value;
+} pal_exec_args;
 
 int __pal_init(pal_attr_t *attr);
 int __pal_exec(char *path, char *argv[], pal_stdio_fds *stdio, int *exit_code);


### PR DESCRIPTION
- v2 implementation in a separate file.
- v2 support SGX in-tree driver, don't support SGX oot driver.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>