### PR TITLE
shim/runtime/v2/rune/v2: Fix the return value error of getCarrierKind

### DIFF
--- a/shim/runtime/v2/rune/v2/rune.go
+++ b/shim/runtime/v2/rune/v2/rune.go
@@ -138,7 +138,7 @@ func getCarrierKind(bundlePath string) (found bool, value rune.CarrierKind, err 
 	}
 	v, ok := config.GetEnv(spec, constants.EnvKeyRuneCarrier)
 	if !ok {
-		return
+		return true, rune.Empty, nil
 	}
 	value = rune.CarrierKind(v)
 	if value == rune.Occlum || value == rune.Graphene || value == rune.Empty || value == rune.Skeleton {


### PR DESCRIPTION
If not set RuneCarrier(such as Pods), the getCarrierkind should return
<true, rune.Empty, nil>.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>