### PR TITLE
README.md: remove /var/run/epm configuration in config.json explicitly

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/README.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/README.md
@@ -145,22 +145,11 @@ You can run epm service following with epm [README](https://github.com/alibaba/i
 
 ## Run epm client
 Assuming you have an OCI bundle according to previous steps, please add config into config.json as following:
-
-```shell
-{
-        "destination": "/var/run/epm/",
-        "type": "bind",
-        "source": "/var/run/epm/",
-        "options": [
-                "rbind",
-                "rprivate"
-        ]
-}
-
+```json
 "annotations": {
 	"enclave.type": "intelSgx",
-	"enclave.runtime.path": "/usr/lib/liberpal-skeleton-v${SKELETON_PAL_VERSION}.so",
-	"enclave.runtime.args": "debug, epm"
+	"enclave.runtime.path": "/usr/lib/liberpal-skeleton-v3.so",
+	"enclave.runtime.args": "epm"
 }
 ```
 


### PR DESCRIPTION
The socket path /var/run/epm is used by epm service and epm client to transfer socket info
between host and container. The path is mounted during starting container in this implementation.
So it can be removed in config.json.

Signed-off-by: Liang Yang <liang3.yang@intel.com>