### PR TITLE
rune/libenclave: do not load psw and pal dynamic library when rune exec

### DIFF
--- a/rune/libenclave/container_linux.go
+++ b/rune/libenclave/container_linux.go
@@ -1960,7 +1960,6 @@ func (c *linuxContainer) currentState() (*State, error) {
 		BaseState: BaseState{
 			ID:                   c.ID(),
 			Config:               *c.config,
-			EnclaveConfig:        *c.enclaveConfig,
 			InitProcessPid:       pid,
 			InitProcessStartTime: startTime,
 			Created:              c.created,
@@ -1971,6 +1970,10 @@ func (c *linuxContainer) currentState() (*State, error) {
 		NamespacePaths:      make(map[configs.NamespaceType]string),
 		ExternalDescriptors: externalDescriptors,
 	}
+	if c.enclaveConfig != nil {
+		state.BaseState.EnclaveConfig = *c.enclaveConfig
+	}
+
 	if pid > 0 {
 		for _, ns := range c.config.Namespaces {
 			state.NamespacePaths[ns.Type] = ns.GetPath(pid)

--- a/rune/libenclave/factory_linux.go
+++ b/rune/libenclave/factory_linux.go
@@ -313,7 +313,6 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		initProcessStartTime: state.InitProcessStartTime,
 		id:                   id,
 		config:               &state.Config,
-		enclaveConfig:        &state.EnclaveConfig,
 		initPath:             l.InitPath,
 		initArgs:             l.InitArgs,
 		criuPath:             l.CriuPath,
@@ -323,6 +322,10 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 		root:                 containerRoot,
 		created:              state.Created,
 	}
+	if state.EnclaveConfig.Enclave != nil {
+		c.enclaveConfig = &state.EnclaveConfig
+	}
+
 	c.state = &loadedState{c: c}
 	if err := c.refreshState(); err != nil {
 		return nil, err

--- a/rune/libenclave/intelsgx/preload/device_linux.go
+++ b/rune/libenclave/intelsgx/preload/device_linux.go
@@ -1,4 +1,4 @@
-package intelsgx // import "github.com/inclavare-containers/rune/libenclave/intelsgx"
+package preload // import "github.com/inclavare-containers/rune/libenclave/intelsgx/preload"
 
 /*
 #cgo linux LDFLAGS: -ldl
@@ -32,6 +32,6 @@ func preloadSgxPswLib() {
 	loadLibrary("libsgx_launch.so.1")
 }
 
-func init() {
+func PreloadLib() {
 	preloadSgxPswLib()
 }

--- a/rune/libenclave/internal/runtime/pal/loader.go
+++ b/rune/libenclave/internal/runtime/pal/loader.go
@@ -23,7 +23,7 @@ var fptr_pal_get_local_report unsafe.Pointer
 func Loadbinary(path string) {
 	dl := C.dlopen(C.CString(path), C.RTLD_NOW)
 	if dl == nil {
-		C.perror(C.CString("failed to load library "))
+		C.perror(C.CString("failed to load library " + path))
 	}
 
 	fptr_pal_get_version = C.dlsym(dl, C.CString("pal_get_version"))


### PR DESCRIPTION
This bug fix the error message of "Failed to load library" when running rune exec.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>