### PR TITLE
rune/libenclave/pal: update the relationship between rune and the pal_destroy API

### DIFF
--- a/rune/libenclave/internal/runtime/pal/spec.md
+++ b/rune/libenclave/internal/runtime/pal/spec.md
@@ -26,6 +26,7 @@ The PAL API will evolve. You can submit proposal for the extension of PAL API. W
 |	   | pal_init |  pal_init |
 |      |  pal_exec | pal_create_process |
 |	  |                | pal_exec |
+|      | pal_destroy | pal_destroy | 
 | exec | pal_exec  | pal_create_process |
 |      |           | pal_exec           | 
 | delete | pal_destroy | pal_destroy |


### PR DESCRIPTION
rune run subcommand calls the pal_destroy API while rune create and start can't
call the pal_destroy API because they run in the detach mode.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>