### PR TITLE
Integrate WAMR as an enclave runtime for rune

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The major components of Inclavare Containers are:
 - enclave runtime  
   The backend of `rune` is a component called enclave runtime, which is responsible for loading and running trusted and protected applications inside enclaves. The interface between `rune` and enclave runtime is [Enclave Runtime PAL API](rune/libenclave/internal/runtime/pal/spec.md), which allows invoking enclave runtime through well-defined functions. The softwares for confidential computing may benefit from this interface to interact with cloud-native ecosystem.  
   
-  One typical class of enclave runtime implementations is based on Library OSes. Currently, the recommended enclave runtime interacting with `rune` is [Occlum](https://github.com/occlum/occlum), a memory-safe, multi-process Library OS for Intel SGX.  
+  One typical class of enclave runtime implementations is based on Library OSes. Currently, the recommended enclave runtime interacting with `rune` is [Occlum](https://github.com/occlum/occlum), a memory-safe, multi-process Library OS for Intel SGX.  And another typical class of enclave runtime is [WebAssembly Micro Runtime (WAMR)](https://github.com/bytecodealliance/wasm-micro-runtime) with Intel SGX, a standalone WebAssembly (WASM) runtime with a small footprint, including a VM core, an application framework and a dynamic management for WASM applications.
   
   In addition, you can write your own enclave runtime with any programming language and SDK (e.g, [Intel SGX SDK](https://github.com/intel/linux-sgx)) you prefer as long as it implements Enclave Runtime PAL API.
 
@@ -88,7 +88,7 @@ If you don't want to build and install Inclavare Containers from latest source c
 
 ```shell
 sudo yum install rune shim-rune sgx-tools
-``` 
+```
 
 - On Ubuntu 18.04 server
 
@@ -149,3 +149,7 @@ Please refer to [this guide](docs/develop_and_deploy_hello_world_application_in_
 ## Occlum LibOS
 
 Please refer to [this guide](docs/Running_Occlum_with_Docker_and_OCI_Runtime_rune.md) to run [Occlum](https://github.com/occlum/occlum) with `rune`.
+
+## WebAssembly Micro Runtime (WAMR)
+
+Please refer to [this guide](https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/product-mini/platforms/linux-sgx/enclave-sample/App#wamr-as-an-enclave-runtime-for-rune) to run [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) with `rune`.

--- a/docs/design/terminology.md
+++ b/docs/design/terminology.md
@@ -11,7 +11,7 @@ This API defines the function calls beutween Enclave Runtime PAL and init-runele
 The implementer of Enclave Runtime PAL API, on behalf of Enclave Runtime.
 
 # Enclave Runtime
-The implementer of enclave. Occlum and Graphene-SGX are all the so-called Enclave Runtime.
+The implementer of enclave. Occlum, Graphene-SGX and WAMR (WebAssembly Micro Runtime) are all the so-called Enclave Runtime.
 
 # Enclave Application
 The actual running entity inside Enclave Runtime.

--- a/rune/README.md
+++ b/rune/README.md
@@ -49,6 +49,12 @@ Please refer to [this tutorial](libenclave/internal/runtime/pal/skeleton/README.
 
 Please refer to [this tutorial](../docs/Running_Occlum_with_Docker_and_OCI_Runtime_rune.md) for more details.
 
+### WebAssembly Micro Runtime (WAMR)
+
+[WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) is a standalone WebAssembly (WASM) runtime with a small footprint, including a VM core, an application framework and a dynamic management for WASM applications.
+
+Please refer to [this tutorial](https://github.com/bytecodealliance/wasm-micro-runtime/tree/main/product-mini/platforms/linux-sgx/enclave-sample/App#wamr-as-an-enclave-runtime-for-rune) for more details.
+
 # Developement
 
 ## Running OCI bundle
@@ -117,4 +123,5 @@ sudo rune run ${Occlum_application_container_name}
 ```
 
 # Credits
+
 Some codes in rune have been borrowed from [runc](https://github.com/opencontainers/runc) project.

--- a/rune/docs/pal_programming_guide.md
+++ b/rune/docs/pal_programming_guide.md
@@ -1,7 +1,7 @@
 # Enclave Runtime Programming Guide v2
 
 # 1. Background
-The enclave runtime currently supported by runE is occlum. In order to facilitate other libos programs to run in runE, a set of enclave rumtime API interfaces is defined. Libos only needs to support this set of API interfaces to run as an enclave runtime in runE.
+The enclave runtime currently supported by runE are occlum and WAMR (WebAssembly Micro Runtime). In order to facilitate other libos programs to run in runE, a set of enclave rumtime API interfaces is defined. Libos only needs to support this set of API interfaces to run as an enclave runtime in runE.
 
 # 2. enclave runtime in runE
 runE enclave runtime is bounded by the enclave runtime pal API layer, below the API layer is runE, above the API layer is the enclave runtime, and the operating mode is libos.


### PR DESCRIPTION
The PAL interface is implemented in WAMR.
This patch provides brief guides for uses and developers to run
WASM app in WAMR with SGX by rune.

Signed-off-by: Le Yao <le.yao@intel.com>