### PR TITLE
rune: remove "skeleton" from args returned by rune spec

### DIFF
--- a/rune/spec.go
+++ b/rune/spec.go
@@ -90,7 +90,7 @@ created by an unprivileged user.
 		spec.Hostname = "rune"
 		spec.Annotations = map[string]string{
 			"enclave.type":         "intelSgx",
-			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton-v1.so",
+			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton-v2.so",
 			"enclave.runtime.args": "debug",
 		}
 

--- a/rune/spec.go
+++ b/rune/spec.go
@@ -91,7 +91,7 @@ created by an unprivileged user.
 		spec.Annotations = map[string]string{
 			"enclave.type":         "intelSgx",
 			"enclave.runtime.path": "/var/run/rune/liberpal-skeleton-v1.so",
-			"enclave.runtime.args": "skeleton,debug",
+			"enclave.runtime.args": "debug",
 		}
 
 		spec.Mounts = append(spec.Mounts, *createLibenclaveMount())


### PR DESCRIPTION
Fixes: #250

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>