### PR TITLE
fix an error and remove a hardcode. 

### DIFF
--- a/ra-tls/sgx-ra-tls/ra_tls_options.c.sh
+++ b/ra-tls/sgx-ra-tls/ra_tls_options.c.sh
@@ -16,7 +16,7 @@ if ( [[ "$QUOTE_TYPE" != "SGX_LINKABLE_SIGNATURE" ]] ) && \
     echo "//QUOTE_TYPE must be one of SGX_UNLINKABLE_SIGNATURE or SGX_LINKABLE_SIGNATURE"
 fi
 
-SPID_BYTE_ARRAY=$(echo $SPID | python -c 'import sys ; s = sys.stdin.readline().strip(); print("".join(["0x"+s[2*i:2*i+2]+"," for i in range(len(s)/2)]))')
+SPID_BYTE_ARRAY=$(echo $SPID | python -c 'import sys ; s = sys.stdin.readline().strip(); print("".join(["0x"+s[2*i:2*i+2]+"," for i in range(int(len(s)/2))]))')
 
 cat <<HEREDOC
 #include "ra-attester.h"
@@ -24,7 +24,7 @@ cat <<HEREDOC
 struct ra_tls_options my_ra_tls_options = {
     // SPID format is 32 hex-character string, e.g., 0123456789abcdef0123456789abcdef
     .spid = {{$SPID_BYTE_ARRAY}},
-    .quote_type = SGX_UNLINKABLE_SIGNATURE,
+    .quote_type = $QUOTE_TYPE,
     .ias_server = "api.trustedservices.intel.com/sgx/dev",
     // EPID_SUBSCRIPTION_KEY format is "012345679abcdef012345679abcdef"
     .subscription_key = "$EPID_SUBSCRIPTION_KEY"


### PR DESCRIPTION
ra-tls: In python, range paramter should use int type instead of float. And remove SGX_UNLINKABLE_SIGNATURE hardcode replacing with variant quote_type.