### PR TITLE
shim-rune: add the client signature for shim-rune and update spec files of epm.

### DIFF
--- a/epm/dist/deb/debian/postrm
+++ b/epm/dist/deb/debian/postrm
@@ -2,3 +2,5 @@
 
 EPM_CONFIG_DIR=/etc/epm
 rm -f $EPM_CONFIG_DIR/config.toml
+systemctl disable epm
+systemctl stop epm

--- a/epm/dist/deb/debian/rules
+++ b/epm/dist/deb/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 BUILD_ROOT := $(CURDIR)/debian/epm
-BUILD_DIR := /usr/local/bin
+BUILD_DIR := /usr/bin
 LICENSE := /usr/share/licenses/epm
 
 %:

--- a/epm/dist/rpm/epm.spec
+++ b/epm/dist/rpm/epm.spec
@@ -90,6 +90,8 @@ systemctl enable epm
 systemctl start epm
 %postun
 rm -f %{EPM_CONFIG_DIR}/config.toml
+systemctl disable epm
+systemctl stop epm
 
 %files
 %{_defaultlicensedir}/%{name}/LICENSE

--- a/shim/README-zh_CN.md
+++ b/shim/README-zh_CN.md
@@ -42,11 +42,18 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 
 [containerd]
     socket = "/run/containerd/containerd.sock"
-
+# The epm section is optional. 
+# If the epm serivce is deployed, you can configure a appropriate unix socket address in "epm.socket" field, 
+# otherwise just delete the epm section.
+[epm]
+    socket = "/run/epm/epm.sock"
 [enclave_runtime]
-
+    # The signature_method represents the signature method for enclave.
+    # It can be "server" or "client", the default value is "server"
+    signature_method = "server"
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"
+        enclave_libos_path = "/opt/occlum/build/lib/libocclum-libos.so"
     [enclave_runtime.graphene]
 
 ```

--- a/shim/README.md
+++ b/shim/README.md
@@ -42,11 +42,18 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 
 [containerd]
     socket = "/run/containerd/containerd.sock"
-
+# The epm section is optional. 
+# If the epm serivce is deployed, you can configure a appropriate unix socket address in "epm.socket" field, 
+# otherwise just delete the epm section.
+[epm]
+    socket = "/run/epm/epm.sock"
 [enclave_runtime]
-
+    # The signature_method represents the signature method for enclave.
+    # It can be "server" or "client", the default value is "server"
+    signature_method = "server"
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"
+        enclave_libos_path = "/opt/occlum/build/lib/libocclum-libos.so"
     [enclave_runtime.graphene]
 
 ```

--- a/shim/config/config.go
+++ b/shim/config/config.go
@@ -22,8 +22,9 @@ type Graphene struct {
 }
 
 type EnclaveRuntime struct {
-	Occlum   Occlum   `toml:"occlum"`
-	Graphene Graphene `toml:"graphene"`
+	SignatureMethod string   `toml:"signature_method"`
+	Occlum          Occlum   `toml:"occlum"`
+	Graphene        Graphene `toml:"graphene"`
 }
 
 type Config struct {

--- a/shim/runtime/carrier/occlum/occlum.go
+++ b/shim/runtime/carrier/occlum/occlum.go
@@ -225,9 +225,9 @@ func (o *occlum) GenerateSigningMaterial(req *task.CreateTaskRequest, args *carr
 	dataDir := filepath.Join(req.Bundle, dataDirName)
 	signingMaterial = filepath.Join(rootfsDir, o.workDirectory, "enclave_sig.dat")
 	args.Config = filepath.Join(rootfsDir, o.workDirectory, "build/Enclave.xml")
-	if o.bundleCacheConfig.cacheLevel == types.BundleCache1PoolType {
-		return
-	}
+	//if o.bundleCacheConfig.cacheLevel == types.BundleCache1PoolType {
+	//	return
+	//}
 	cmdArgs := []string{
 		filepath.Join(dataDir, carrierScriptFileName),
 		"--action", "generateSigningMaterial",

--- a/shim/runtime/v2/rune/constants/constants.go
+++ b/shim/runtime/v2/rune/constants/constants.go
@@ -12,3 +12,8 @@ const (
 	EnvKeyImageDigest        = "IMAGE_DIGEST"
 	RuneDefaultWorkDirectory = "/run/rune"
 )
+
+const (
+	SignatureMethodServer = "server"
+	SignatureMethodClient = "client"
+)

--- a/shim/runtime/v2/rune/v2/rune.go
+++ b/shim/runtime/v2/rune/v2/rune.go
@@ -47,6 +47,14 @@ func (s *service) carrierMain(req *taskAPI.CreateTaskRequest) (carrier.Carrier, 
 		return emptycarr, nil
 	}
 
+	var cfg shim_config.Config
+	if _, err := toml.DecodeFile(constants.ConfigurationPath, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg.EnclaveRuntime.SignatureMethod == constants.SignatureMethodClient {
+		return carr, nil
+	}
+
 	switch carrierKind {
 	case rune.Occlum:
 		if carr, err = occlum.NewOcclumCarrier(s.context, req.Bundle); err != nil {


### PR DESCRIPTION
1. add a new configuration field `enclave_runtime.signature_method` for shim-rune, which represents the signature method for enclave.
2. update spec files of epm.