### PR TITLE
rune/libenclave/skeleton: add null_dereference_protection and mmap_min_addr to metadata area

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/arch.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/arch.h
@@ -432,6 +432,8 @@ struct metadata {
 	uint64_t max_mmap_size;
 	uint64_t attributes;
 	uint64_t xfrm;
+	bool null_dereference_protection;
+	uint64_t mmap_min_addr;
 } __packed;
 
 /* *INDENT-OFF* */

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.c
@@ -9,7 +9,9 @@
 struct metadata m __attribute__((section(".metadata"))) = {
 	.max_mmap_size = 0,
 	.attributes = 0,
-	.xfrm = 0
+	.xfrm = 0,
+	.null_dereference_protection = false,
+	.mmap_min_addr = 0
 };
 
 static void *memcpy(void *dest, const void *src, size_t n)

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
@@ -162,22 +162,16 @@ uint64_t calc_enclave_offset(uint64_t mmap_min_addr,
 {
 	uint64_t encl_offset;
 
-	if (mmap_min_addr) {
-		/* OOT driver cannot enable enclave dereference protection
-		 * if vm.mmap_min_addr is set to non-zero. In this case,
-		 * load_base - encl_base must equal to 0 in order to keep
-		 * consistent between mmap area and enclave range.
-		 */
-		encl_offset = 0;
-		/* But there is no such a restriction for in-tree driver.
-		 * Currently, null_dereference_protection is always true
-		 * if in-tree driver is used.
-		 */
-		if (null_dereference_protection)
+	/* If NULL dereference protection is not enabled,
+	 * there is no need to make zero page into enclaves.
+	 */
+	encl_offset = 0;
+
+	if (null_dereference_protection) {
+		if (mmap_min_addr)
 			encl_offset = mmap_min_addr;
-	} else {
-		/* Enable the enclave dereference protection automatically */
-		encl_offset = ENCLAVE_GUARD_AREA_SIZE;
+		else
+			encl_offset = ENCLAVE_GUARD_AREA_SIZE;
 	}
 
 	return encl_offset;


### PR DESCRIPTION
User can decide whether to enable null_dereference_protection protection
through the command line in sgxsign tool.

In addition, the user can predefine the value of mmap_min_addr when signing on
a machine with a different vm.mmap_min_addr against runtime.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>