### PR TITLE
rune/skeleton: Fix compilation and dynamic link failure

### DIFF
--- a/rune/libenclave/internal/runtime/pal/kvmtool/libvmm.c
+++ b/rune/libenclave/internal/runtime/pal/kvmtool/libvmm.c
@@ -100,23 +100,24 @@ int libvmm_vm_init(struct kvm *vm)
     static char cmdline[BUFSIZ];
     int ret;
 
-    strncat(cmdline, KERNEL_COMMANDLINE_COMMON, sizeof(cmdline));
+    strncat(cmdline, KERNEL_COMMANDLINE_COMMON, sizeof(cmdline) - 1);
     if (vm->cfg.custom_rootfs) {
         strncat(cmdline,
                     " rw"
                     " rootflags=trans=virtio,version=9p2000.L,cache=loose"
                     " rootfstype=9p",
-                    sizeof(cmdline));
+                    sizeof(cmdline) - 1);
     } else if (vm->cfg.initrd_filename) {
-        strncat(cmdline, " root=/dev/vda rw", sizeof(cmdline));
+        strncat(cmdline, " root=/dev/vda rw", sizeof(cmdline) - 1);
     } else {
         return -EINVAL;
     }
 
     if (vm->cfg.real_init) {
-        strncat(cmdline, " init=", sizeof(cmdline));
-        strncat(cmdline, vm->cfg.real_init, sizeof(cmdline));
+        strncat(cmdline, " init=", sizeof(cmdline) - 1);
+        strncat(cmdline, vm->cfg.real_init, sizeof(cmdline) - 1);
     }
+    cmdline[sizeof(cmdline) - 1] = '\0';
 
     vm->cfg.real_cmdline = cmdline;
 

--- a/rune/libenclave/internal/runtime/pal/loader.go
+++ b/rune/libenclave/internal/runtime/pal/loader.go
@@ -24,7 +24,7 @@ var fptr_pal_get_local_report unsafe.Pointer
 func Loadbinary(path string) {
 	dl := C.dlopen(C.CString(path), C.RTLD_NOW)
 	if dl == nil {
-		logrus.Fatal("failed to load %s, dlerror: %s", path, C.GoString(C.dlerror()))
+		logrus.Fatalf("failed to load %s, dlerror: %s", path, C.GoString(C.dlerror()))
 	}
 
 	fptr_pal_get_version = C.dlsym(dl, C.CString("pal_get_version"))

--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -20,8 +20,8 @@ libvmm:
 
 ../kvmtool/libvmm.a: libvmm
 
-$(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v1.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o
-	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c
+$(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v1.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o ../kvmtool/libvmm.a
+	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil
 
 $(OUTPUT)/liberpal-skeleton-v1.o: liberpal-skeleton-v1.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
@@ -35,8 +35,8 @@ $(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
 $(OUTPUT)/liberpal-skeleton.o: liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
-$(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o
-	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c
+$(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o ../kvmtool/libvmm.a
+	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil
 
 $(OUTPUT)/liberpal-skeleton-v3.o: liberpal-skeleton-v3.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@


### PR DESCRIPTION
Fix the skeleton compilation warning and the problem that dlopen()
fails to load liberpal-skeleton.so v1 and v3.

Fixes: #290

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>