### PR TITLE
rune & sgx-tools: bump the versions of deb and rpm to 0.5.2

### DIFF
--- a/rune/dist/deb/debian/changelog
+++ b/rune/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+rune (0.5.2-1) unstable; urgency=low
+
+  * Update to version 0.5.2.
+
+ -- Shirong Hao <shirong@linux.alibaba.com>  Wed, 30 Dec 2020 10:35:12 +0000
+
 rune (0.5.1-1) unstable; urgency=low
 
   * Update to version 0.5.1.

--- a/rune/dist/rpm/rune.spec
+++ b/rune/dist/rpm/rune.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: rune
-Version: 0.5.1
+Version: 0.5.2
 Release: %{centos_base_release}%{?dist}
 Summary: CLI tool for spawning and running enclaves in containers according to the OCI specification.
 
@@ -56,6 +56,9 @@ install -p -m 644 %{name}/LICENSE %{buildroot}%{_defaultlicensedir}/%{name}-%{ve
 %{BIN_DIR}/%{name}
 
 %changelog
+* Wed Dec 30 2020 Shirong Hao <shirong@linux.alibaba.com> - 0.5.2
+- Update to version 0.5.2
+
 * Mon Nov 30 2020 Shirong Hao <shirong@linux.alibaba.com> - 0.5.1
 - Update to version 0.5.1
 

--- a/sgx-tools/dist/deb/debian/changelog
+++ b/sgx-tools/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+sgx-tools (0.5.2-1) unstable; urgency=low
+
+  * Update to version 0.5.2.
+
+ -- Shirong Hao <shirong@linux.alibaba.com>  Wed, 30 Dec 2020 10:35:12 +0000
+
 sgx-tools (0.5.1-1) unstable; urgency=low
 
   * Update to version 0.5.1.

--- a/sgx-tools/dist/rpm/sgx-tools.spec
+++ b/sgx-tools/dist/rpm/sgx-tools.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: sgx-tools
-Version: 0.5.1
+Version: 0.5.2
 Release: %{centos_base_release}%{?dist}
 Summary: sgx-tools is a commandline tool, used to interact Intel SGx aesm service.
 
@@ -51,6 +51,9 @@ install -p -m 755 %{name}/%{name} %{buildroot}%{BIN_DIR}
 %{BIN_DIR}/%{name}
 
 %changelog
+* Wed Dec 30 2020 Shirong Hao <shirong@linux.alibaba.com> - 0.5.2
+- Update to version 0.5.2
+
 * Mon Nov 30 2020 Shirong Hao <shirong@linux.alibaba.com> - 0.5.1
 - Update to version 0.5.1
 


### PR DESCRIPTION
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>