### PR TITLE
patch/no-sgx-flc: note `no-sgx-flc` feature is not working with `Occlum` in README.md

### DIFF
--- a/patch/no-sgx-flc/README.md
+++ b/patch/no-sgx-flc/README.md
@@ -3,8 +3,9 @@ There are still non-trivial number of systems without FLC support.
 # Prerequisite
 - Choose either SGX DCAP or in-tree Linux driver to use.
   * Apply the patch `0001-SGX-DCAP-Linux-Driver-Support-SGX1-machine-even-without-FLC-s.patch` to [SGX DCAP Linux driver](https://github.com/intel/SGXDataCenterAttestationPrimitives).
-- * Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/haitaohuang/linux-sgx-2/tree/v33).
+  * Apply the patch `0001-sgx-Support-SGX1-machine-even-without-FLC-support.patch` to [v33 SGX in-tree driver](https://github.com/haitaohuang/linux-sgx-2/tree/v33).
 - Apply the patch `0001-psw-Support-SGX1-machine-with-SGX-in-tree-driver.patch` to [Intel SGX SDK 2.10](https://github.com/intel/linux-sgx/tree/sgx_2.10) or higher.
+  * Note: [Occlum](https://github.com/occlum/occlum) has a modified Intel SGX SDK repository named [`occlum/linux-sgx`](https://github.com/occlum/linux-sgx). So if not applying the patch `0001-psw-Support-SGX1-machine-with-SGX-in-tree-driver.patch` to `occlum/linux-sgx`, `Occlum` can't work with the `DCAP` or `in-tree` SGX Linux driver.
 
 # Validation
 - Successfully run [sgx-tools](https://github.com/alibaba/inclavare-containers/tree/master/sgx-tools#test) to generate a launch token.


### PR DESCRIPTION
Fixes #216

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>