### PR TITLE
ra-tls/pal: Add the ocall_sgx_init_quote and ocall_remote_attestation functions

### DIFF
--- a/ra-tls/pal/App.c
+++ b/ra-tls/pal/App.c
@@ -230,7 +230,7 @@ int pal_get_local_report(void *targetinfo, int targetinfo_len, void *report, int
 	}
 
 	int ret;
-	sgxStatus = enc_create_key_and_x509(eid, &ret, ctx, targetinfo, report);
+	sgxStatus = enc_create_key_and_x509(eid, ctx);
 	if (sgxStatus != SGX_SUCCESS || ret != SGX_SUCCESS ) {
 		PAL_ERROR("enc_create_key_and_x509 failure");
 		return EXIT_FAILURE;

--- a/ra-tls/pal/Makefile
+++ b/ra-tls/pal/Makefile
@@ -60,8 +60,7 @@ ifeq ($(HAVE_WOLFSSL_BENCHMARK), 1)
 endif
 
 #App_C_Files := App.c server-tls.c sgxsdk-ra-attester_u.c ias-ra.c
-#App_C_Files := App.c sgxsdk-ra-attester_u.c
-App_C_Fils := App.c
+App_C_Files := App.c sgxsdk-ra-attester_u.c
 App_Include_Paths := $(Wolfssl_Include_Paths) -I$(SGX_SDK)/include -I$(SGX_RA_TLS_ROOT) -I$(INCDIR) -I$(shell readlink -f .)
 
 App_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -shared -Wno-attributes -Wall -Wno-unused-const-variable $(App_Include_Paths) $(Wolfssl_C_Extra_Flags)

--- a/ra-tls/pal/sgxsdk-ra-attester_u.c
+++ b/ra-tls/pal/sgxsdk-ra-attester_u.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include <sgx_uae_service.h>
+
+#include <ra.h>
+#include <ra-attester.h>
+// #include <ias-ra.h>
+
+/* Untrusted code to do remote attestation with the SGX SDK. */
+
+void ocall_remote_attestation
+(
+    sgx_report_t* report,
+    const struct ra_tls_options* opts,
+    attestation_verification_report_t* attn_report
+)
+{
+    // produce quote
+    uint32_t quote_size;
+    sgx_calc_quote_size(NULL, 0, &quote_size);
+    
+    sgx_quote_t* quote = (sgx_quote_t*) calloc(1, quote_size);
+    
+    sgx_status_t status;
+    status = sgx_get_quote(report,
+                           opts->quote_type,
+                           &opts->spid,
+                           NULL,
+                           NULL,
+                           0,
+                           NULL,
+                           quote,
+                           quote_size);
+    assert(SGX_SUCCESS == status);
+
+    // verify against IAS
+    // obtain_attestation_verification_report(quote, quote_size, opts, attn_report);
+}
+
+void ocall_sgx_init_quote
+(
+    sgx_target_info_t* target_info
+)
+{
+    sgx_epid_group_id_t gid;
+    sgx_status_t status = sgx_init_quote(target_info, &gid);
+    assert(status == SGX_SUCCESS);
+}


### PR DESCRIPTION
These functions are defined by sgx-ra-tls in sgx-ra-tls/ra_tls.edl. If not implemented
in ra-tls/pal, running stub enclave with rune couldn't dlopen liberpal-stub.so with
undefined symbol ocall_sgx_init_quote or ocall_remote_attestation.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>