### PR TITLE
rune/libenclave/skeleton: add pal api v3

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/.gitignore
+++ b/rune/libenclave/internal/runtime/pal/skeleton/.gitignore
@@ -4,3 +4,6 @@ encl.ss
 *.o
 sgxsign
 signing_key.pem
+*.so
+*.token
+Dockerfile

--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -12,7 +12,7 @@ HOST_LDFLAGS := -fPIC -shared -Wl,-Bsymbolic
 IS_OOT_DRIVER := $(shell [ ! -e /dev/isgx ])
 IS_SGX_FLC := $(shell lscpu | grep -q sgx_lc)
 
-TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton-v1.so $(OUTPUT)/liberpal-skeleton-v2.so $(OUTPUT)/signing_key.pem
+TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton-v1.so $(OUTPUT)/liberpal-skeleton-v2.so $(OUTPUT)/liberpal-skeleton-v3.so $(OUTPUT)/signing_key.pem
 
 ifeq ($(IS_OOT_DRIVER),1)
     TEST_CUSTOM_PROGS += $(OUTPUT)/encl.token
@@ -32,6 +32,12 @@ $(OUTPUT)/liberpal-skeleton-v2.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skele
 	$(CC) $(HOST_LDFLAGS) -o $@ $^
 
 $(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
+	$(CC) $(HOST_CFLAGS) -c $< -o $@
+
+$(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o
+	$(CC) $(HOST_LDFLAGS) -o $@ $^
+
+$(OUTPUT)/liberpal-skeleton-v3.o: liberpal-skeleton-v3.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/liberpal-skeleton.o: liberpal-skeleton.c

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v3.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v3.c
@@ -3,32 +3,38 @@
 #include <sys/wait.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <linux/types.h>
 #include <sys/stat.h>
 #include "liberpal-skeleton.h"
+#include "sgx_call.h"
+#include "defines.h"
 
 int pal_get_version(void)
 {
-	return 2;
+	return 3;
 }
 
 int pal_init(pal_attr_t *attr)
 {
-	if (is_oot_driver) {
-		fprintf(stderr, "Skeleton PAL API v2 doesn't support SGX OOT driver!\n");
-		return -1;
-	}
-
 	return __pal_init(attr);
 }
 
 int pal_create_process(pal_create_process_args *args)
 {
-	return __pal_create_process(args);
+	if (!is_oot_driver) {
+		return __pal_create_process(args);
+	}
+
+	return 0;
 }
 
 int pal_exec(pal_exec_args *attr)
 {
 	return wait4child(attr);
+}
+
+int pal_get_local_report(void *targetinfo, int targetinfo_len, void *report, int* report_len) {
+	return __pal_get_local_report(targetinfo, targetinfo_len, report, report_len);
 }
 
 int pal_kill(int pid, int sig)

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 extern bool is_oot_driver;
+extern bool debugging;
 
 typedef struct {
         const char *args;
@@ -29,6 +30,10 @@ typedef struct {
 
 int __pal_init(pal_attr_t *attr);
 int __pal_exec(char *path, char *argv[], pal_stdio_fds *stdio, int *exit_code);
+int __pal_create_process(pal_create_process_args *args);
+int wait4child(pal_exec_args *attr);
+int __pal_get_local_report(void *targetinfo, int targetinfo_len, void *report, int* report_len);
+int __pal_kill(int pid, int sig);
 int __pal_destory(void);
 
 #endif

--- a/rune/libenclave/internal/runtime/pal/skeleton/skeleton_remote_attestation_with_rune.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/skeleton_remote_attestation_with_rune.md
@@ -1,0 +1,67 @@
+# Introduction
+This guide will guide you how to use remote attestation based on SGX in skeleton with rune.
+
+# Before you start
+- Build a skeleton bundle according to [this guide](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/skeleton/README.md) from scratch.
+- Build rune according to [this guide](https://github.com/alibaba/inclavare-containers#rune).
+- Register a `SPID` and `Subscription Key` of [IAS](https://api.portal.trustedservices.intel.com/EPID-attestation). After the registration, Intel will respond with a SPID which is needed to communicate with IAS.
+
+# Enable Remote Attestation when skeleton starts
+ You need to configure enclave runtime as following:
+```json
+"annotations": {
+	"enclave.type": "intelSgx",
+	"enclave.runtime.path": "/usr/lib/liberpal-skeleton.so",
+	"enclave.runtime.args": "debug,attest-test",
+	"enclave.attestation.ra_type": "EPID",
+	"enclave.is_product_enclave": "false",
+	"enclave.attestation.ra_epid_spid": "${EPID_SPID}",
+	"enclave.attestation.ra_epid_subscription_key": "${EPID_SUBSCRIPTION_KEY}",
+	"enclave.attestation.ra_epid_is_linkable": "false"
+}
+```
+
+where:
+- @enclave.type: specify the type of enclave hardware to use, such as `intelSgx`.
+- @enclave.runtime.path: specify the path to enclave runtime to launch.
+- @enclave.runtime.args: specify the specific arguments to enclave runtime, seperated by the comma.
+- @enclave.attestation.ra_type:  specify the type of remote attestation, such as `EPID`(recommended) or `DCAP`(not supported by `IAS` now). If `not` set this value,  Remote Attestation is `disable` when skeleton starting.
+- @enclave.is_product_enclave: specify the type of enclave is in product mode or debug mode.
+- @enclave.attestation.ra_epid_spid: specify the `SPID`.
+- @enclave.attestation.ra_epid_subscription_key: specify the `Subscription Key`.
+- @enclave.attestation.ra_epid_is_linkable: specify the type of `EPID` is `linkable` or `unlinkable`.  
+
+then you can type the following command to run skeleton:
+
+```shell
+cd "$HOME/rune_workdir/rune-container"
+
+# copy /etc/resolv.conf from host to bundles to ensure network is ready for the remote attestation of IAS.
+cp /etc/resolv.conf rootfs/etc/resolv.conf
+
+sudo rune run skeleton-enclave-container
+```
+
+# Use `rune attest` command with skeleton
+Before using `rune attest` command, you must ensure your skeleton container(such as skeleton-enclave-container) running by setting `"enclave.runtime.args": "attest-test"` in config.json.
+```json
+"annotations": {
+        "enclave.runtime.args": "attest-test"
+}
+```
+
+You can type the following command to use `rune attest` command with skeleton:
+
+```shell
+rune attest --product=false \ 
+		--linkable=false \
+		--spid=${EPID_SPID} \
+		--subscription-key=${EPID_SUBSCRIPTION_KEY} \
+		skeleton-enclave-container
+```
+
+where:
+- @product: specify the type of enclave is in product mode or debug mode.
+- @linkable: specify the type of `EPID` is `linkable` or `unlinkable`.
+- @spid: specify the `SPID`.
+- @subscription-key: specify the `Subscription Key`.


### PR DESCRIPTION
1. Add pal_get_local_report to both support remote attestation when enclave
runtime started and rune attest command.
2. Use is_debug_mode to process the debug arg of Enclave Runtime.
3. rune/libenclave/skeleton: add skeleton_remote_attestation_with_rune.md.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>