### PR TITLE
rune/libenclave/attestation: move sgx-epid-challenger.go to the sgx/sgx_challenger package

### DIFF
--- a/rune/libenclave/attestation/challenger.go
+++ b/rune/libenclave/attestation/challenger.go
@@ -55,7 +55,7 @@ func NewChallenger(aType string, cfg map[string]string) (Challenger, error) {
 
 var challengerList []Challenger
 
-func registerChallenger(challenger Challenger) error {
+func RegisterChallenger(challenger Challenger) error {
 	for _, c := range challengerList {
 		if c.Name() == challenger.Name() {
 			return fmt.Errorf("Attestation service %s registered already", challenger.Name())

--- a/rune/libenclave/attestation/sgx/sgx_challenger/sgx-epid-challenger.go
+++ b/rune/libenclave/attestation/sgx/sgx_challenger/sgx-epid-challenger.go
@@ -1,7 +1,8 @@
-package attestation // import "github.com/inclavare-containers/rune/libenclave/attestation"
+package sgx_challenger // import "github.com/inclavare-containers/rune/libenclave/attestation/sgx/sgx_challenger"
 
 import (
 	"fmt"
+	"github.com/inclavare-containers/rune/libenclave/attestation"
 	"github.com/inclavare-containers/rune/libenclave/attestation/sgx/ias"
 	"github.com/sirupsen/logrus"
 )
@@ -33,14 +34,14 @@ func (epid *sgxEpidChallenger) Check(quote []byte) error {
 	return epid.ias.CheckQuote(quote)
 }
 
-func (epid *sgxEpidChallenger) Verify(quote []byte) (*ReportStatus, error) {
+func (epid *sgxEpidChallenger) Verify(quote []byte) (*attestation.ReportStatus, error) {
 	s, err := epid.ias.VerifyQuote(quote)
 	if err != nil {
 		return nil, err
 	}
 
 	/* FIXME: check whether the report status is acceptable */
-	status := &ReportStatus{
+	status := &attestation.ReportStatus{
 		StatusCode:     StatusSgxBit,
 		SpecificStatus: s,
 	}
@@ -48,13 +49,13 @@ func (epid *sgxEpidChallenger) Verify(quote []byte) (*ReportStatus, error) {
 	return status, nil
 }
 
-func (epid *sgxEpidChallenger) GetReport(quote []byte, nonce uint64) (*ReportStatus, map[string]string, error) {
+func (epid *sgxEpidChallenger) GetReport(quote []byte, nonce uint64) (*attestation.ReportStatus, map[string]string, error) {
 	s, report, err := epid.ias.RetrieveIasReport(quote, nonce)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	status := &ReportStatus{
+	status := &attestation.ReportStatus{
 		StatusCode:     StatusSgxBit,
 		SpecificStatus: s,
 	}
@@ -62,7 +63,7 @@ func (epid *sgxEpidChallenger) GetReport(quote []byte, nonce uint64) (*ReportSta
 	return status, report, nil
 }
 
-func (epid *sgxEpidChallenger) ShowReportStatus(status *ReportStatus) {
+func (epid *sgxEpidChallenger) ShowReportStatus(status *attestation.ReportStatus) {
 	if status.StatusCode&StatusSgxBit != StatusSgxBit {
 		logrus.Error("Report status is used for SGX EPID-based")
 		return
@@ -78,7 +79,7 @@ func (epid *sgxEpidChallenger) ShowReportStatus(status *ReportStatus) {
 }
 
 func init() {
-	if err := registerChallenger(&sgxEpidChallenger{}); err != nil {
+	if err := attestation.RegisterChallenger(&sgxEpidChallenger{}); err != nil {
 		fmt.Print(err)
 	}
 }

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -44,10 +44,10 @@ func (pal *enclaveRuntimePal) Init(args string, logLevel string) error {
 	no_epm := true
 	if !strings.Contains(args, "no-epm") {
 		no_epm = false
-	       /* enclaveinfo.Layout retrieves from /proc/pid/mmaps, in file
+		/* enclaveinfo.Layout retrieves from /proc/pid/mmaps, in file
 		* mmaps /dev/sgx/enclave mmaping address is sorted from low
 		* address to high one. So layout[0].Addr will be minimum.
-		*/
+		 */
 		pal.enclaveSubType = EnclaveSubType
 		enclaveinfo = epm.GetEnclave(pal.enclaveSubType)
 		if enclaveinfo != nil {

--- a/rune/libenclave/internal/runtime/pal/pal_linux.go
+++ b/rune/libenclave/internal/runtime/pal/pal_linux.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-restruct/restruct"
 	"github.com/inclavare-containers/epm/pkg/epm-api/v1alpha1"
 	"github.com/inclavare-containers/rune/libenclave/attestation"
-	_ "github.com/inclavare-containers/rune/libenclave/attestation/sgx/ias"
+	_ "github.com/inclavare-containers/rune/libenclave/attestation/sgx/sgx_challenger"
 	"github.com/inclavare-containers/rune/libenclave/epm"
 	"github.com/inclavare-containers/rune/libenclave/intelsgx"
 	"log"


### PR DESCRIPTION
sgx-related codes should be located into rune/libenclave/attestation/sgx
package. More specifically, {sgx-attester-related, sgx-challenger-related,
sgx-verifier-related} should be placed into
rune/libenclave/attestation/{sgx_attester, sgx_challenger, sgx_verifier} packages.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>