### PR TITLE
rune/libenclave/skeleton: fix an issue about undefined symbol

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/Makefile
+++ b/rune/libenclave/internal/runtime/pal/skeleton/Makefile
@@ -21,13 +21,13 @@ libvmm:
 ../kvmtool/libvmm.a: libvmm
 
 $(OUTPUT)/liberpal-skeleton-v1.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v1.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o ../kvmtool/libvmm.a
-	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil
+	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil -lbfd
 
 $(OUTPUT)/liberpal-skeleton-v1.o: liberpal-skeleton-v1.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/liberpal-skeleton-v2.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v2.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o ../kvmtool/libvmm.a
-	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil
+	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil -lbfd
 
 $(OUTPUT)/liberpal-skeleton-v2.o: liberpal-skeleton-v2.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
@@ -36,7 +36,7 @@ $(OUTPUT)/liberpal-skeleton.o: liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@
 
 $(OUTPUT)/liberpal-skeleton-v3.so: $(OUTPUT)/sgx_call.o $(OUTPUT)/liberpal-skeleton-v3.o $(OUTPUT)/liberpal-skeleton.o $(OUTPUT)/sgxutils.o $(OUTPUT)/aesm.o $(OUTPUT)/aesm.pb-c.o ../kvmtool/libvmm.a
-	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil
+	$(CC) $(HOST_LDFLAGS) -o $@ $^ -lprotobuf-c -lutil -lbfd
 
 $(OUTPUT)/liberpal-skeleton-v3.o: liberpal-skeleton-v3.c liberpal-skeleton.c
 	$(CC) $(HOST_CFLAGS) -c $< -o $@


### PR DESCRIPTION
When running skeleton, an error will be showed as "dlerror: /usr/lib/
liberpal-skeleton-v3.so: undefined symbol: bfd_openr"

Signed-off-by: Liang Yang <liang3.yang@intel.com>