### PR TITLE
rune/libenclave: Supplement the missing return value description information of enclave runtime pal API v2 spec

### DIFF
--- a/rune/libenclave/internal/runtime/pal/spec_v2.md
+++ b/rune/libenclave/internal/runtime/pal/spec_v2.md
@@ -18,7 +18,7 @@ N/A
 
 ### Return value
 ```
-N/A
+@int: the PAL API version of the current enclave runtime.
 ```
 
 ## 2.pal_init()
@@ -105,6 +105,13 @@ int pal_exec(struct pal_exec_args *attr);
 ```
 @pid: The pid of the generation process.
 @exit_value: The exit value of the process.
+```
+
+### Return value
+```
+0: Success
+-EINVAL: Invalid argument
+-ENOSYS: The function is not supported
 ```
 
 ## 5.pal_kill()


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>