### PR TITLE
rune: print the error message when --debug specified

### DIFF
--- a/rune/init.go
+++ b/rune/init.go
@@ -50,7 +50,13 @@ var initCommand = cli.Command{
 		factory, _ := libenclave.New("", nil, false)
 		if err := factory.StartInitialization(); err != nil {
 			// as the error is sent back to the parent there is no need to log
-			// or write it to stderr because the parent process will handle this
+			// or write it to stderr because the parent process will handle this.
+			// However, locating the log file is painful especially using docker
+			// or any high level container runtime, so the error is still printed
+			// to stderr if --debug is specified.
+			if context.GlobalBool("debug") {
+				fmt.Fprint(os.Stderr, err)
+			}
 			os.Exit(1)
 		}
 		panic("libenclave: container init failed to exec")


### PR DESCRIPTION
For debug purpose, locating the log file at, e.g,
/run/containerd/io.containerd.runtime.v1.linux/moby/6c1d388b3f1fe157506852a6228769a7e5fb38a7153319a66377e0cd332e1d96/log.json,
is painful especially using docker or any high level container
runtime, so the error is still printed to stderr if --debug
is specified.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>