### PR TITLE
rune/libenclave/epm: fix a bug about sgx mmap failure

### DIFF
--- a/rune/libenclave/epm/cmsg.go
+++ b/rune/libenclave/epm/cmsg.go
@@ -76,6 +76,7 @@ func recvFd(socksPath string, fd *int) error {
 		logrus.Warnf("In recvFd connection close error: %v", err)
 		return err
 	}
+	epmchan <- nil
 
 	return nil
 }

--- a/rune/libenclave/epm/epm.go
+++ b/rune/libenclave/epm/epm.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+var epmchan = make(chan error, 1)
+
 const (
 	InvalidEpmID string = "InvalidEPMID"
 	address             = "/var/run/epm/epm.sock"
@@ -73,6 +75,8 @@ func GetCache(ID string, subtype string) *v1alpha1.Enclave {
 		return nil
 	}
 	ptypes.UnmarshalAny(cacheResp.Cache.Options, &enclaveinfo)
+	<-epmchan
+	close(epmchan)
 	enclaveinfo.Fd = int64(fd)
 	return &enclaveinfo
 }


### PR DESCRIPTION
Sometimes epm client tries to get enclave information from pool, the enclave file
descriptor is not received from epm server in time. It will lead that the enclave
fd as zero is filled into enclave information. So when sgx mmap happens, the wrong enclave
information will be inputed as parameter, it will cause permission denied. To correct
the error, it need sync between recieving and filling real fd value into enclave information.

Fixes: #592
Signed-off-by: Liang Yang <liang3.yang@intel.com>