### PR TITLE
rune/libenclave: Change import paths to "github.com/inclavare-containers/rune"

### DIFF
--- a/rune/libenclave/agent.go
+++ b/rune/libenclave/agent.go
@@ -1,4 +1,4 @@
-package libenclave // import "github.com/opencontainers/runc/libenclave"
+package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 
 import (
 	"fmt"

--- a/rune/libenclave/attestation/check.go
+++ b/rune/libenclave/attestation/check.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 import (
 	"fmt"

--- a/rune/libenclave/attestation/nonce.go
+++ b/rune/libenclave/attestation/nonce.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 import (
 	"encoding/binary"

--- a/rune/libenclave/attestation/registry.go
+++ b/rune/libenclave/attestation/registry.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 var registry []Registry
 

--- a/rune/libenclave/attestation/service.go
+++ b/rune/libenclave/attestation/service.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 import (
 	"fmt"

--- a/rune/libenclave/attestation/sgx/attest.go
+++ b/rune/libenclave/attestation/sgx/attest.go
@@ -1,4 +1,4 @@
-package sgx // import "github.com/opencontainers/runc/libenclave/attestation/sgx"
+package sgx // import "github.com/inclavare-containers/rune/libenclave/attestation/sgx"
 
 // RA Type
 const (

--- a/rune/libenclave/attestation/sgx/ias/api.go
+++ b/rune/libenclave/attestation/sgx/ias/api.go
@@ -1,4 +1,4 @@
-package ias // import "github.com/opencontainers/runc/libenclave/attestation/sgx/ias"
+package ias // import "github.com/inclavare-containers/rune/libenclave/attestation/sgx/ias"
 
 const (
 	apiV3 = 3

--- a/rune/libenclave/attestation/sgx/ias/ias.go
+++ b/rune/libenclave/attestation/sgx/ias/ias.go
@@ -1,4 +1,4 @@
-package ias // import "github.com/opencontainers/runc/libenclave/attestation/sgx/ias"
+package ias // import "github.com/inclavare-containers/rune/libenclave/attestation/sgx/ias"
 
 import (
 	"bytes"

--- a/rune/libenclave/attestation/utils.go
+++ b/rune/libenclave/attestation/utils.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 func GetParameter(key string, p map[string]string) string {
 	for k, v := range p {

--- a/rune/libenclave/attestation/verify.go
+++ b/rune/libenclave/attestation/verify.go
@@ -1,4 +1,4 @@
-package attestation // import "github.com/opencontainers/runc/libenclave/attestation"
+package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
 
 const (
 	// FIXME: allow tuning via parameter

--- a/rune/libenclave/configs/config.go
+++ b/rune/libenclave/configs/config.go
@@ -1,4 +1,4 @@
-package configs // import "github.com/opencontainers/runc/libenclave/configs"
+package configs // import "github.com/inclavare-containers/rune/libenclave/configs"
 
 type InitEnclaveConfig struct {
 	Type                  string `json:"type"`

--- a/rune/libenclave/init.go
+++ b/rune/libenclave/init.go
@@ -1,4 +1,4 @@
-package libenclave // import "github.com/opencontainers/runc/libenclave"
+package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 
 import (
 	"github.com/opencontainers/runc/libcontainer/configs"

--- a/rune/libenclave/intelsgx/aesmd.go
+++ b/rune/libenclave/intelsgx/aesmd.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 import (
 	"bytes"

--- a/rune/libenclave/intelsgx/arch.go
+++ b/rune/libenclave/intelsgx/arch.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 var (
 	sgx1Supported           bool = false

--- a/rune/libenclave/intelsgx/cpuid.go
+++ b/rune/libenclave/intelsgx/cpuid.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 /*
 #include <stdlib.h>

--- a/rune/libenclave/intelsgx/device_linux.go
+++ b/rune/libenclave/intelsgx/device_linux.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 /*
 #cgo linux LDFLAGS: -ldl

--- a/rune/libenclave/intelsgx/epc.go
+++ b/rune/libenclave/intelsgx/epc.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 type SgxEpcSection struct {
 	PhysicalAddress uint64

--- a/rune/libenclave/intelsgx/launch_control.go
+++ b/rune/libenclave/intelsgx/launch_control.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 var (
 	sgxLaunchControlSupported bool = false

--- a/rune/libenclave/intelsgx/secs.go
+++ b/rune/libenclave/intelsgx/secs.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
+package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
 
 func getSecsAttributes() (uint32, uint32, uint32, uint32) {
 	eax, ebx, ecx, edx := cpuid(cpuidSgxFeature, sgxAttributes)

--- a/rune/libenclave/internal/runtime/core/core.go
+++ b/rune/libenclave/internal/runtime/core/core.go
@@ -1,4 +1,4 @@
-package enclave_runtime_core // import "github.com/opencontainers/runc/libenclave/internal/runtime/core"
+package enclave_runtime_core // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/core"
 
 import (
 	"fmt"

--- a/rune/libenclave/internal/runtime/enclave_runtime.go
+++ b/rune/libenclave/internal/runtime/enclave_runtime.go
@@ -1,4 +1,4 @@
-package runtime // import "github.com/opencontainers/runc/libenclave/internal/runtime"
+package runtime // import "github.com/inclavare-containers/rune/libenclave/internal/runtime"
 
 import (
 	"github.com/opencontainers/runc/libenclave/configs"

--- a/rune/libenclave/internal/runtime/pal/api_linux_v1.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux_v1.go
@@ -1,4 +1,4 @@
-package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 
 /*
 #include <stdlib.h>

--- a/rune/libenclave/internal/runtime/pal/api_linux_v2.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux_v2.go
@@ -1,4 +1,4 @@
-package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 
 /*
 #include <stdlib.h>

--- a/rune/libenclave/internal/runtime/pal/api_linux_v3.go
+++ b/rune/libenclave/internal/runtime/pal/api_linux_v3.go
@@ -1,4 +1,4 @@
-package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 
 /*
 #include <stdlib.h>

--- a/rune/libenclave/internal/runtime/pal/pal.go
+++ b/rune/libenclave/internal/runtime/pal/pal.go
@@ -1,4 +1,4 @@
-package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 
 import (
 	"github.com/opencontainers/runc/libenclave/configs"

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -1,4 +1,4 @@
-package enclave_runtime_pal // import "github.com/opencontainers/runc/libenclave/internal/runtime/pal"
+package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 
 import "C"
 

--- a/rune/libenclave/runelet.go
+++ b/rune/libenclave/runelet.go
@@ -1,4 +1,4 @@
-package libenclave // import "github.com/opencontainers/runc/libenclave"
+package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 
 import (
 	"encoding/json"

--- a/rune/libenclave/sync.go
+++ b/rune/libenclave/sync.go
@@ -1,4 +1,4 @@
-package libenclave // import "github.com/opencontainers/runc/libenclave"
+package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 
 import (
 	"encoding/json"

--- a/rune/libenclave/utils.go
+++ b/rune/libenclave/utils.go
@@ -1,4 +1,4 @@
-package libenclave // import "github.com/opencontainers/runc/libenclave"
+package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 
 import (
 	"bytes"


### PR DESCRIPTION
Change import paths from "github.com/opencontainers/runc" to "github.com/inclavare-containers/rune"

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>