### PR TITLE
rune/libenclave/skeleton: add max-mmap-size metadata area

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -77,15 +77,7 @@ where:
 - @ENCLAVE_PATH: specify the path to enclave runtime to launch.
 - @ENCLAVE_ARGS: specify the specific arguments to enclave runtime, seperated by the comma.
 
-In order to measure the overhead of enclave launch time, we add the `mmap-size` parameter for skeleton and `-s` option for `sgxsign` tool.
-
-The `mmap-size` parameter and `-s` option should be the same value to specify the memory size of the enclave to launch. For example, if `mmap-size` is `40960`, skeleton will launch an enclave with `40960` bytes of memory size.
-
-If you want to launch an enclave with a specific value, you should add `-s ${SIZE}` option with `sgxsign` tool to specify the memory size of the enclave to launch. In addition, You must specify `mmap-size` in `ENCLAVE_RUNTIME_ARGS` with the same number.
-
-```shell
-ENCLAVE_RUNTIME_ARGS="debug,mmap-size=${SIZE}"
-```
+In order to measure the overhead of enclave launch time, we add the `-s` option for `sgxsign` tool. For example, if `-s` option is `40960000`, skeleton will launch an enclave with `40960000` bytes of memory size.
 
 ---
 
@@ -129,8 +121,6 @@ where:
 - @enclave.type: specify the type of enclave hardware to use, such as intelSgx.
 - @enclave.runtime.path: specify the path to enclave runtime to launch.
 - @enclave.runtime.args: specify the specific arguments to enclave runtime, seperated by the comma.
-
-Note that if you add `-s ${SIZE}` when signing your enclave image with `sgxsign` tool. You must specify `mmap-size=${SIZE}` in "enclave.runtime.args`.
 
 ## Run skeleton
 Assuming you have an OCI bundle from the previous step you can execute the container in this way.

--- a/rune/libenclave/internal/runtime/pal/skeleton/arch.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/arch.h
@@ -428,6 +428,10 @@ struct sgx_report {
 } __packed __aligned(512);
 static_assert(sizeof(struct sgx_report) == 512, "incorrect size of sgx_report");
 
+struct metadata {
+	uint64_t max_mmap_size;
+} __packed;
+
 /* *INDENT-OFF* */
 #endif   /* _ASM_X86_SGX_ARCH_H */
 /* *INDENT-ON* */

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.c
@@ -6,6 +6,10 @@
 #include "arch.h"
 #include "sgx_call.h"
 
+struct metadata m __attribute__((section(".metadata"))) = {
+	.max_mmap_size = 0
+};
+
 static void *memcpy(void *dest, const void *src, size_t n)
 {
 	size_t i;

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.lds
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.lds
@@ -18,6 +18,11 @@ SECTIONS
 		*(.data*)
 	}
 
+	. = ALIGN(4096);
+	.metadata : {
+                *(.metadata*)
+	}
+
 	/DISCARD/ : {
 		*(.data*)
 		*(.comment*)


### PR DESCRIPTION
There is no need to add `mmap-size` parameter in config.json file, because skeleton will get the mmap-size value from the metadata area.

Fixes: #296
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>