### PR TITLE
Xfrm should be a subset of xcr0 in different machine

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -24,13 +24,13 @@ endif
 
 all: $(TEST_CUSTOM_PROGS)
 
-$(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v1.o $(OUTPUT)/liberpal-skeleton.o
+$(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v1.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o
 	$(CC) $(HOST_LDFLAGS) -o $@ $^
 
 $(OUTPUT)/liberpal-skeleton-v1.o: liberpal-skeleton-v1.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
-$(OUTPUT)/liberpal-skeleton-v2.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v2.o $(OUTPUT)/liberpal-skeleton.o
+$(OUTPUT)/liberpal-skeleton-v2.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v2.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o
 	$(CC) $(HOST_LDFLAGS) -o $@ $^
 
 $(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
@@ -39,13 +39,16 @@ $(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
 $(OUTPUT)/liberpal-skeleton.o: liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
-$(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o
+$(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o
 	$(CC) $(HOST_LDFLAGS) -o $@ $^
 
 $(OUTPUT)/liberpal-skeleton-v3.o: liberpal-skeleton-v3.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/sgx_call.o: sgx_call.S
+	$(CC) $(HOST_CFLAGS) -c $< -o $@
+
+$(OUTPUT)/sgxutils.o: sgxutils.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/encl.bin: $(OUTPUT)/encl.elf $(OUTPUT)/sgxsign
@@ -70,14 +73,15 @@ $(OUTPUT)/encl.ss: $(OUTPUT)/encl.bin $(OUTPUT)/signing_key.pem
 $(OUTPUT)/encl.token: $(OUTPUT)/encl.ss
 	sgx-tools gen-token --signature encl.ss --token $@
 
-$(OUTPUT)/sgxsign: sgxsign.c
-	$(CC) -I../include -o $@ $< -lcrypto
+$(OUTPUT)/sgxsign: sgxsign.c sgxutils.c
+	$(CC) -I../include -o $@ $^ -lcrypto
 
 EXTRA_CLEAN := \
 	$(OUTPUT)/encl.bin \
 	$(OUTPUT)/encl.elf \
 	$(OUTPUT)/encl.ss \
 	$(OUTPUT)/sgx_call.o \
+	$(OUTPUT)/sgxutils.o \
 	$(OUTPUT)/sgxsign \
 	$(OUTPUT)/liberpal-skeleton*.o \
 	$(OUTPUT)/liberpal-skeleton*.so \

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -114,13 +114,16 @@ static bool encl_create(int dev_fd, unsigned long bin_size,
 {
 	struct sgx_enclave_create ioc;
 	int rc;
+	uint64_t xfrm;
 
 	memset(secs, 0, sizeof(*secs));
 	secs->ssa_frame_size = 1;
 	secs->attributes = SGX_ATTR_MODE64BIT;
 	if (enclave_debug)
 		secs->attributes |= SGX_ATTR_DEBUG;
-	secs->xfrm = 7;
+
+	get_sgx_xfrm_by_cpuid(&xfrm);
+	secs->xfrm = xfrm;
 
 	for (secs->size = PAGE_SIZE; secs->size < bin_size; )
 		secs->size <<= 1;

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
@@ -17,6 +17,25 @@ enum sgx_page_flags {
 	SGX_PAGE_MEASURE	= 0x01,
 };
 
+#define	SGX_LEAF	0x12
+
+/**
+ *CPUID function 1
+ *ECX[26] enums general support for XSAVE
+ *ECX[27] enums XSAVE is enabled or not
+*/
+#define	XSAVE_SHIFT	26
+#define	OSXSAVE_SHIFT	27
+
+/**
+ *CPUID function 0DH, sub-function 1
+ *EAX[1] enums support for compaction extensions to XSAVE
+ */
+#define	XSAVEC_SHIFT	1
+
+/* XSAVE Feature Request Mask */
+#define	SGX_XFRM_LEGACY	0x0000000000000003ULL     /* Legacy XFRM which includes the basic feature bits required by SGX, x87 state(0x01) and SSE state(0x02) */
+
 #define SGX_MAGIC 0xA4
 
 #define SGX_IOC_ENCLAVE_CREATE \
@@ -143,4 +162,5 @@ typedef int (*sgx_enclave_exit_handler_t)(long rdi, long rsi, long rdx,
 					  void *tcs, int ret,
 					  struct sgx_enclave_exception *e);
 
+void get_sgx_xfrm_by_cpuid(uint64_t *xfrm);
 #endif /* _UAPI_ASM_X86_SGX_H */

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
@@ -422,6 +422,7 @@ int main(int argc, char **argv)
 {
 	uint64_t header1[2] = {0x000000E100000006, 0x0000000000010000};
 	uint64_t header2[2] = {0x0000006000000101, 0x0000000100000060};
+	uint64_t xfrm;
 	struct sgx_sigstruct ss;
 	const char *program;
 	int opt;
@@ -465,7 +466,10 @@ int main(int argc, char **argv)
 #endif
 	if (enclave_debug)
 		ss.body.attributes |= SGX_ATTR_DEBUG;
-	ss.body.xfrm = 7;
+
+	get_sgx_xfrm_by_cpuid(&xfrm);
+	ss.body.xfrm = xfrm;
+
 	ss.body.attributes_mask = ss.body.attributes;
 
 	/* sanity check only */

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
@@ -1,0 +1,94 @@
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "sgx.h"
+
+static inline void cpuid(int *eax, int *ebx, int *ecx, int *edx)
+{
+#if defined(__x86_64__)
+	asm volatile ("cpuid"
+		: "=a" (*eax),
+		"=b" (*ebx),
+		"=c" (*ecx),
+		"=d" (*edx)
+		: "0" (*eax), "2" (*ecx)
+		: "memory");
+#else
+	/*on 32bit, ebx can NOT be used as PIC code*/
+	asm volatile ("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
+		: "=a" (*eax), "=r" (*ebx), "=c" (*ecx), "=d" (*edx)
+		: "0" (*eax), "2" (*ecx)
+		: "memory");
+#endif
+}
+
+static inline void __cpuid(int a[4], int b)
+{
+    a[0] = b;
+    a[2] = 0;
+    cpuid(&a[0], &a[1], &a[2], &a[3]);
+}
+
+static inline void __cpuidex(int a[4], int b, int c)
+{
+    a[0] = b;
+    a[2] = c;
+    cpuid(&a[0], &a[1], &a[2], &a[3]);
+}
+
+static inline uint64_t xgetbv(uint32_t index)
+{
+    uint32_t eax, edx;
+
+    asm volatile(".byte 0x0f,0x01,0xd0" /* xgetbv */
+		: "=a" (eax), "=d" (edx)
+		: "c" (index));
+
+    return eax + ((uint64_t)edx << 32);
+}
+
+static inline uint64_t get_xcr0()
+{
+    return xgetbv(0);
+}
+
+static bool try_get_xcr0(uint64_t *value)
+{
+    int cpu_info[4] = {0, 0, 0, 0};
+
+    *value = SGX_XFRM_LEGACY;
+
+    // check if xgetbv instruction is supported
+    __cpuid(cpu_info, 1);
+    // ecx[27:26] indicate whether support xsave/xrstor, and whether enable xgetbv, xsetbv
+    if (!(cpu_info[2] & (1<<XSAVE_SHIFT)) || !(cpu_info[2] & (1<<OSXSAVE_SHIFT)))
+        return false;
+
+    *value = get_xcr0();
+
+    // check if xsavec is supported
+    // Assume that XSAVEC is always supported if XSAVE is supported
+    cpu_info[0] = cpu_info[1] = cpu_info[2] = cpu_info[3] = 0;
+    __cpuidex(cpu_info, 0xD, 1);
+    if (!(cpu_info[0] & (1<<XSAVEC_SHIFT)))
+        return false;
+
+    return true;
+}
+
+void get_sgx_xfrm_by_cpuid(uint64_t *xfrm)
+{
+    int cpu_info[4] = {0, 0, 0, 0};
+
+    __cpuidex(cpu_info, SGX_LEAF, 1);
+
+    if (false == try_get_xcr0(xfrm))
+    {
+	// if XSAVE is supported, while XSAVEC is not supported,
+	// set xfrm to legacy, because XSAVEC cannot be executed within enclave.
+	*xfrm = SGX_XFRM_LEGACY;
+    } else {
+	// If x-feature is supported and enabled by OS, we need make sure it is also supported in enclave.
+	*xfrm &= (((uint64_t)cpu_info[3] << 32) | cpu_info[2]);
+    }
+}


### PR DESCRIPTION
Xfrm needs support the same xsave feature in encalve as in OS.
By cpuid, it can get the same value between xfrm and xcr0.

Reviewed-by: Jia Zhang <zhang.jia@linux.alibaba.com>
Signed-off-by: Liang Yang <liang3.yang@intel.com>