### PR TITLE
rune/libenclave/skeleton: refactor pal api v2 and add pal api v3.

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/.gitignore
+++ b/rune/libenclave/internal/runtime/pal/skeleton/.gitignore
@@ -4,3 +4,6 @@ encl.ss
 *.o
 sgxsign
 signing_key.pem
+*.so
+*.token
+Dockerfile

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
@@ -23,45 +23,17 @@ int pal_init(pal_attr_t *attr)
 
 int pal_create_process(pal_create_process_args *args)
 {
-	if (args == NULL || args->path == NULL || args->argv == NULL || args->pid == NULL || args->stdio == NULL) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	int pid;
-	if ((pid = fork()) < 0)
-		return -1;
-	else if (pid == 0) {
-		int exit_code, ret;
-
-		ret = __pal_exec(args->path, args->argv, args->stdio, &exit_code);
-		exit(ret ? ret : exit_code);
-	} else
-		*args->pid = pid;
-
-	return 0;
+	return __pal_create_process(args);
 }
 
 int pal_exec(pal_exec_args *attr)
 {
-	if (attr == NULL || attr->exit_value == NULL) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	int status;
-	waitpid(attr->pid, &status, 0);
-
-	if (WIFEXITED(status) || WIFSIGNALED(status))
-		*attr->exit_value = WEXITSTATUS(status);
-
-	return 0;
+	return wait4child(attr);
 }
 
 int pal_kill(int pid, int sig)
 {
-	/* No implementation */
-	return 0;
+	return __pal_kill(pid, sig);
 }
 
 int pal_destroy(void)

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -38,6 +38,7 @@ static bool initialized = false;
 static char *sgx_dev_path;
 static bool no_sgx_flc = false;
 static bool enclave_debug = true;
+bool debugging = false;
 bool is_oot_driver;
 /*
  * For SGX in-tree driver, dev_fd cannot be closed until an enclave instance
@@ -377,6 +378,8 @@ static void check_opts(const char *opt)
 {
 	if (!strcmp(opt, "no-sgx-flc"))
 		no_sgx_flc = true;
+	else if (!strcmp(opt, "debug"))
+		debugging = true;
 }
 
 static void parse_args(const char *args)

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 extern bool is_oot_driver;
+extern bool debugging;
 
 typedef struct {
         const char *args;

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -29,6 +29,9 @@ typedef struct {
 
 int __pal_init(pal_attr_t *attr);
 int __pal_exec(char *path, char *argv[], pal_stdio_fds *stdio, int *exit_code);
+int __pal_create_process(pal_create_process_args *args);
+int wait4child(pal_exec_args *attr);
+int __pal_kill(int pid, int sig);
 int __pal_destory(void);
 
 #endif


### PR DESCRIPTION
1. sink the implementation of PAL V2 APIs: Move the implementation of skeleton PAL V2 APIs from liberpal-skeleton-v2.c to liberpal-skeleton.c
2. ignore *.so, *.token and Dockerfile.
3. add sanity check in skeleton PAL APIs.
4. support the `debug` arg.
5. support PAL API V3: support pal_get_local_report API and remote attestation at bootstrap, add skeleton_remote_attestation_with_rune.md.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>