### PR TITLE
CI/CD: add dcap-related compile dependency in centos8.1 and ubuntu18.04

### DIFF
--- a/.github/workflows/docker/Dockerfile-compile-check-centos8.1
+++ b/.github/workflows/docker/Dockerfile-compile-check-centos8.1
@@ -4,8 +4,8 @@ LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 
 RUN dnf clean all && rm -r /var/cache/dnf && \
     dnf --enablerepo=PowerTools install -y which wget git \
-    make gcc libseccomp-devel binutils-devel protobuf-devel \
-    protobuf-c-devel openssl openssl-devel
+    make gcc gcc-c++ libseccomp-devel binutils-devel protobuf \
+    protobuf-devel protobuf-c-devel openssl openssl-devel
 
 WORKDIR /root
 
@@ -20,3 +20,8 @@ ENV GOPATH       /root/gopath
 ENV PATH         $PATH:$GOROOT/bin:$GOPATH/bin
 ENV GOPROXY      "https://mirrors.aliyun.com/goproxy,direct"
 ENV GO111MODULE  on
+
+# install dcap
+RUN wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/centos8.2-server/sgx_rpm_local_repo.tgz && \
+    tar -zxvf sgx_rpm_local_repo.tgz && rm sgx_rpm_local_repo.tgz && cd sgx_rpm_local_repo && rpm -ivh *.rpm && \
+    rm -rf sgx_rpm_local_repo

--- a/.github/workflows/docker/Dockerfile-compile-check-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-compile-check-ubuntu18.04
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 
-RUN apt-get update && apt-get install -y autoconf gcc make wget git \
+RUN apt-get update && apt-get install -y autoconf gcc g++ make wget git \
     libseccomp-dev binutils-dev libprotoc-dev libprotobuf-c0-dev \
     protobuf-c-compiler pkg-config libssl-dev openssl
 
@@ -19,3 +19,8 @@ ENV GOPATH       /root/gopath
 ENV PATH         $PATH:$GOROOT/bin:$GOPATH/bin
 ENV GOPROXY      "https://mirrors.aliyun.com/goproxy,direct"
 ENV GO111MODULE  on
+
+# install dcap
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+
+RUN apt-get update -y  && apt-get install -y libsgx-launch libsgx-epid libsgx-urts libsgx-quote-ex libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-ql-dev libsgx-headers


### PR DESCRIPTION
Fixes: #495
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>