### PR TITLE
CI/CD: in the Dockerfile-ubuntu18.04, use soft link instead of installing  libsgx-headers to compile rune

### DIFF
--- a/.github/workflows/docker/Dockerfile-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-ubuntu18.04
@@ -37,8 +37,5 @@ RUN apt-get install -y apt-transport-https ca-certificates curl software-propert
 RUN mkdir -p /etc/docker && \
     echo "{\n\t\"runtimes\": {\n\t\t\"rune\": {\n\t\t\t\"path\": \"/usr/local/bin/rune\",\n\t\t\t\"runtimeArgs\": []\n\t\t}\n\t},\n\t\"storage-driver\": \"vfs\"\n}" >> /etc/docker/daemon.json
 
-# configure SGX apt source
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-
-# install libsgx-headers which is needed by libsgx-dcap-quote-verify*.deb
-RUN apt-get update -y && apt-get remove -y libsgx-dcap-ql-dev && apt-get install -y libsgx-headers=2.12.100.3-bionic1
+# configure sgxsdk 2.11 and dcap 1.8
+RUN [ ! -e /usr/include/sgx_attributes.h ] && ln -sfn /opt/intel/sgxsdk/include/sgx_attributes.h /usr/include/sgx_attributes.h


### PR DESCRIPTION
/usr/include/sgx_attributes.h is a file of the libsgx-headers deb since
sgxsdk 2.12. However, Dockerfile-ubuntu18.04 based on
occlum/occlum:$OCCLUM_VERSION-ubuntu18.04 docker image, and the occlum
ubuntu 18.04 docker image based on a lower version sgxsdk 2.11 which
doesn't have a libsgx-headers deb. So we use the soft link the fix the
error of compiling rune.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>