### PR TITLE
.github/workflows: use the scratch image to replace centos to speed up docker build in CI/CD

### DIFF
--- a/.github/workflows/rune_centos_with_docker_and_crictl.yml
+++ b/.github/workflows/rune_centos_with_docker_and_crictl.yml
@@ -45,13 +45,19 @@ jobs:
         rpm -ivh shim-rune-$RUNE_VERSION-1.el8.x86_64.rpm"
 
     - name: Build Occlum application image on centos
-      run: docker exec $centos bash -c "dockerd -b docker0 --storage-driver=vfs &"
+      run: | 
+        docker exec $centos bash -c "dockerd -b docker0 --storage-driver=vfs &"
 
         docker exec $centos bash -c "occlum-gcc -o hello_world hello_world.c;
         occlum new occlum_instance && cd occlum_instance;
         cp ../hello_world image/bin/ && occlum build;
         occlum package occlum_instance.tar.gz;
-        cp /root/Dockerfile /root/occlum_instance;
+        cat >/root/occlum_instance/Dockerfile <<-EOF
+        FROM scratch
+
+        ADD occlum_instance.tar.gz /
+        ENTRYPOINT [\"/bin/hello_world\"]
+        EOF
         docker build . -t occlum-app"
 
     - name: Build skeleton image on centos
@@ -60,13 +66,12 @@ jobs:
         cd /root/inclavare-containers/rune/libenclave/internal/runtime/pal/skeleton;
         make -j${CPU_NUM} && cp liberpal-skeleton-v*.so /usr/lib;
         cat >Dockerfile <<-EOF
-        FROM centos:8.1.1911
+        FROM scratch
 
-        RUN mkdir -p /run/rune
-        WORKDIR /run/rune
+        COPY encl.bin /
+        COPY encl.ss /
 
-        COPY encl.bin .
-        COPY encl.ss .
+        ENTRYPOINT [\"dummy\"]
         EOF"
 
         docker exec $centos bash -c "cd /root/inclavare-containers/rune/libenclave/internal/runtime/pal/skeleton;

--- a/.github/workflows/rune_ubuntu_with_docker_and_crictl.yml
+++ b/.github/workflows/rune_ubuntu_with_docker_and_crictl.yml
@@ -89,10 +89,8 @@ jobs:
         occlum package occlum_instance.tar.gz"
 
         docker exec $ubuntu bash -c "cat <<- EOF >/root/occlum_instance/Dockerfile
-        FROM centos:8.1.1911
-        RUN mkdir -p /run/rune
-        WORKDIR /run/rune
-        ADD occlum_instance.tar.gz /run/rune
+        FROM scratch
+        ADD occlum_instance.tar.gz /
         ENTRYPOINT [\"/bin/hello_world\"]
         EOF"
 
@@ -109,13 +107,11 @@ jobs:
         cd /root/inclavare-containers/rune/libenclave/internal/runtime/pal/skeleton
         make -j${CPU_NUM} && cp liberpal-skeleton-v*.so /usr/lib;
         cat >Dockerfile <<-EOF
-        FROM centos:8.1.1911
+        FROM scratch
 
-        RUN mkdir -p /run/rune
-        WORKDIR /run/rune
-
-        COPY encl.bin .
-        COPY encl.ss .
+        COPY encl.bin /
+        COPY encl.ss /
+        ENTRYPOINT [\"dummy\"]
         EOF"
 
         docker exec $ubuntu bash -c "cd /root/inclavare-containers/rune/libenclave/internal/runtime/pal/skeleton;


### PR DESCRIPTION
We change centos to scratch because the size of scratch image is 0 while
the size of centos is tens of MB, so use the scratch image to replace
centos to speed up docker build in CI/CD. The last and the most important,
centos will no longer be free at the end of 2021.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>