### PR TITLE
CI/CD: mask `command not found` error message

### DIFF
--- a/.github/workflows/nightly-centos-sgx1.yml
+++ b/.github/workflows/nightly-centos-sgx1.yml
@@ -22,8 +22,8 @@ jobs:
 
     - name: Clear the environment
       run: |
-        sudo kubectl delete pod --all || true
-        sudo kubeadm reset -f || true
+        sudo kubectl delete pod --all 2>/dev/null || true
+        sudo kubeadm reset -f 2>/dev/null || true
         for service in kubectl kubelet containerd epm
         do
           sudo systemctl stop $service || true

--- a/.github/workflows/nightly-ubuntu-sgx1.yml
+++ b/.github/workflows/nightly-ubuntu-sgx1.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Clear the environment
         run: |
-          sudo kubectl delete pod --all || true
-          sudo kubeadm reset -f || true
+          sudo kubectl delete pod --all 2>/dev/null || true
+          sudo kubeadm reset -f 2>/dev/null || true
           for service in kubelet containerd epm
           do
             sudo systemctl stop $service || true


### PR DESCRIPTION
When clearing the build environment, kubectl and kubeadm may be
not installed. In this case, the `command not found` error message
should be invisible.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>