### PR TITLE
rune: install rune to /usr/local/bin instead of /usr/local/sbin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ After build Inclavare Containers on your system, you can use the following comma
 sudo make install
 ```
 
-`rune` will be installed to `/usr/local/sbin/rune` on your system. `shim-rune` will be installed to `/usr/local/bin/containerd-shim-rune-v2`. `sgx-tools` will be installed to `/usr/local/bin/sgx-tools`.
+`rune` will be installed to `/usr/local/bin/rune` on your system. `shim-rune` will be installed to `/usr/local/bin/containerd-shim-rune-v2`. `sgx-tools` will be installed to `/usr/local/bin/sgx-tools`.
 
 If you don't want to build and install Inclavare Containers from latest source code. We also provide RPM/DEB repository to help you install Inclavare Containers quickly. Please see the [steps about how to configure repository](https://github.com/alibaba/inclavare-containers/blob/master/docs/create_a_confidential_computing_kubernetes_cluster_with_inclavare_containers.md#1-add-inclavare-containers-repository) firstly. Then you can run the following command to install Inclavare Containers on your system.
 
@@ -115,7 +115,7 @@ Add the assocated configurations for `rune` in dockerd config file, e.g, `/etc/d
 }
 ```
 
-then restart dockerd on your system. If you install Inclavare Containers based on source code, please specify the path of rune as `/usr/local/sbin/rune` instead.
+then restart dockerd on your system. If you install Inclavare Containers based on source code, please specify the path of rune as `/usr/local/bin/rune` instead.
 
 You can check whether `rune` is correctly enabled or not with:
 

--- a/rune/Makefile
+++ b/rune/Makefile
@@ -1,7 +1,7 @@
 GO := go
 
 PREFIX := $(DESTDIR)/usr/local
-BINDIR := $(PREFIX)/sbin
+BINDIR := $(PREFIX)/bin
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")

--- a/rune/README.md
+++ b/rune/README.md
@@ -23,7 +23,7 @@ make
 sudo make install
 ```
 
-`rune` will be installed to `/usr/local/sbin/rune` on your system.
+`rune` will be installed to `/usr/local/bin/rune` on your system.
 
 # Using rune
 

--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -49,7 +49,7 @@ Add the `rune` OCI runtime configuration in dockerd config file, e.g, `/etc/dock
 {
 	"runtimes": {
 		"rune": {
-			"path": "/usr/local/sbin/rune",
+			"path": "/usr/local/bin/rune",
 			"runtimeArgs": []
 		}
 	}


### PR DESCRIPTION
Fixes: #195

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>