### PR TITLE
rune/libenclave: support new enclave type jailhouse

### DIFF
--- a/rune/libenclave/check.go
+++ b/rune/libenclave/check.go
@@ -142,6 +142,14 @@ func genEnclaveDeviceTemplate(etype string) []*configs.Device {
 				Major: 10,
 			},
 		}
+	case enclaveConfigs.EnclaveTypeJailHouse:
+		return []*configs.Device{
+			&configs.Device{
+				Type:  'c',
+				Path:  "/dev/jailhouse",
+				Major: 10,
+			},
+		}
 	default:
 		return nil
 	}
@@ -162,6 +170,8 @@ func genEnclavePathTemplate(etype string) []string {
 		return []string{"/dev/isgx", "/dev/sgx/enclave", "/dev/gsgx"}
 	case enclaveConfigs.EnclaveTypeAwsNitroEnclaves:
 		return []string{"/dev/nitro_enclaves"}
+	case enclaveConfigs.EnclaveTypeJailHouse:
+		return []string{"/dev/jailhouse"}
 	default:
 		return nil
 	}
@@ -175,6 +185,8 @@ func CreateEnclaveDeviceConfig(devices *[]*configs.Device, etype string) {
 		mode = 0666
 	case enclaveConfigs.EnclaveTypeAwsNitroEnclaves:
 		mode = 0660
+	case enclaveConfigs.EnclaveTypeJailHouse:
+		mode = 0666
 	default:
 		return
 	}

--- a/rune/libenclave/configs/config.go
+++ b/rune/libenclave/configs/config.go
@@ -20,6 +20,7 @@ const (
 	EnclaveTypeNone             string = ""
 	EnclaveTypeIntelSgx         string = "intelSgx"
 	EnclaveTypeAwsNitroEnclaves string = "AwsNitroEnclaves"
+	EnclaveTypeJailHouse        string = "Jailhouse"
 )
 
 type Enclave struct {

--- a/rune/libenclave/init.go
+++ b/rune/libenclave/init.go
@@ -3,6 +3,7 @@ package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 import (
 	"github.com/inclavare-containers/rune/libenclave/configs"
 	"github.com/inclavare-containers/rune/libenclave/intelsgx"
+	"github.com/inclavare-containers/rune/libenclave/jailhouse"
 	"github.com/inclavare-containers/rune/libenclave/nitroenclaves"
 	"net"
 	"os/user"
@@ -43,5 +44,7 @@ func init() {
 		enclaveType = configs.EnclaveTypeIntelSgx
 	} else if nitroenclaves.IsNitroEnclaves() {
 		enclaveType = configs.EnclaveTypeAwsNitroEnclaves
+	} else if jailhouse.IsJailHouseSupported() {
+		enclaveType = configs.EnclaveTypeJailHouse
 	}
 }

--- a/rune/libenclave/jailhouse/device_linux.go
+++ b/rune/libenclave/jailhouse/device_linux.go
@@ -1,0 +1,31 @@
+package jailhouse // import "github.com/inclavare-containers/rune/libenclave/jailhouse"
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	JailHouseDevice = "/dev/jailhouse"
+)
+
+func IsJailHouseSupported() bool {
+	var stat unix.Stat_t
+	err := unix.Lstat(JailHouseDevice, &stat)
+	if err != nil {
+		return false
+	}
+
+	devNumber := uint64(stat.Rdev)
+	major := unix.Major(devNumber)
+	if major != 10 {
+		return false
+	}
+
+	if stat.Mode&unix.S_IFCHR != unix.S_IFCHR {
+		return false
+	}
+	logrus.Debug("Jailhouse Enclave detected")
+
+	return true
+}


### PR DESCRIPTION
There are more and more non hardware-assisted enclave forms to support.
Jailhouse is one of this kind of enclave, we should support it.

Fixes:#344
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>