### PR TITLE
skeleton: fix a typo issue.

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v1.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v1.c
@@ -19,5 +19,5 @@ int pal_exec(char *path, char *argv[], pal_stdio_fds *stdio, int *exit_code)
 
 int pal_destroy(void)
 {
-	return __pal_destory();
+	return __pal_destroy();
 }

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v2.c
@@ -35,5 +35,5 @@ int pal_kill(int pid, int sig)
 
 int pal_destroy(void)
 {
-	return __pal_destory();
+	return __pal_destroy();
 }

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v3.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton-v3.c
@@ -71,5 +71,5 @@ int pal_kill(int pid, int sig)
 
 int pal_destroy(void)
 {
-	return __pal_destory();
+	return __pal_destroy();
 }

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -641,7 +641,7 @@ int __pal_kill(int pid, int sig)
 	return 0;
 }
 
-int __pal_destory(void)
+int __pal_destroy(void)
 {
 	FILE *fp = fdopen(pal_stdio.stderr, "w");
 	if (!fp)

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -55,7 +55,7 @@ int wait4child(pal_exec_args *attr);
 int __pal_get_local_report(void *targetinfo, int targetinfo_len,
 			   void *report, int *report_len);
 int __pal_kill(int pid, int sig);
-int __pal_destory(void);
+int __pal_destroy(void);
 
 /* *INDENT-OFF* */
 #endif


### PR DESCRIPTION
pal_destroy API is not consistent with __pal_destory.It will fix this issue.

Signed-off-by: Liang Yang <liang3.yang@intel.com>