### PR TITLE
CI/CD: install libsgx-headers*.deb in Dockerfile-ubuntu18.04

### DIFF
--- a/.github/workflows/docker/Dockerfile-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-ubuntu18.04
@@ -36,3 +36,9 @@ RUN apt-get install -y apt-transport-https ca-certificates curl software-propert
 # configure docker
 RUN mkdir -p /etc/docker && \
     echo "{\n\t\"runtimes\": {\n\t\t\"rune\": {\n\t\t\t\"path\": \"/usr/local/bin/rune\",\n\t\t\t\"runtimeArgs\": []\n\t\t}\n\t},\n\t\"storage-driver\": \"vfs\"\n}" >> /etc/docker/daemon.json
+
+# configure SGX apt source
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+
+# install libsgx-headers which is needed by libsgx-dcap-quote-verify*.deb
+RUN apt-get update -y && apt-get remove -y libsgx-dcap-ql-dev && apt-get install -y libsgx-headers=2.12.100.3-bionic1


### PR DESCRIPTION
`libsgx-header*.deb` is needed by `libsgx-dcap-quote-verify*.deb`. If
`libsgx-dcap-quote-verify*.deb` isn't installed by `apt-get install` but
installed by `dpkg`, we also need to install `libsgx-headers` explicitly.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>