### PR TITLE
rune/libenclave/skeleton && sgx-tools: Solve the launch token adaptat…

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -9,17 +9,14 @@ ENCL_CFLAGS := -Wall -Werror -static -nostdlib -nostartfiles -fPIC \
 	       -fno-stack-protector -mrdrnd -std=gnu11
 HOST_LDFLAGS := -fPIC -shared -Wl,-Bsymbolic
 
-IS_OOT_DRIVER := $(shell [ ! -e /dev/isgx ])
-IS_SGX_FLC := $(shell lscpu | grep -q sgx_lc)
+IS_SGX_FLC ?= $(shell if lscpu | grep -q sgx_lc; then echo "1"; else echo "0"; fi;)
 
 PRODUCT_ENCLAVE ?=
 
 TEST_CUSTOM_PROGS := $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss $(OUTPUT)/liberpal-skeleton-v1.so $(OUTPUT)/liberpal-skeleton-v2.so $(OUTPUT)/liberpal-skeleton-v3.so $(OUTPUT)/signing_key.pem
 
-ifeq ($(IS_OOT_DRIVER),1)
-    TEST_CUSTOM_PROGS += $(OUTPUT)/encl.token
-else ifeq ($(IS_SGX_FLC),)
-    TEST_CUSTOM_PROGS += $(OUTPUT)/encl.token
+ifeq ($(IS_SGX_FLC),0)
+        TEST_CUSTOM_PROGS += $(OUTPUT)/encl.token
 endif
 
 all: $(TEST_CUSTOM_PROGS)
@@ -62,16 +59,18 @@ $(OUTPUT)/signing_key.pem:
 	openssl genrsa -3 -out $@ 3072
 
 ifeq ($(PRODUCT_ENCLAVE),1)
-    PRODUCT_OPT := -p
+        PRODUCT_OPT := -p
 else
-    PRODUCT_OPT :=
+        PRODUCT_OPT :=
 endif
 
 $(OUTPUT)/encl.ss: $(OUTPUT)/encl.bin $(OUTPUT)/signing_key.pem
 	$(OUTPUT)/sgxsign $(PRODUCT_OPT) signing_key.pem $(OUTPUT)/encl.bin $(OUTPUT)/encl.ss
 
+ifeq ($(IS_SGX_FLC),0)
 $(OUTPUT)/encl.token: $(OUTPUT)/encl.ss
 	sgx-tools gen-token --signature encl.ss --token $@
+endif
 
 $(OUTPUT)/sgxsign: sgxsign.c sgxutils.c
 	$(CC) -I../include -o $@ $^ -lcrypto
@@ -85,8 +84,11 @@ EXTRA_CLEAN := \
 	$(OUTPUT)/sgxsign \
 	$(OUTPUT)/liberpal-skeleton*.o \
 	$(OUTPUT)/liberpal-skeleton*.so \
-	$(OUTPUT)/signing_key.pem \
-	$(OUTPUT)/encl.token
+	$(OUTPUT)/signing_key.pem
+
+ifeq ($(IS_SGX_FLC),0)
+        EXTRA_CLEAN += $(OUTPUT)/encl.token
+endif
 
 clean:
 	rm -f ${EXTRA_CLEAN}

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -433,8 +433,10 @@ int __pal_init(pal_attr_t *attr)
 	if (!load_sigstruct(SIGSTRUCT, &sigstruct))
 		return -ENOENT;
 
-	if (!load_token(TOKEN, &token))
-		return -ENOENT;
+	if (!is_launch_control_supported()) {
+		if (!load_token(TOKEN, &token))
+			return -ENOENT;
+	}
 
 	if (!encl_build(&secs, bin, bin_size, &sigstruct, &token))
 		return -EINVAL;

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
@@ -7,6 +7,7 @@
 
 #include <linux/types.h>
 #include <linux/ioctl.h>
+#include <stdbool.h>
 
 /**
  * enum sgx_epage_flags - page control flags
@@ -18,6 +19,9 @@ enum sgx_page_flags {
 };
 
 #define	SGX_LEAF	0x12
+
+// CPUID leafs
+#define	CPUIID_EXTENDED_FEATURE_FLAGS	0x7
 
 /**
  *CPUID function 1
@@ -163,4 +167,5 @@ typedef int (*sgx_enclave_exit_handler_t)(long rdi, long rsi, long rdx,
 					  struct sgx_enclave_exception *e);
 
 void get_sgx_xfrm_by_cpuid(uint64_t *xfrm);
+bool is_launch_control_supported(void);
 #endif /* _UAPI_ASM_X86_SGX_H */

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
@@ -88,3 +88,12 @@ void get_sgx_xfrm_by_cpuid(uint64_t *xfrm)
 		*xfrm &= (((uint64_t)cpu_info[3] << 32) | cpu_info[2]);
 	}
 }
+
+bool is_launch_control_supported(void)
+{
+	int cpu_info[4] = {0, 0, 0, 0};
+
+	__cpuidex(cpu_info, CPUIID_EXTENDED_FEATURE_FLAGS, 0);
+
+	return !!(cpu_info[2] & 0x40000000);
+}

--- a/sgx-tools/gen-token.go
+++ b/sgx-tools/gen-token.go
@@ -32,6 +32,11 @@ For example, generate the token file according to the given signature file:
 		},
 	},
 	Action: func(context *cli.Context) error {
+
+		if intelsgx.IsSGXLaunchControlSupported() {
+			return fmt.Errorf("gen-token command is unable to run without SGX launch control feature")
+		}
+
 		sigPath := context.String("signature")
 		if sigPath == "" {
 			return fmt.Errorf("signature argument cannot be empty")


### PR DESCRIPTION
…ion problem of sgx2 + in-tree

- sgx-tools gen-token command reports an error when running on FLC machines
- Operations related to lanunch token are not supported on FLC machines

Signed-off-by: Shirong Hao shirong@linux.alibaba.com