### PR TITLE
rune/libenclave/skeleton: add xfrm and attribute metadate area

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/arch.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/arch.h
@@ -430,6 +430,8 @@ static_assert(sizeof(struct sgx_report) == 512, "incorrect size of sgx_report");
 
 struct metadata {
 	uint64_t max_mmap_size;
+	uint64_t attributes;
+	uint64_t xfrm;
 } __packed;
 
 /* *INDENT-OFF* */

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.c
@@ -7,7 +7,9 @@
 #include "sgx_call.h"
 
 struct metadata m __attribute__((section(".metadata"))) = {
-	.max_mmap_size = 0
+	.max_mmap_size = 0,
+	.attributes = 0,
+	.xfrm = 0
 };
 
 static void *memcpy(void *dest, const void *src, size_t n)


### PR DESCRIPTION
Since the built environment and runtime environment may be different. It is necessary for users to define the expected value of the processor extension state supported by the target platform at runtime by themselves. The expected value will be stored in the metadata area in enclave images, skeleton will act according.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>