### PR TITLE
rune/skeleton: add sanity check for exponent

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/arch.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/arch.h
@@ -49,6 +49,7 @@ enum sgx_sub_leaf_types {
 #define SGX_CPUID_SUB_LEAF_TYPE_MASK	GENMASK(3, 0)
 
 #define SGX_MODULUS_SIZE 384
+#define SGX_EXPONENT_SIZE 1
 
 /**
  * enum sgx_miscselect - additional information to an SSA frame


### PR DESCRIPTION
SGX asks for the fixed exponent value 3.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>