### PR TITLE
CI/CD: adjust the jobs order of get local report and get remote report.

### DIFF
--- a/.github/workflows/commit_skeleton.yml
+++ b/.github/workflows/commit_skeleton.yml
@@ -103,13 +103,13 @@ jobs:
         sleep 5
         done"
 
-    - name: Get remote report with rune attest command
-      if: ${{ contains(matrix.sgx, 'SGX1') }}
-      run: docker exec $rune_test bash -c "rune --debug attest --isRA --linkable=false --spid=${{ secrets.SPID }} --subscription-key=${{ secrets.SUB_KEY }} skeleton-enclave-container"
-
     - name: Get local report with rune attest command
       if: ${{ contains(matrix.sgx, 'SGX1') }}
       run: docker exec $rune_test bash -c "rune --debug attest --reportFile=/report.bin skeleton-enclave-container"
+
+    - name: Get remote report with rune attest command
+      if: ${{ contains(matrix.sgx, 'SGX1') }}
+      run: docker exec $rune_test bash -c "rune --debug attest --isRA --linkable=false --spid=${{ secrets.SPID }} --subscription-key=${{ secrets.SUB_KEY }} skeleton-enclave-container"
 
     - name: Get target info with sgx-tools
       if: ${{ contains(matrix.sgx, 'SGX1') }}


### PR DESCRIPTION
If not successfully getting local report, it wouldn't get remote report
successfully any more.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>