### PR TITLE
patch/no-sgx-flc: add the SGX DCAP linux driver patch and update README.md.

### DIFF
--- a/patch/no-sgx-flc/0001-SGX-DCAP-Linux-Driver-Support-SGX1-machine-even-without-FLC-s.patch
+++ b/patch/no-sgx-flc/0001-SGX-DCAP-Linux-Driver-Support-SGX1-machine-even-without-FLC-s.patch
@@ -1,0 +1,180 @@
+From 92ebb80362a92cce57470f43dc742ee2ed468816 Mon Sep 17 00:00:00 2001
+From: "YiLin.Li" <YiLin.Li@linux.alibaba.com>
+Date: Wed, 21 Oct 2020 10:41:54 +0000
+Subject: [PATCH] Linux Driver: Support SGX1 machine even without FLC support
+
+There are still lots of SGX1 machines without FLC support deployed
+in filed. These machines eventually needs to be migrated to be supported
+by SGX DCAP driver which is product-ready and well-maintained.
+
+This patch targets to address the gap between SGX1 machine and SGX
+DCAP driver.
+
+Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
+Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>
+---
+ driver/linux/driver.c                   |  5 ---
+ driver/linux/include/uapi/asm/sgx_oot.h | 15 ++++++++
+ driver/linux/ioctl.c                    | 63 +++++++++++++++++++++++++++++++++
+ driver/linux/main.c                     |  1 -
+ 4 files changed, 78 insertions(+), 6 deletions(-)
+
+diff --git a/driver/linux/driver.c b/driver/linux/driver.c
+index 1de2b4d..43db300 100644
+--- a/driver/linux/driver.c
++++ b/driver/linux/driver.c
+@@ -172,11 +172,6 @@ int __init sgx_drv_init(void)
+ 	int ret;
+ 	int i;
+ 
+-	if (!boot_cpu_has(X86_FEATURE_SGX_LC)) {
+-		pr_info("The public key MSRs are not writable.\n");
+-		return -ENODEV;
+-	}
+-
+ 	cpuid_count(SGX_CPUID, 0, &eax, &ebx, &ecx, &edx);
+ 	sgx_misc_reserved_mask = ~ebx | SGX_MISC_RESERVED_MASK;
+ 	sgx_encl_size_max_64 = 1ULL << ((edx >> 8) & 0xFF);
+diff --git a/driver/linux/include/uapi/asm/sgx_oot.h b/driver/linux/include/uapi/asm/sgx_oot.h
+index e196cfd..2c4e9c0 100644
+--- a/driver/linux/include/uapi/asm/sgx_oot.h
++++ b/driver/linux/include/uapi/asm/sgx_oot.h
+@@ -25,6 +25,8 @@ enum sgx_page_flags {
+ 	_IOWR(SGX_MAGIC, 0x01, struct sgx_enclave_add_pages)
+ #define SGX_IOC_ENCLAVE_INIT \
+ 	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
++#define SGX_IOC_ENCLAVE_INIT_WITH_TOKEN \
++	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init_with_token)
+ #define SGX_IOC_ENCLAVE_SET_ATTRIBUTE \
+ 	_IOW(SGX_MAGIC, 0x03, struct sgx_enclave_set_attribute)
+ 
+@@ -65,6 +67,19 @@ struct sgx_enclave_init {
+ 	__u64 sigstruct;
+ };
+ 
++/*
++ * struct sgx_enclave_init_with_token - parameter structure for the
++ *                                      %SGX_IOC_ENCLAVE_INIT_WITH_TOKEN ioctl
++ * @addr:       address in the ELRANGE
++ * @sigstruct:  address for the SIGSTRUCT data
++ * @einittoken: address for the EINITTOKEN data
++ */
++struct sgx_enclave_init_with_token {
++	__u64 addr;
++	__u64 sigstruct;
++	__u64 einittoken;
++} __packed;
++
+ /**
+  * struct sgx_enclave_set_attribute - parameter structure for the
+  *				      %SGX_IOC_ENCLAVE_SET_ATTRIBUTE ioctl
+diff --git a/driver/linux/ioctl.c b/driver/linux/ioctl.c
+index 1ca7612..6e0335a 100644
+--- a/driver/linux/ioctl.c
++++ b/driver/linux/ioctl.c
+@@ -179,6 +179,8 @@ static int sgx_encl_create(struct sgx_encl *encl, struct sgx_secs *secs)
+ 	encl->secs.encl = encl;
+ 	encl->secs_attributes = secs->attributes;
+ 	encl->allowed_attributes |= SGX_ATTR_ALLOWED_MASK;
++	if (!boot_cpu_has(X86_FEATURE_SGX_LC))
++		encl->allowed_attributes |= SGX_ATTR_EINITTOKENKEY;
+ 	encl->base = secs->base;
+ 	encl->size = secs->size;
+ 	encl->ssaframesize = secs->ssa_frame_size;
+@@ -739,6 +741,11 @@ static long sgx_ioc_enclave_init(struct sgx_encl *encl, void __user *arg)
+ 	void *token;
+ 	int ret;
+ 
++	if (!boot_cpu_has(X86_FEATURE_SGX_LC)) {
++		pr_info("The public key MSRs are not writable.\n");
++		return -ENODEV;
++	}
++
+ 	if ((atomic_read(&encl->flags) & SGX_ENCL_INITIALIZED) ||
+ 	    !(atomic_read(&encl->flags) & SGX_ENCL_CREATED))
+ 		return -EINVAL;
+@@ -781,6 +788,59 @@ out:
+ 	return ret;
+ }
+ 
++static long sgx_ioc_enclave_init_with_token(struct sgx_encl *encl, void __user *arg)
++{
++	struct sgx_sigstruct *sigstruct;
++	struct sgx_enclave_init_with_token einit;
++	struct page *initp_page;
++	void *token;
++	int ret;
++
++	if (!(atomic_read(&encl->flags) & SGX_ENCL_CREATED))
++		return -EINVAL;
++
++	if (copy_from_user(&einit, arg, sizeof(einit)))
++		return -EFAULT;
++
++	initp_page = alloc_page(GFP_KERNEL);
++	if (!initp_page)
++		return -ENOMEM;
++
++	sigstruct = kmap(initp_page);
++	token = (void *)((unsigned long)sigstruct + PAGE_SIZE / 2);
++
++	if (copy_from_user(token, (void __user *)einit.einittoken,
++			   SGX_LAUNCH_TOKEN_SIZE)) {
++		ret = -EFAULT;
++		goto out;
++	}
++
++	if (copy_from_user(sigstruct, (void __user *)einit.sigstruct,
++			   sizeof(*sigstruct))) {
++		ret = -EFAULT;
++		goto out;
++	}
++
++	/*
++	 * A legacy field used with Intel signed enclaves. These used to mean
++	 * regular and architectural enclaves. The CPU only accepts these values
++	 * but they do not have any other meaning.
++	 *
++	 * Thus, reject any other values.
++	 */
++	if (sigstruct->header.vendor != 0x0000 &&
++	    sigstruct->header.vendor != 0x8086) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ret = sgx_encl_init(encl, sigstruct, token);
++out:
++	kunmap(initp_page);
++	__free_page(initp_page);
++	return ret;
++}
++
+ /**
+  * sgx_ioc_enclave_set_attribute - handler for %SGX_IOC_ENCLAVE_SET_ATTRIBUTE
+  * @filep:	open file to /dev/sgx
+@@ -850,6 +910,9 @@ long sgx_ioctl(struct file *filep, unsigned int cmd, unsigned long arg)
+ 	case SGX_IOC_ENCLAVE_INIT:
+ 		ret = sgx_ioc_enclave_init(encl, (void __user *)arg);
+ 		break;
++	case SGX_IOC_ENCLAVE_INIT_WITH_TOKEN:
++		ret = sgx_ioc_enclave_init_with_token(encl, (void __user *)arg);
++		break;
+ 	case SGX_IOC_ENCLAVE_SET_ATTRIBUTE:
+ 		ret = sgx_ioc_enclave_set_attribute(encl, (void __user *)arg);
+ 		break;
+diff --git a/driver/linux/main.c b/driver/linux/main.c
+index aae3eba..92b577e 100644
+--- a/driver/linux/main.c
++++ b/driver/linux/main.c
+@@ -549,7 +549,6 @@ static bool detect_sgx(struct cpuinfo_x86 *c)
+ 
+     if (!(fc & FEAT_CTL_SGX_LC_ENABLED)) {
+         pr_info_once("sgx: The launch control MSRs are not writable\n");
+-        return false;
+     }
+ 
+     return true;
+-- 
+1.8.3.1
+

--- a/patch/no-sgx-flc/README.md
+++ b/patch/no-sgx-flc/README.md
@@ -1,7 +1,9 @@
 There are still non-trivial number of systems without FLC support.
 
 # Prerequisite
-- Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/haitaohuang/linux-sgx-2/tree/v33).
+- Choose either SGX DCAP or in-tree Linux driver to use.
+  * Apply the patch `0001-SGX-DCAP-Linux-Driver-Support-SGX1-machine-even-without-FLC-s.patch` to [SGX DCAP Linux driver](https://github.com/intel/SGXDataCenterAttestationPrimitives).
+- * Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/haitaohuang/linux-sgx-2/tree/v33).
 - Apply the patch `0001-psw-Support-SGX1-machine-with-SGX-in-tree-driver.patch` to [Intel SGX SDK 2.10](https://github.com/intel/linux-sgx/tree/sgx_2.10) or higher.
 
 # Validation

--- a/patch/no-sgx-flc/README.md
+++ b/patch/no-sgx-flc/README.md
@@ -1,7 +1,7 @@
 There are still non-trivial number of systems without FLC support.
 
 # Prerequisite
-- Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/jsakkine-intel/linux-sgx/tree/v33).
+- Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/haitaohuang/linux-sgx-2/tree/v33).
 - Apply the patch `0001-psw-Support-SGX1-machine-with-SGX-in-tree-driver.patch` to [Intel SGX SDK 2.10](https://github.com/intel/linux-sgx/tree/sgx_2.10) or higher.
 
 # Validation


### PR DESCRIPTION
1. Enable non-trivial SGX 1 machines with SGX DCAP driver.
2. Update the URL of the v33 in-tree Linux SGX driver.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>