### PR TITLE
CI/CD: workround skeleton occasionally failed problem

### DIFF
--- a/.github/workflows/commit_skeleton.yml
+++ b/.github/workflows/commit_skeleton.yml
@@ -51,7 +51,24 @@ jobs:
 
     - name: Run skeleton v1
       if: always()
-      run: docker exec $rune_test bash -c "docker run -i --rm --runtime=rune -e ENCLAVE_TYPE=intelSgx -e ENCLAVE_RUNTIME_PATH=/usr/lib/liberpal-skeleton-v1.so -e ENCLAVE_RUNTIME_ARGS=debug skeleton-enclave"
+      run: |
+        docker exec $rune_test bash -c 'cd /root/inclavare-containers-test/rune/libenclave/internal/runtime/pal/skeleton;
+        count=0;
+        while true; do
+        let count++;
+        docker run -i --rm --runtime=rune -e ENCLAVE_TYPE=intelSgx -e ENCLAVE_RUNTIME_PATH=/usr/lib/liberpal-skeleton-v1.so -e ENCLAVE_RUNTIME_ARGS=debug skeleton-enclave;
+        if [ $? -eq 0 ]; then
+          break;
+        elif [ $count -ge 5 ]; then
+          echo falied;
+          exit -1;
+        else
+          rm -rf signing_key.pem encl.ss 2>/dev/null;
+          openssl genrsa -3 -out signing_key.pem 3072 2>/dev/null;
+          ./sgxsign signing_key.pem encl.bin encl.ss 2>/dev/null;
+          docker build . -t skeleton-enclave -f /root/Dockerfile-skeleton 2>/dev/null;
+        fi
+        done'
 
     - name: Run skeleton v2
       if: always()


### PR DESCRIPTION
The sgxsign tool may not be able to process some keys,
which leads to EINIT error. We will fix it in the future.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>