### PR TITLE
rune/libenclave/skeleton: Remove skeleton image

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -36,8 +36,6 @@ EOF
 docker build . -t skeleton-enclave
 ```
 
-[Skeleton container image](https://hub.docker.com/r/inclavarecontainers/skeleton-enclave/tags) is available for the demonstration purpose.
-
 ## Build and install rune
 Please refer to [this guide](https://github.com/alibaba/inclavare-containers#rune) to build `rune` from scratch.
 


### PR DESCRIPTION
- The code of liberpal-skeleton is constantly being updated, it may not be compatible with the previous images.

 Signed-off-by: Shirong Hao shirong@linux.alibaba.com