### PR TITLE
rune/libenclave/skeleton: remove xfrm and attributes from metadata area

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/arch.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/arch.h
@@ -90,7 +90,8 @@ enum sgx_attribute {
 
 #define SGX_ATTR_RESERVED_MASK	(BIT_ULL(3) | BIT_ULL(6) | GENMASK_ULL(63, 8))
 #define SGX_ATTR_ALLOWED_MASK	(SGX_ATTR_DEBUG | SGX_ATTR_MODE64BIT | \
-				 SGX_ATTR_KSS)
+				 SGX_ATTR_KSS | SGX_ATTR_PROVISIONKEY | \
+				 SGX_ATTR_EINITTOKENKEY)
 
 /**
  * struct sgx_secs - SGX Enclave Control Structure (SECS)
@@ -430,8 +431,6 @@ static_assert(sizeof(struct sgx_report) == 512, "incorrect size of sgx_report");
 
 struct metadata {
 	uint64_t max_mmap_size;
-	uint64_t attributes;
-	uint64_t xfrm;
 	bool null_dereference_protection;
 	uint64_t mmap_min_addr;
 } __packed;

--- a/rune/libenclave/internal/runtime/pal/skeleton/encl.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/encl.c
@@ -8,8 +8,6 @@
 
 struct metadata m __attribute__((section(".metadata"))) = {
 	.max_mmap_size = 0,
-	.attributes = 0,
-	.xfrm = 0,
 	.null_dereference_protection = false,
 	.mmap_min_addr = 0
 };


### PR DESCRIPTION
The information of xfrm and attributes are reflected in the signature,
there is no need to add to the metadata area.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>