### PR TITLE
sgx-tools: Add the get-ias-report command to get RA report from IAS

### DIFF
--- a/sgx-tools/README.md
+++ b/sgx-tools/README.md
@@ -4,6 +4,7 @@
 - Given the signature file of an Enclave, `sgx-tools gen-token` command can generate the corresponding token file from aesmd service.
 - `sgx-tools gen-qe-target-info` command can generate Quoting Enclave's target information file from aesm service.
 - Given the report file of an Enclave, `sgx-tools gen-quote` command can generate quote file from aesm service.
+- Given the quote file of an Enclave, a registered `SPID` and `Subscription Key` of [IAS](https://api.portal.trustedservices.intel.com/EPID-attestation), `sgx-tools get-ias-report` command can get remote attestation report from IAS.
 
 ## Install Intel `aesmd` service
 ### Hardware requirements

--- a/sgx-tools/README.md
+++ b/sgx-tools/README.md
@@ -3,7 +3,7 @@
 `sgx-tools` is a command line tool for inclavare-containers.
 - Given the signature file of an Enclave, `sgx-tools gen-token` command can generate the corresponding token file from aesmd service.
 - `sgx-tools gen-qe-target-info` command can generate Quoting Enclave's target information file from aesm service.
-- Given the report file of an Enclave, `sgx-tools gen-quote` command can generate quote file from aesm service.
+- Given the report file of an Enclave, a registered `SPID` of [IAS](https://api.portal.trustedservices.intel.com/EPID-attestation), `sgx-tools gen-quote` command can generate quote file from aesm service.
 - Given the quote file of an Enclave, a registered `SPID` and `Subscription Key` of [IAS](https://api.portal.trustedservices.intel.com/EPID-attestation), `sgx-tools get-ias-report` command can get remote attestation report from IAS.
 
 ## Install Intel `aesmd` service

--- a/sgx-tools/gen-quote.go
+++ b/sgx-tools/gen-quote.go
@@ -19,7 +19,7 @@ var generateQuoteCommand = cli.Command{
 EXAMPLE:
 For example, generate the quote file according to the given local report file:
 
-	# sgx-tools gen-quote --report foo.rep`,
+	# sgx-tools gen-quote --report foo.rep --spid ${SPID}`,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "report",

--- a/sgx-tools/get-ias-report.go
+++ b/sgx-tools/get-ias-report.go
@@ -1,0 +1,146 @@
+package main // import "github.com/inclavare-containers/sgx-tools"
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/go-restruct/restruct"
+	"github.com/opencontainers/runc/libenclave/attestation"
+	"github.com/opencontainers/runc/libenclave/attestation/sgx"
+	"github.com/opencontainers/runc/libenclave/intelsgx"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"io"
+	"log"
+	"os"
+)
+
+var getIasReportCommand = cli.Command{
+	Name:  "get-ias-report",
+	Usage: "get remote attestation report from IAS",
+	ArgsUsage: `[command options]
+
+EXAMPLE:
+For example, get remote attestation report from IAS according to quote file:
+
+	# sgx-tools get-ias-report --quote foo.quote --spid ${SPID} --subscription-key ${SUBSCRIPTION_KEY}`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "quote",
+			Usage: "path to the input quote file containing QUOTE",
+		},
+		cli.StringFlag{
+			Name:  "ias-report",
+			Usage: "path to the output IAS report file containing IAS report",
+		},
+		cli.BoolFlag{
+			Name:  "product",
+			Usage: "specify whether using production attestation service",
+		},
+		cli.StringFlag{
+			Name:  "spid",
+			Usage: "spid",
+		},
+		cli.StringFlag{
+			Name:  "subscription-key, -key",
+			Usage: "specify the subscription key",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		quotePath := context.String("quote")
+		if quotePath == "" {
+			return fmt.Errorf("quote argument cannot be empty")
+		}
+
+		iasReportPath := context.String("ias-report")
+		if iasReportPath == "" {
+			iasReportPath = "ias-report.bin"
+		}
+
+		spid := context.String("spid")
+		if spid == "" {
+			return fmt.Errorf("spid argument cannot be empty")
+		}
+
+		subscriptionKey := context.String("subscription-key")
+		if subscriptionKey == "" {
+			return fmt.Errorf("subscription-key argument cannot be empty")
+		}
+
+		var product uint32 = sgx.DebugEnclave
+		if context.Bool("product") {
+			product = sgx.ProductEnclave
+		}
+
+		if context.GlobalBool("verbose") {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		rf, err := os.Open(quotePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("quote file %s not found", quotePath)
+			}
+			return err
+		}
+		defer rf.Close()
+
+		var rfi os.FileInfo
+		rfi, err = rf.Stat()
+		if err != nil {
+			return err
+		}
+
+		if rfi.Size() > intelsgx.SgxMaxQuoteLength {
+			return fmt.Errorf("quote file %s not match Quote", quotePath)
+		}
+
+		quote := make([]byte, rfi.Size())
+		if _, err = io.ReadFull(rf, quote); err != nil {
+			return fmt.Errorf("quote file %s read failed", quotePath)
+		}
+
+		q := &intelsgx.Quote{}
+		if err := restruct.Unpack(quote, binary.LittleEndian, &q); err != nil {
+			return err
+		}
+
+		// get IAS remote attestation report
+		p := parseAttestParameters(spid, subscriptionKey, product)
+		challenger, err := attestation.NewChallenger("sgx-epid", p)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+
+		if err = challenger.Check(quote); err != nil {
+			log.Fatal(err)
+			return err
+		}
+
+		status, iasReport, err := challenger.GetReport(quote, 0)
+		if err != nil {
+			return fmt.Errorf("%s", err)
+		}
+
+		challenger.ShowReportStatus(status)
+
+		logrus.Infof("iasReport = %v", iasReport)
+
+		return nil
+	},
+	SkipArgReorder: true,
+}
+
+func parseAttestParameters(spid string, subscriptionKey string, product uint32) map[string]string {
+	p := make(map[string]string)
+
+	p["spid"] = spid
+	p["subscription-key"] = subscriptionKey
+	if product == sgx.ProductEnclave {
+		p["service-class"] = "product"
+	} else if product == sgx.DebugEnclave {
+		p["service-class"] = "dev"
+	}
+
+	return p
+}

--- a/sgx-tools/go.mod
+++ b/sgx-tools/go.mod
@@ -3,7 +3,7 @@ module github.com/inclavare-containers/sgx-tools
 go 1.14
 
 require (
-	github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1 // indirect
+	github.com/go-restruct/restruct v0.0.0-20191227155143-5734170a48a1
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.6.0

--- a/sgx-tools/main.go
+++ b/sgx-tools/main.go
@@ -45,6 +45,7 @@ func main() {
 		generateTokenCommand,
 		generateQeTargetInfoCommand,
 		generateQuoteCommand,
+		getIasReportCommand,
 	}
 
 	//app.Before = func(context *cli.Context) error {

--- a/sgx-tools/vendor/github.com/opencontainers/runc/libenclave/attestation/sgx/attest.go
+++ b/sgx-tools/vendor/github.com/opencontainers/runc/libenclave/attestation/sgx/attest.go
@@ -1,0 +1,15 @@
+package sgx // import "github.com/opencontainers/runc/libenclave/attestation/sgx"
+
+// RA Type
+const (
+	UnknownRaType = iota
+	EPID
+	DCAP
+)
+
+// RA Enclave Type
+const (
+	InvalidEnclaveType = iota
+	DebugEnclave
+	ProductEnclave
+)

--- a/sgx-tools/vendor/modules.txt
+++ b/sgx-tools/vendor/modules.txt
@@ -12,6 +12,7 @@ github.com/konsorten/go-windows-terminal-sequences
 # github.com/opencontainers/runc v0.0.0-00010101000000-000000000000 => github.com/alibaba/inclavare-containers/rune v0.0.0-20200910122807-fd8d2f54e423
 ## explicit
 github.com/opencontainers/runc/libenclave/attestation
+github.com/opencontainers/runc/libenclave/attestation/sgx
 github.com/opencontainers/runc/libenclave/attestation/sgx/ias
 github.com/opencontainers/runc/libenclave/intelsgx
 github.com/opencontainers/runc/libenclave/intelsgx/proto


### PR DESCRIPTION
1. Add the `get-ias-report` command to get RA report from IAS according to the given quote file.
2. Modify the usage description of gen-quote command.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>