### PR TITLE
rune/libenclave/attestation: fix the return error of the sgxEpidChallenger.New function

### DIFF
--- a/rune/libenclave/attestation/sgx-epid-challenger.go
+++ b/rune/libenclave/attestation/sgx-epid-challenger.go
@@ -22,7 +22,7 @@ func (epid *sgxEpidChallenger) Name() string {
 func (epid *sgxEpidChallenger) New(cfg map[string]string) error {
 	ias, err := ias.NewIasAttestation(cfg)
 	if err != nil {
-		return nil
+		return err
 	}
 	epid.ias = ias
 


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>