### PR TITLE
shim-rune && epm: use /var/run/epm and /var/run/rune to replace /run/epm and /run/rune

### DIFF
--- a/docs/develop_and_deploy_hello_world_application_in_kubernetes_cluster.md
+++ b/docs/develop_and_deploy_hello_world_application_in_kubernetes_cluster.md
@@ -173,7 +173,7 @@ If you were to write an SGX Hello World project using some SGX SDK, the project 
         image: docker.io/inclavarecontainers/occlum-hello-world:scratch
         imagePullPolicy: IfNotPresent
         name: helloworld
-        workingDir: /run/rune
+        workingDir: /var/run/rune
     EOF
     ```
     **Note**: The field `runtimeClassName` should be set to `rune` which means the container will be handled by rune, specify the environment `RUNE_CARRIER` to `occlum` telling the `shim-rune`  to create and run an occlum application.<br />

--- a/epm/README.md
+++ b/epm/README.md
@@ -23,7 +23,7 @@ ls -l /usr/local/bin/epm
 
 ### Step 2: Configuration
 
-The Configuration file of epm must be placed into `/run/epm/config.toml`
+The Configuration file of epm must be placed into `/var/run/epm/config.toml`
 
 ```toml
 root = "/var/local/epm"
@@ -31,7 +31,7 @@ db_path = "/etc/epm/epm.db"
 db_timeout = 10
 
 [grpc]
-  address = "/run/epm/epm.sock"
+  address = "/var/run/epm/epm.sock"
   uid = 0
   gid = 0
   max_recv_message_size = 16777216
@@ -40,5 +40,5 @@ db_timeout = 10
 
 ## Run the epm
 ```bash
-/bin/bash /usr/local/bin/epm --config=/run/epm/config.toml --stderrthreshold=0
+/bin/bash /usr/local/bin/epm --config=/var/run/epm/config.toml --stderrthreshold=0
 ```

--- a/epm/dist/deb/debian/postinst
+++ b/epm/dist/deb/debian/postinst
@@ -9,7 +9,7 @@ db_path = "/etc/epm/epm.db"
 db_timeout = 10
 
 [grpc]
-  address = "/run/epm/epm.sock"
+  address = "/var/run/epm/epm.sock"
   uid = 0
   gid = 0
   max_recv_message_size = 16777216

--- a/epm/dist/rpm/epm.spec
+++ b/epm/dist/rpm/epm.spec
@@ -58,7 +58,7 @@ db_path = "/etc/epm/epm.db"
 db_timeout = 10
 
 [grpc]
-  address = "/run/epm/epm.sock"
+  address = "/var/run/epm/epm.sock"
   uid = 0
   gid = 0
   max_recv_message_size = 16777216

--- a/epm/pkg/epm/bundle-cache-pool/occlum/bundle-cache_test.go
+++ b/epm/pkg/epm/bundle-cache-pool/occlum/bundle-cache_test.go
@@ -229,7 +229,7 @@ func Test_BundleCache0Manager_GetCache(t *testing.T) {
 			ID:   "408fbccd943bb",
 		},
 	}
-	err = m.SaveCache("/tmp/f8e9696f895741aae5c034cf063806f28fa4809d37f789056cd90c6026c9f120/rootfs/run/rune", cache)
+	err = m.SaveCache("/tmp/f8e9696f895741aae5c034cf063806f28fa4809d37f789056cd90c6026c9f120/rootfs/var/run/rune", cache)
 	if err != nil {
 		t.Fatal(err)
 	}*/

--- a/shim/README-zh_CN.md
+++ b/shim/README-zh_CN.md
@@ -46,7 +46,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 # If the epm serivce is deployed, you can configure a appropriate unix socket address in "epm.socket" field, 
 # otherwise just delete the epm section.
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     # The signature_method represents the signature method for enclave.
     # It can be "server" or "client", the default value is "server"
@@ -102,6 +102,6 @@ spec:
     image: registry.cn-shanghai.aliyuncs.com/larus-test/hello-world:v2
     imagePullPolicy: IfNotPresent
     name: helloworld
-    workingDir: /run/rune
+    workingDir: /var/run/rune
 EOF
 ```

--- a/shim/README.md
+++ b/shim/README.md
@@ -46,7 +46,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 # If the epm serivce is deployed, you can configure a appropriate unix socket address in "epm.socket" field, 
 # otherwise just delete the epm section.
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     # The signature_method represents the signature method for enclave.
     # It can be "server" or "client", the default value is "server"
@@ -102,6 +102,6 @@ spec:
     image: registry.cn-shanghai.aliyuncs.com/larus-test/hello-world:v2
     imagePullPolicy: IfNotPresent
     name: helloworld
-    workingDir: /run/rune
+    workingDir: /var/run/rune
 EOF
 ```

--- a/shim/conf/config.toml
+++ b/shim/conf/config.toml
@@ -5,7 +5,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 [containerd]
     socket = "/run/containerd/containerd.sock"
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"

--- a/shim/config/config_test.go
+++ b/shim/config/config_test.go
@@ -15,7 +15,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 [containerd]
     socket = "/run/containerd/containerd.sock"
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"

--- a/shim/dist/deb/debian/postinst
+++ b/shim/dist/deb/debian/postinst
@@ -9,7 +9,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 [containerd]
     socket = "/run/containerd/containerd.sock"
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"

--- a/shim/dist/rpm/shim-rune.spec
+++ b/shim/dist/rpm/shim-rune.spec
@@ -58,7 +58,7 @@ sgx_tool_sign = "/opt/intel/sgxsdk/bin/x64/sgx_sign"
 [containerd]
     socket = "/run/containerd/containerd.sock"
 [epm]
-    socket = "/run/epm/epm.sock"
+    socket = "/var/run/epm/epm.sock"
 [enclave_runtime]
     [enclave_runtime.occlum]
         enclave_runtime_path = "/opt/occlum/build/lib/libocclum-pal.so"

--- a/shim/runtime/v2/rune/constants/constants.go
+++ b/shim/runtime/v2/rune/constants/constants.go
@@ -10,7 +10,7 @@ const (
 	EnvKeyRaEpidSubKey       = "ENCLAVE_RA_EPID_SUB_KEY"
 	EnvKeyRaEpidIsLinkable   = "ENCLAVE_RA_EPID_IS_LINKABLE"
 	EnvKeyImageDigest        = "IMAGE_DIGEST"
-	RuneDefaultWorkDirectory = "/run/rune"
+	RuneDefaultWorkDirectory = "/var/run/rune"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>