### PR TITLE
epm: keep one channel between epm and container.

### DIFF
--- a/epm/pkg/epm/enclave-cache-pool/enclavepool/enclave-cache.go
+++ b/epm/pkg/epm/enclave-cache-pool/enclavepool/enclave-cache.go
@@ -13,6 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	EPMDir string = "/var/run/containerd"
+)
+
 var mut sync.Mutex
 var EnclavePoolStore map[int]*v1alpha1.Enclave
 var EnclavePoolPreStore map[string]*v1alpha1.Enclave
@@ -66,7 +70,7 @@ func (d *EnclaveCacheManager) GetPoolType() string {
 func SaveFd(cacheID string, err *error) {
 	var fd int
 
-	sockpath := filepath.Join("/var/run/sock/", cacheID)
+	sockpath := filepath.Join(EPMDir, cacheID)
 	fd, *err = utils.RecvFd(sockpath)
 	if fd != -1 {
 		EnclavePoolPreStore[cacheID].Fd = int64(fd)
@@ -105,7 +109,8 @@ func (d *EnclaveCacheManager) GetCache(ID string) (*v1alpha1.Cache, error) {
 	}
 
 	fd := enclaveinfo.Fd
-	err = utils.SendFd("/var/run/sock/"+cache.ID, int(fd))
+	sockpath := filepath.Join(EPMDir, cache.ID)
+	err = utils.SendFd(sockpath, int(fd))
 	if err != nil {
 		logrus.Warnf("send fd to epm client failure!", err)
 	}

--- a/rune/libenclave/epm/epm.go
+++ b/rune/libenclave/epm/epm.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	address = "/var/run/containerd/containerd.sock"
+	address     = "/var/run/containerd/containerd.sock"
+	sockpathdir = "/var/run/containerd"
 )
 
 func UnixConnect(addr string, t time.Duration) (net.Conn, error) {
@@ -44,7 +45,7 @@ func GetCache(ID string) *v1alpha1.Enclave {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	sockpath := filepath.Join("/var/run/sock", ID)
+	sockpath := filepath.Join(sockpathdir, ID)
 	go recvFd(sockpath, &fd)
 
 	Type := "enclave-cache-pool"
@@ -94,7 +95,7 @@ func SaveCache(ID string) {
 
 	c.SaveCache(ctx, &v1alpha1.SaveCacheRequest{Cache: &cache})
 
-	unisock := filepath.Join("/var/run/sock", ID)
+	unisock := filepath.Join(sockpathdir, ID)
 	sendFd(unisock, int(enclaveinfo.Fd))
 }
 

--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -165,15 +165,6 @@ Assuming you have an OCI bundle according to previous steps, please add config i
                 "rbind",
                 "rprivate"
         ]
-},
-{
-        "destination": "/var/run/sock/",
-        "type": "bind",
-        "source": "/var/run/sock/",
-        "options": [
-                "rbind",
-                "rprivate"
-        ]
 }
 
 "annotations": {


### PR DESCRIPTION
It's independent of epm module and container. we have to make a channel between
epm and container.

Fixes: #256
Signed-off-by: Liang Yang <liang3.yang@intel.com>