### PR TITLE
rune/libenclave/skeleton: fix a memory leak issue

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -523,9 +523,11 @@ int __pal_init_v1(pal_attr_v1_t *attr)
 	ret = SGX_ENTER_1_ARG(ECALL_INIT, (void *) secs.base, result);
 	if (ret) {
 		fprintf(stderr, "failed to initialize enclave\n");
+		free(result);
 		return ret;
 	}
 	puts(result);
+	free(result);
 
 	initialized = true;
 


### PR DESCRIPTION
Signed-off-by: Liang Yang <liang3.yang@intel.com>