### PR TITLE
CI/CD: use rune kill command to kill remote containers when all rune attest test completing

### DIFF
--- a/.github/workflows/commit_skeleton.yml
+++ b/.github/workflows/commit_skeleton.yml
@@ -107,7 +107,7 @@ jobs:
       if: ${{ contains(matrix.sgx, 'SGX1') }}
       run: docker exec $rune_test bash -c "rune --debug run skeleton-enclave-container" &
 
-    - name: Wait RA containers Running
+    - name: Wait RA containers Running with rune list command
       if: ${{ contains(matrix.sgx, 'SGX1') }}
       timeout-minutes: 2
       run: |
@@ -127,6 +127,27 @@ jobs:
     - name: Get remote report with rune attest command
       if: ${{ contains(matrix.sgx, 'SGX1') }}
       run: docker exec $rune_test bash -c "rune --debug attest --isRA --linkable=false --spid=${{ secrets.SPID }} --subscription-key=${{ secrets.SUB_KEY }} skeleton-enclave-container"
+
+    - name: Kill RA containers with rune kill command
+      if: ${{ contains(matrix.sgx, 'SGX1') }}
+      timeout-minutes: 3
+      run: |
+        docker exec $rune_test bash -c "
+        status=\$(rune list 2>/dev/null | grep skeleton-enclave-container | awk '{print \$3}')
+        echo Current status: \$status
+        if [[ \$status = 'running' ]]; then
+          echo Killing RA containers...
+          rune kill skeleton-enclave-container 9
+          while true; do
+                status=\$(rune list 2>/dev/null | grep skeleton-enclave-container | awk '{print \$3}')
+                echo Current status: \$status
+                if [[ \$status = '' ]]; then
+                    echo Killing successfully
+                    break
+                fi
+                sleep 5
+          done
+        fi"
 
     - name: Get target info with sgx-tools
       if: ${{ contains(matrix.sgx, 'SGX1') }}


### PR DESCRIPTION
We need to kill the RA containers after all rune attest test completing
to recycle resources. Besides, we also need to test whether the rune kill
command is OK or not.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>