### PR TITLE
rune/skeleton: fix liberpal-skeleton-v3 crash

### DIFF
--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -3,16 +3,14 @@ package enclave_runtime_pal // import "github.com/inclavare-containers/rune/libe
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/alibaba/inclavare-containers/epm/pkg/epm-api/v1alpha1"
 	"github.com/go-restruct/restruct"
 	"github.com/inclavare-containers/rune/libenclave/attestation"
 	_ "github.com/inclavare-containers/rune/libenclave/attestation/sgx/ias"
 	"github.com/inclavare-containers/rune/libenclave/epm"
 	"github.com/inclavare-containers/rune/libenclave/intelsgx"
-	"strings"
-
 	"log"
 	"os"
+	"strings"
 )
 
 const (
@@ -21,42 +19,48 @@ const (
 )
 
 func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {
-	var enclaveinfo *v1alpha1.Enclave
-	var err error
-	var addr uint64 = 0
-	var fd int = -1
-
-	pal.enclavePoolID = InvalidEpmID
+	/* Assuming v1 is used */
 	api := &enclaveRuntimePalApiV1{}
 	ver := api.get_version()
 	if ver > palApiVersion {
 		return fmt.Errorf("unsupported pal api version %d", ver)
 	}
-	pal.version = ver
 
-	/* FIXME: If EPM provides epm existence detect API, the static check will be substituted. Enclave pool
-	 * will be distinguished by pal.Type and Pal.subType once subType can be provided by new PAL interface
-	 * in future.
+	pal.version = ver
+	pal.enclavePoolID = InvalidEpmID
+
+	if ver < 3 {
+		return api.init(args, logLevel)
+	}
+
+	/* FIXME: If EPM provides epm existence detect API, the static
+	 * check will be substituted. Enclave pool will be distinguished
+	 * by pal.Type and Pal.subType once subType can be provided by new
+	 * PAL interface in future.
 	 */
+	var addr uint64 = 0
+	var fd int = -1
+
+	apiV3 := &enclaveRuntimePalApiV3{}
+
 	if strings.Contains(args, "epm") {
-		/* enclaveinfo.Layout retrieves from /proc/pid/mmaps, in file mmaps /dev/sgx/enclave mmaping
-		 * address is sorted from low address to high one. So layout[0].Addr will be minimum.
+		/* enclaveinfo.Layout retrieves from /proc/pid/mmaps, in file
+		 * mmaps /dev/sgx/enclave mmaping address is sorted from low
+		 * address to high one. So layout[0].Addr will be minimum.
 		 */
-		enclaveinfo = epm.GetEnclave()
+		enclaveinfo := epm.GetEnclave()
 		if enclaveinfo != nil {
 			epm.SgxMmap(*enclaveinfo)
 			addr = enclaveinfo.Layout[0].Addr
 			fd = int(enclaveinfo.Fd)
 		}
-		api := &enclaveRuntimePalApiV3{}
-		err = api.init(args, logLevel, fd, addr)
-		if err == nil {
-			ID := epm.SavePreCache()
-			pal.enclavePoolID = ID
-		}
-		return err
 	}
-	return api.init(args, logLevel)
+
+	err := apiV3.init(args, logLevel, fd, addr)
+	if err == nil && strings.Contains(args, "epm") {
+		pal.enclavePoolID = epm.SavePreCache()
+	}
+	return err
 }
 
 func (pal *enclaveRuntimePal) Exec(cmd []string, envp []string, stdio [3]*os.File) (int32, error) {

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -28,14 +28,6 @@
 #define SGX_REG_PAGE_FLAGS \
 	(SGX_SECINFO_REG | SGX_SECINFO_R | SGX_SECINFO_W | SGX_SECINFO_X)
 
-struct enclave_info {
-	uint64_t mmap_base;
-	uint64_t mmap_size;
-	uint64_t encl_base;
-	uint64_t encl_size;
-	uint64_t encl_offset;
-};
-
 struct sgx_secs secs;
 static pal_stdio_fds pal_stdio;
 bool initialized = false;

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.h
@@ -47,7 +47,15 @@ typedef struct {
 	int *exit_value;
 } pal_exec_args;
 
-int encl_init();
+struct enclave_info {
+	uint64_t mmap_base;
+	uint64_t mmap_size;
+	uint64_t encl_base;
+	uint64_t encl_size;
+	uint64_t encl_offset;
+};
+
+int encl_init(struct enclave_info *encl_info);
 void parse_args(const char *args);
 /* *INDENT-OFF* */
 int __pal_init_v1(pal_attr_v1_t *attr);


### PR DESCRIPTION
EPM feature is only supported by newer than PAL v3. However,
current implementation deems a PAL without EPM configured as
PAL v1. This causes a PAL v3 without EPM configured calls
PAL v1 init().

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>