### PR TITLE
rune: Update the version of liberpal-skeleton.so in rune

### DIFF
--- a/rune/.gitignore
+++ b/rune/.gitignore
@@ -5,4 +5,4 @@ contrib/cmd/recvtty/recvtty
 man/man8
 release
 *.pb.go
-liberpal-skeleton.so
+liberpal-skeleton*.so

--- a/rune/Makefile
+++ b/rune/Makefile
@@ -43,8 +43,8 @@ all: rune recvtty skeleton
 recvtty:
 	$(GO_BUILD) -o contrib/cmd/recvtty/recvtty ./contrib/cmd/recvtty
 
-skeleton: libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.so
-libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.so:
+skeleton: libenclave/internal/runtime/pal/skeleton/liberpal-skeleton*.so
+libenclave/internal/runtime/pal/skeleton/liberpal-skeleton*.so:
 	make -C libenclave/internal/runtime/pal/skeleton
 
 static: $(PROTOS)

--- a/rune/libcontainer/specconv/example.go
+++ b/rune/libcontainer/specconv/example.go
@@ -159,7 +159,7 @@ func Example() *specs.Spec {
 		},
 		Annotations: map[string]string{
 			"enclave.type":         "intelSgx",
-			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton.so",
+			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton-v1.so",
 			"enclave.runtime.args": "skeleton,debug",
 		},
 	}

--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -10,7 +10,7 @@ Refer to [this guide](https://github.com/alibaba/inclavare-containers/tree/maste
 
 Note that this step is only required when using SGX out-of-tree driver.
 
-## Build liberpal-skeleton.so
+## Build liberpal-skeleton
 ```shell
 cd "${path_to_inclavare_containers}/rune/libenclave/internal/runtime/pal/skeleton"
 make


### PR DESCRIPTION
- Use liberpal-skeleton-v${SKELETON_PAL_VERSION}.so to replace liberpal-skeleton.so in README.
- Use liberpal-skeleton-v1.so to replace liberpal-skeleton.so in rune/libcontainer/specconv/example.go
- Use liberpal-skeleton*.so to repalce liberpal-skeleton.so in rune/Makefile and .gitignore

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>