### PR TITLE
.github/workflows: use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/commit_centos.yml
+++ b/.github/workflows/commit_centos.yml
@@ -2,7 +2,7 @@ name: Run rune on centos with docker and crictl test
 
 # Controls when the action will run. Triggers the workflow on pull request labeled testing-before-checkin.
 on:
-  pull_request:
+  pull_request_target:
     types: labeled
 
 jobs:
@@ -10,7 +10,9 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
     - name: Get version
       run: echo "RUNE_VERSION=$(grep 'Version:' rune/dist/rpm/rune.spec | awk '{print $2}')" >> $GITHUB_ENV;

--- a/.github/workflows/commit_ubuntu.yml
+++ b/.github/workflows/commit_ubuntu.yml
@@ -2,7 +2,7 @@ name: Run rune on ubuntu with docker and crictl test
 
 # Controls when the action will run. Triggers the workflow on pull request labeled testing-before-checkin.
 on:
-  pull_request:
+  pull_request_target:
     types: labeled
 
 jobs:
@@ -11,7 +11,9 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       # We usually update rune.spec to the latest version before release. Therefore we get the latest version according to rune.spec.
     - name: Get version


### PR DESCRIPTION
We use the pull_request_target hook to enable proper permissions for
pull requests coming from forks.