### PR TITLE
rune/skeleton: rename sgx_ecall to sgx_enclave_call

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.S
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.S
@@ -11,9 +11,9 @@
 	# - RDI, RSI, RDX, RCX, R8 and R9 are parameters
 	# - R10 contains the ecall number
 	# - R11 contains the base of TCS
-	.global sgx_ecall
-	.type sgx_ecall, @function
-sgx_ecall:
+	.global sgx_enclave_call
+	.type sgx_enclave_call, @function
+sgx_enclave_call:
 	mov	$1, %rax
 	push	%rbx
 	mov	tcs_busy(%rip), %rbx	

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx_call.h
@@ -24,7 +24,7 @@
 		asm volatile( \
 			"mov %1, %%r10\n\t" \
 			"mov %2, %%r11\n\t" \
-			"call sgx_ecall\n\t" \
+			"call sgx_enclave_call\n\t" \
 			: "=a" (__ret) \
 			: "r" ((uint64_t)ecall_num), "r" (tcs), \
 			  "D" (a0) \
@@ -39,7 +39,7 @@
 		asm volatile( \
 			"mov %1, %%r10\n\t" \
 			"mov %2, %%r11\n\t" \
-			"call sgx_ecall\n\t" \
+			"call sgx_enclave_call\n\t" \
 			: "=a" (__ret) \
 			: "r" ((uint64_t)ecall_num), "r" (tcs), \
 			  "D" (a0), "S" (a1), "d" (a2) \


### PR DESCRIPTION
sgx_ecall conflicts with libsgx_urts from Intel SGX SDK.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>