### PR TITLE
rune/libenclave/skeleton: use enclave-size parameter and -s option instead of memory-size and -m

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -74,14 +74,14 @@ where:
 - @ENCLAVE_PATH: specify the path to enclave runtime to launch.
 - @ENCLAVE_ARGS: specify the specific arguments to enclave runtime, seperated by the comma.
 
-In order to measure the overhead of enclave launch time, we add a `memory-size` parameter for skeleton and `-m` option for `sgxsign` tool.
+In order to measure the overhead of enclave launch time, we add the `enclave-size` parameter for skeleton and `-s` option for `sgxsign` tool.
 
-`memory-size` parameter and `-m` option should be the same value to specify the memory size of enclave to launch. For example, if `memory-size` is `40960`, skeleton will launch enclave with `40960` bytes of memory size.
+The `enclave-size` parameter and `-s` option should be the same value to specify the memory size of the enclave to launch. For example, if `enclave-size` is `40960`, skeleton will launch an enclave with `40960` bytes of memory size.
 
-If you want to launch enclave with a specific value, you should add `-m ${SIZE}` option with `sgxsign` tool to specify the memory size of enclave to launch. In addition, You must specify `memory-size` in `ENCLAVE_RUNTIME_ARGS` with the same number.
+If you want to launch an enclave with a specific value, you should add `-s ${SIZE}` option with `sgxsign` tool to specify the memory size of the enclave to launch. In addition, You must specify `enclave-size` in `ENCLAVE_RUNTIME_ARGS` with the same number.
 
 ```shell
-ENCLAVE_RUNTIME_ARGS="debug,memory-size=${SIZE}"
+ENCLAVE_RUNTIME_ARGS="debug,enclave-size=${SIZE}"
 ```
 
 ---
@@ -127,7 +127,7 @@ where:
 - @enclave.runtime.path: specify the path to enclave runtime to launch.
 - @enclave.runtime.args: specify the specific arguments to enclave runtime, seperated by the comma.
 
-Note that if you add `-m ${SIZE}` when signing your enclave image with `sgxsign` tool. You must specify `memory-size=${SIZE}` in "enclave.runtime.args`.
+Note that if you add `-s ${SIZE}` when signing your enclave image with `sgxsign` tool. You must specify `enclave-size=${SIZE}` in "enclave.runtime.args`.
 
 ## Run skeleton
 Assuming you have an OCI bundle from the previous step you can execute the container in this way.

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -447,7 +447,7 @@ static void check_opts(const char *opt)
 		no_sgx_flc = true;
 	else if (!strcmp(opt, "debug"))
 		debugging = true;
-	else if (strstr(opt, "memory-size")) {
+	else if (strstr(opt, "enclave-size")) {
 		max_enclave_size = atoi(strchr(opt, '=') + 1);
 	}
 }

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
@@ -485,10 +485,10 @@ int main(int argc, char **argv)
 	RSA *sign_key;
 	bool enclave_debug = true;
 	uint64_t max_enclave_size = 0;
-	char *const short_options = "pm:";
+	char *const short_options = "ps:";
 	struct option long_options[] = {
 		{"product", no_argument, NULL, 'p'},
-		{"memory-size", required_argument, NULL, 'm'},
+		{"enclave-size", required_argument, NULL, 's'},
 		{0, 0, 0, 0}
 	};
 
@@ -501,7 +501,7 @@ int main(int argc, char **argv)
 		case 'p':
 			enclave_debug = false;
 			break;
-		case 'm':
+		case 's':
 			max_enclave_size = atoi(optarg);
 		case -1:
 			break;


### PR DESCRIPTION
 Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>