### PR TITLE
rune/README.md && rpm && deb && CI/CD: add the compile dependence for verifying SGX DCAP quote

### DIFF
--- a/.github/workflows/docker/Dockerfile-compile-check-centos8.1
+++ b/.github/workflows/docker/Dockerfile-compile-check-centos8.1
@@ -23,5 +23,4 @@ ENV GO111MODULE  on
 
 # install dcap
 RUN wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/centos8.2-server/sgx_rpm_local_repo.tgz && \
-    tar -zxvf sgx_rpm_local_repo.tgz && rm sgx_rpm_local_repo.tgz && cd sgx_rpm_local_repo && rpm -ivh *.rpm && \
-    rm -rf sgx_rpm_local_repo
+    tar -zxvf sgx_rpm_local_repo.tgz && rm sgx_rpm_local_repo.tgz && cd sgx_rpm_local_repo && rpm -ivh libsgx-headers*.rpm libsgx-dcap-quote-verify*.rpm && rm -rf sgx_rpm_local_repo

--- a/.github/workflows/docker/Dockerfile-compile-check-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-compile-check-ubuntu18.04
@@ -23,4 +23,4 @@ ENV GO111MODULE  on
 # install dcap
 RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
 
-RUN apt-get update -y  && apt-get install -y libsgx-launch libsgx-epid libsgx-urts libsgx-quote-ex libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-ql-dev libsgx-headers
+RUN apt-get update -y  && apt-get install -y libsgx-dcap-quote-verify libsgx-dcap-quote-verify-dev

--- a/.github/workflows/nightly-ubuntu-sgx1.yml
+++ b/.github/workflows/nightly-ubuntu-sgx1.yml
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get remove -y libsgx-ae-epid libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 \
             libsgx-aesm-launch-plugin libsgx-enclave-common sgx-aesm-service libsgx-urts \
             libsgx-launch libsgx-epid libsgx-quote-ex libsgx-enclave-common-dbgsym \
-            libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify || true
+            libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-quote-verify-dev || true
           sudo apt-get remove -y *sgx* || true
           sudo /bin/bash /opt/intel/sgxdriver/uninstall.sh || true
           sudo /bin/bash /opt/intel/sgxsdk/uninstall.sh || true
@@ -106,7 +106,7 @@ jobs:
           sudo apt-get install -y libsgx-launch libsgx-urts
           sudo apt-get install -y libsgx-epid libsgx-urts
           sudo apt-get install -y libsgx-quote-ex libsgx-urts
-          sudo apt-get install -y libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify
+          sudo apt-get install -y libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-quote-verify-dev
           sudo /bin/bash /opt/intel/sgx-aesm-service/cleanup.sh
           sudo /bin/bash /opt/intel/sgx-aesm-service/startup.sh
           chmod +x sgx_linux_x64_driver_2.6.0_b0a445b.bin sgx_linux_x64_sdk_2.11.100.2.bin
@@ -490,7 +490,7 @@ jobs:
           sudo apt-get remove -y libsgx-ae-epid libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 \
             libsgx-aesm-launch-plugin libsgx-enclave-common sgx-aesm-service libsgx-urts \
             libsgx-launch libsgx-epid libsgx-quote-ex libsgx-enclave-common-dbgsym \
-            libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify || true
+            libsgx-ae-qve libsgx-dcap-ql libsgx-dcap-quote-verify libsgx-dcap-quote-verify-dev || true
           sudo apt-get remove -y *sgx* || true
           sudo /bin/bash /opt/intel/sgxdriver/uninstall.sh || true
           sudo /bin/bash /opt/intel/sgxsdk/uninstall.sh || true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ git clone https://github.com/alibaba/inclavare-containers
 2. Install the Dependency required by Inclavare Containers
 - Go version 1.14 or higher.
 - `libseccomp`.
+- [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives): please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
+	- libsgx-dcap-quote-verify: both for centos and ubuntu
+	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devev(centos)
 
 3. Build Inclavare Containers
 

--- a/rune/README.md
+++ b/rune/README.md
@@ -8,6 +8,10 @@
 
 Additionally, `rune` by default enables seccomp support as [runc](https://github.com/opencontainers/runc#building) so you need to install libseccomp on your platform.
 
+Besides, `rune` depends on [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives). Please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
+- libsgx-dcap-quote-verify: both for centos and ubuntu
+- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devev(centos)
+
 ```bash
 # create $WORKSPACE folder
 mkdir -p "$WORKSPACE"

--- a/rune/dist/deb/debian/control
+++ b/rune/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: rune
 Section: devel
 Priority: extra
 Maintainer: shirong <shirong@linux.alibaba.com>
-Build-Depends: debhelper (>=9), libseccomp-dev
+Build-Depends: debhelper (>=9), libseccomp-dev, libsgx-dcap-quote-verify, libsgx-dcap-quote-verify-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/rune/dist/rpm/rune.spec
+++ b/rune/dist/rpm/rune.spec
@@ -15,6 +15,8 @@ URL: https://github.com/alibaba/%{PROJECT}
 Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
 
 BuildRequires: libseccomp-devel
+BuildRequires: libsgx-dcap-quote-verify
+BuildRequires: libsgx-dcap-quote-verify-devel
 ExclusiveArch: x86_64
 
 %description


### PR DESCRIPTION
1. CI/CD: add the ubuntu and centos compile dependence of verifying SGX DCAP quote.
2. rune/dist/rpm && deb: add the compile dependence for verifying SGX DCAP quote.
3. rune/README.md: add the ubuntu and centos compile dependence of verifying SGX DCAP quote.
4. CI/CD: add libsgx-dcap-quote-verify-dev deb in nightly-ubuntu-sgx1.yml.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>