### PR TITLE
rune: delete read only attribute of rootfs in `config.json` file generated by command `rune spec`

### DIFF
--- a/rune/spec.go
+++ b/rune/spec.go
@@ -83,6 +83,10 @@ created by an unprivileged user.
 		}
 		spec := specconv.Example()
 		spec.Process.Cwd = "/var/run/rune"
+		spec.Root = &specs.Root{
+			Path:     "rootfs",
+			Readonly: false,
+		}
 		spec.Hostname = "rune"
 		spec.Annotations = map[string]string{
 			"enclave.type":         "intelSgx",


### PR DESCRIPTION
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>