### PR TITLE
rune/libenclave: Fix the name of PSW library libsgx_launch.so

### DIFF
--- a/rune/libenclave/intelsgx/device_linux.go
+++ b/rune/libenclave/intelsgx/device_linux.go
@@ -3,6 +3,7 @@ package intelsgx // import "github.com/opencontainers/runc/libenclave/intelsgx"
 /*
 #cgo linux LDFLAGS: -ldl
 #include <stdlib.h>
+#include <stdio.h>
 #include <dlfcn.h>
 */
 import "C"
@@ -10,6 +11,15 @@ import "C"
 import (
 	"unsafe"
 )
+
+func loadLibrary(p string) {
+	path := C.CString(p)
+	dl := C.dlopen(path, C.RTLD_NOW)
+	if dl == nil {
+		C.perror(C.CString("failed to load library " + p))
+	}
+	C.free(unsafe.Pointer(path))
+}
 
 // Due to the design of runelet, the Enclave Runtime PAL is loaded
 // in host but launched in container. The fact that certain libraries
@@ -19,9 +29,7 @@ import (
 // are completely loaded in host, preload them prior to switch
 // into container.
 func preloadSgxPswLib() {
-	path := C.CString("libsgx_launch.so")
-	C.dlopen(path, C.RTLD_NOW)
-	C.free(unsafe.Pointer(path))
+	loadLibrary("libsgx_launch.so.1")
 }
 
 func init() {


### PR DESCRIPTION
Change libsgx_launch.so to libsgx_launch.so.1 in preloadSgxPswLib function

Signed-off-by: Shirong Hao<shirong@linux.alibaba.com>