### PR TITLE
rune/libenclave/skeleton/README.md: add declaration that not support DCAP driver until now for the rune attest command

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/running_skeleton_with_rune_attest_command.md
+++ b/rune/libenclave/internal/runtime/pal/skeleton/running_skeleton_with_rune_attest_command.md
@@ -1,5 +1,5 @@
 # Introduction
-This guide will guide you how to use remote attestation based on SGX in skeleton with rune.
+This guide will guide you how to use remote attestation based on SGX in skeleton with rune. **Currently `rune attest` can only run on the machines with [OOT SGX dirver](https://github.com/intel/linux-sgx-driver), we will support [DCAP driver](https://github.com/intel/SGXDataCenterAttestationPrimitives) as soon as possible**.
 
 # Before you start
 - Build a skeleton bundle according to [this guide](https://github.com/alibaba/inclavare-containers/blob/master/rune/libenclave/internal/runtime/pal/skeleton/README.md) from scratch.


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>