### PR TITLE
sgx-tools/dist: drop unnecessary dependency in rpm and deb

### DIFF
--- a/sgx-tools/dist/deb/debian/changelog
+++ b/sgx-tools/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+sgx-tools (0.5.0-2) unstable; urgency=low
+
+  * Drop unnecessary dependency.
+
+ -- Yilin Li <YiLin.Li@linux.alibaba.com>  Tue, 24 Nov 2020 14:11:40 +0000
+
 sgx-tools (0.5.0-1) unstable; urgency=low
 
   * Update to version 0.5.0.

--- a/sgx-tools/dist/deb/debian/control
+++ b/sgx-tools/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: sgx-tools
 Section: devel
 Priority: extra
 Maintainer: shirong <shirong@linux.alibaba.com>
-Build-Depends: debhelper (>=9), libprotobuf-dev (>=3), protobuf-compiler
+Build-Depends: debhelper (>=9)
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/sgx-tools/dist/deb/debian/rules
+++ b/sgx-tools/dist/deb/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 BUILD_ROOT := $(CURDIR)/debian/sgx-tools
 BUILD_DIR := /usr/local/bin
-PROTOBUF_VERSION := 1.3.5
 NAME := sgx-tools
 
 export GO111MODULE := on
@@ -10,7 +9,6 @@ export GO111MODULE := on
 	dh $@
 
 override_dh_auto_build:
-	go get github.com/golang/protobuf/protoc-gen-go@v$(PROTOBUF_VERSION)
 	make -C $(NAME)
 override_dh_auto_install:
 	install -d -p $(BUILD_ROOT)$(BUILD_DIR)

--- a/sgx-tools/dist/rpm/sgx-tools.spec
+++ b/sgx-tools/dist/rpm/sgx-tools.spec
@@ -1,7 +1,6 @@
-%define centos_base_release 1
+%define centos_base_release 2
 %define _debugsource_template %{nil}
 
-%global PROTOBUF_VERSION 1.3.5
 %global PROJECT inclavare-containers
 %global BIN_DIR /usr/local/bin
 
@@ -15,8 +14,6 @@ License: Apache License 2.0
 URL: https://github.com/alibaba/%{PROJECT}
 Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
 
-BuildRequires: protobuf >= 3
-BuildRequires: protobuf-compiler
 ExclusiveArch: x86_64
 
 %description
@@ -40,10 +37,8 @@ if [ $CURRENT_GO_VERSION -lt $NEED_GO_VERSION  ]; then
 fi
 
 export GOPATH=${RPM_BUILD_DIR}/%{PROJECT}-%{version}
-export GOPROXY="https://mirrors.aliyun.com/goproxy,direct"
 export PATH=$PATH:${GOPATH}/bin
 export GO111MODULE=on
-go get github.com/golang/protobuf/protoc-gen-go@v%{PROTOBUF_VERSION}
 pushd %{name}
 make
 popd
@@ -56,6 +51,9 @@ install -p -m 755 %{name}/%{name} %{buildroot}%{BIN_DIR}
 %{BIN_DIR}/%{name}
 
 %changelog
+* Tue Nov 24 2020 Yilin Li <YiLin.Li@linux.alibaba.com> - 0.5.0-2
+- Drop unnecessary dependency
+
 * Wed Oct 28 2020 Shirong Hao <shirong@linux.alibaba.com> - 0.5.0
 - Update to version 0.5.0
 


### PR DESCRIPTION
It's obvious that sgx-tools don't depend on protobuf.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>