### PR TITLE
rune/libenclave: Remove the implementation of runtime.Load()

### DIFF
--- a/rune/libenclave/internal/runtime/enclave_runtime.go
+++ b/rune/libenclave/internal/runtime/enclave_runtime.go
@@ -11,7 +11,6 @@ import (
 )
 
 type EnclaveRuntime interface {
-	Load(path string) error
 	Init(args string, logLevel string) error
 	Attest(string, string, uint32, uint32) error
 	Exec(cmd []string, envp []string, stdio [3]*os.File) (int32, error)
@@ -36,12 +35,6 @@ func StartInitialization(config *configs.InitEnclaveConfig, logLevel string) (*E
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	logrus.Infof("Loading enclave runtime %s", config.Path)
-	err = runtime.Load(config.Path)
-	if err != nil {
-		return nil, err
 	}
 
 	logrus.Infof("Initializing enclave runtime")

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -18,25 +18,14 @@ const (
 	palApiVersion = 2
 )
 
-func (pal *enclaveRuntimePal) Load(palPath string) (err error) {
-	if err = pal.getPalApiVersion(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (pal *enclaveRuntimePal) getPalApiVersion() error {
+func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {
 	api := &enclaveRuntimePalApiV1{}
 	ver := api.get_version()
 	if ver > palApiVersion {
-		return fmt.Errorf("unsupported pal api version %d", ver)
-	}
-	pal.version = ver
-	return nil
-}
+                return fmt.Errorf("unsupported pal api version %d", ver)
+        }
+        pal.version = ver
 
-func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {
-	api := &enclaveRuntimePalApiV1{}
 	return api.init(args, logLevel)
 }
 


### PR DESCRIPTION
Load function has become unnecessary in the rune design. We implement the logic of Load and getPalApiVersion directly in runtime.Init().

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>