### PR TITLE
To fix an issue to be compatible with non-AVX machine running skeleton.

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -120,7 +120,7 @@ static bool encl_create(int dev_fd, unsigned long bin_size,
 	secs->attributes = SGX_ATTR_MODE64BIT;
 	if (enclave_debug)
 		secs->attributes |= SGX_ATTR_DEBUG;
-	secs->xfrm = 7;
+	secs->xfrm = 3;
 
 	for (secs->size = PAGE_SIZE; secs->size < bin_size; )
 		secs->size <<= 1;

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
@@ -465,7 +465,7 @@ int main(int argc, char **argv)
 #endif
 	if (enclave_debug)
 		ss.body.attributes |= SGX_ATTR_DEBUG;
-	ss.body.xfrm = 7;
+	ss.body.xfrm = 3;
 	ss.body.attributes_mask = ss.body.attributes;
 
 	/* sanity check only */


### PR DESCRIPTION
rune/libenclave/skeleton: If xfrm is set to 7, it represents that the machine must support AVX state(XCR0[2]=1) managed by XSAVE. To be compatible with non-AVX feature machine, xfrm should be set to 3.