### PR TITLE
shim: change the occlum version and fix the problem that Centos nightly build failed

### DIFF
--- a/.github/workflows/nightly-centos-sgx1.yml
+++ b/.github/workflows/nightly-centos-sgx1.yml
@@ -10,7 +10,7 @@ on:
 env:
     WORK_DIR: /root/pkgs
     HOME: /root
-    OCCLUM_VERSION: 0.19.0
+    OCCLUM_VERSION: 0.20.0
     kubernetes_version: 1.16.9
     nap_time: 60
 
@@ -105,6 +105,7 @@ jobs:
         nohup ./signatureserver --public-key public_key.pem --private-key private_key.pem &
         netstat -natp | grep 9080 || exit 1
         echo -e "[signature]\n    server_address = \"http://127.0.0.1:9080\"" >> /etc/inclavare-containers/config.toml
+        systemctl restart aesmd
         popd
 
     - name: Configure containerd

--- a/.github/workflows/nightly-ubuntu-sgx1.yml
+++ b/.github/workflows/nightly-ubuntu-sgx1.yml
@@ -10,7 +10,7 @@ on:
 env:
   WORK_DIR: /root/pkgs
   HOME: /root
-  OCCLUM_VERSION: 0.19.0
+  OCCLUM_VERSION: 0.20.0
   kubernetes_version: 1.16.9
   nap_time: 60
 
@@ -217,7 +217,6 @@ jobs:
           sudo apt update && sudo apt install -y apt-transport-https curl
           curl -s https://mirrors.aliyun.com/kubernetes/apt/doc/apt-key.gpg | sudo apt-key add -
           echo "deb https://mirrors.aliyun.com/kubernetes/apt/ kubernetes-xenial main" >>/etc/apt/sources.list.d/kubernetes.list
-          sudo setenforce 0 || true
 
           sudo apt update && apt install -y kubelet=${kubernetes_version}-00 kubeadm=${kubernetes_version}-00 kubectl=${kubernetes_version}-00
           cat << EOF >/etc/resolv.conf.kubernetes


### PR DESCRIPTION
change the occlum version from 0.19.0 to 0.20.0 and restart aesmd after installed the shim and epm.

Signed-off-by: jiazhiguang <jia_zhiguang@126.com>