### PR TITLE
epm: set epm package priority in ubuntu repository

### DIFF
--- a/docs/create_a_confidential_computing_kubernetes_cluster_with_inclavare_containers.md
+++ b/docs/create_a_confidential_computing_kubernetes_cluster_with_inclavare_containers.md
@@ -45,6 +45,13 @@ echo 'deb [arch=amd64] https://mirrors.openanolis.org/inclavare-containers/deb-r
 # add the key to the list of trusted keys used by the apt to authenticate packages
 wget -qO - https://mirrors.openanolis.org/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | sudo apt-key add -
 
+# set a higher priority to epm to avoid conflicts with another epm package which reside in `mirrors.cloud.aliyuncs.com`
+cat << EOF >/etc/apt/preferences.d/inclavare-containers
+Package: epm
+Pin: origin mirrors.openanolis.org
+Pin-Priority: 1000
+EOF
+
 # update the apt
 sudo apt-get update
 ```

--- a/epm/dist/deb/debian/postinst
+++ b/epm/dist/deb/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-EPM_CONFIG_DIR /etc/epm
+EPM_CONFIG_DIR=/etc/epm
 
 mkdir -p $EPM_CONFIG_DIR
 cat << EOF > $EPM_CONFIG_DIR/config.toml


### PR DESCRIPTION
set a higher priority to epm to avoid conflicts with another epm package which reside in `mirrors.cloud.aliyuncs.com` repository.