### PR TITLE
rune/libenclave/skeleton: clean kvmtool when cleaning skeleton

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -93,5 +93,6 @@ EXTRA_CLEAN := \
 
 clean:
 	rm -f ${EXTRA_CLEAN}
+	$(MAKE) -C ../kvmtool clean
 
 .PHONY: clean all


### PR DESCRIPTION
Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>