### PR TITLE
rune/libenclave/pal: add a total enclave runtime PAL API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo make install
 `shim-rune` resides in between `containerd` and `rune`, conducting enclave signing and management beyond the normal `shim` basis. `shim-rune` and `rune` can compose a basic enclave containerization stack for the cloud-native ecosystem. Please refer to [this guide](https://github.com/alibaba/inclavare-containers/blob/master/shim/README.md) for the details.
 
 ### enclave runtime
-The backend of `rune` is a component called enclave runtime, which is responsible for loading and running protected applications inside enclaves. The interface between `rune` and enclave runtime is [Enclave Runtime PAL API](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec_v2.md), which allows invoking enclave runtime through well-defined functions. The software for confidential computing may benefit from this interface to interact with OCI runtime.
+The backend of `rune` is a component called enclave runtime, which is responsible for loading and running protected applications inside enclaves. The interface between `rune` and enclave runtime is [Enclave Runtime PAL API](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec.md), which allows invoking enclave runtime through well-defined functions. The software for confidential computing may benefit from this interface to interact with OCI runtime.
 
 One typical class of enclave runtime implementations is based on library OSes. Currently, the default enclave runtime interacting with `rune` is [Occlum](https://github.com/occlum/occlum), a memory-safe, multi-process library OS for Intel SGX.
 

--- a/rune/libenclave/internal/runtime/pal/spec.md
+++ b/rune/libenclave/internal/runtime/pal/spec.md
@@ -1,0 +1,30 @@
+# Enclave Runtime PAL API Specification
+
+## Introduction
+
+Enclave Runtime PAL API defines a common interface to interact between rune and enclave runtime.
+
+## Versions
+
+Enclave Runtime PAL API Specification currently support [PAL API v1](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec_v1.md) and [PAL API v2](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/spec_v2.md).
+
+If you want to use `rune` to run you enclave runtime, you can choose one of supported PAL API version to achieve. Using higher PAL API is recommended.
+
+The PAL API will evolve. You can submit proposal for the extension of PAL API. We will take it after careful consideration.
+
+## The relationship between `rune` and PAL APIs
+
+`rune` has a lot of subcommands such as `create`,`start`,`exec`,`run`,`kill`,`delete`, and etc. The relationship between them is shown in the following table.
+
+| Subcommand | v1 | v2 |
+| :-------:  | :-------:  |  :-------: |
+| create | pal_get_version | pal_get_version |
+|		| pal_init | pal_init |
+| start | pal_exec | pal_create_process |
+|		|            | pal_exec |
+| run  |  pal_get_version  | pal_get_version |
+|	   | pal_init |  pal_init |
+|      |  pal_exec | pal_create_process |
+|	  |                | pal_exec |
+| delete | pal_destroy | pal_destroy |
+| kill |  |  pal_kill |

--- a/rune/libenclave/internal/runtime/pal/spec_v1.md
+++ b/rune/libenclave/internal/runtime/pal/spec_v1.md
@@ -1,5 +1,4 @@
 # Enclave Runtime PAL API Specification v1
-Enclave Runtime PAL API defines a common interface to interact between `rune` and enclave runtime.
 
 ## 1.pal_init()
 

--- a/rune/libenclave/internal/runtime/pal/spec_v2.md
+++ b/rune/libenclave/internal/runtime/pal/spec_v2.md
@@ -1,5 +1,4 @@
 # Enclave Runtime PAL API Specification v2
-Enclave Runtime PAL API defines a common interface to interact between `rune` and enclave runtime.
 
 ## 1.pal_get_version()
 


### PR DESCRIPTION
Add each PAL API vesion information and the relationship between
`rune` subcommands and PAL APIs in the total enclave PAL API spec.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>