### PR TITLE
rune/skeleton: fix EINIT rc 8 failure on SGX2 platforms

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgx.h
@@ -175,6 +175,9 @@ void get_sgx_xfrm_by_cpuid(uint64_t *xfrm);
 uint32_t sgx_calc_ssaframesize(uint32_t miscselect, uint64_t xfrm);
 uint32_t get_sgx_miscselect_by_cpuid(void);
 bool is_launch_control_supported(void);
+bool is_sgx1_supported(void);
+bool is_sgx2_supported(void);
+
 /* *INDENT-OFF* */
 #endif   /* _UAPI_ASM_X86_SGX_H */
 /* *INDENT-ON* */

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxsign.c
@@ -727,7 +727,7 @@ int main(int argc, char **argv)
 	memcpy(ss.header.header1, header1, sizeof(ss.header.header1));
 	memcpy(ss.header.header2, header2, sizeof(ss.header.header2));
 
-	if (enclave_debug)
+	if (enclave_debug && is_sgx1_supported() && !is_sgx2_supported())
 		ss.header.type = 1 << 31;
 
 	if (calc_sgx_attributes(&ss.body.attributes, &ss.body.attributes_mask))

--- a/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/sgxutils.c
@@ -133,6 +133,24 @@ bool is_launch_control_supported(void)
 	return !!(cpu_info[2] & 0x40000000);
 }
 
+bool is_sgx1_supported(void)
+{
+	int cpu_info[4] = { 0, 0, 0, 0 };
+
+	__cpuidex(cpu_info, SGX_CPUID, 0);
+
+	return !!(cpu_info[0] & 1);
+}
+
+bool is_sgx2_supported(void)
+{
+	int cpu_info[4] = { 0, 0, 0, 0 };
+
+	__cpuidex(cpu_info, SGX_CPUID, 0);
+
+	return !!(cpu_info[0] & 0x2);
+}
+
 /* *INDENT-OFF* */
 int get_mmap_min_addr(uint64_t *addr)
 {


### PR DESCRIPTION
The solution for SGX1 platforms is not working for SGX2, thus it is
necessary to make sure the hack is only applicable to SGX1 platforms.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>