### PR TITLE
skeleton: allow to dynamically enable enclave debug

### DIFF
--- a/rune/libenclave/attestation/internal/sgx/dcap/qvl.go
+++ b/rune/libenclave/attestation/internal/sgx/dcap/qvl.go
@@ -2,6 +2,7 @@ package dcap // import "github.com/inclavare-containers/rune/libenclave/attestat
 
 /*
 #cgo LDFLAGS: -lsgx_dcap_quoteverify
+#cgo CFLAGS: -I/opt/intel/sgxsdk/include
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -282,6 +282,8 @@ static bool encl_create(int dev_fd, unsigned long bin_size,
 		return false;
 	// *INDENT-ON*
 	secs->attributes = sigstruct->body.attributes;
+	if (debugging)
+		secs->attributes |= SGX_ATTR_DEBUG;
 
 	uint64_t probed_xfrm;
 	get_sgx_xfrm_by_cpuid(&probed_xfrm);

--- a/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/liberpal-skeleton.c
@@ -680,6 +680,9 @@ static void check_opts(const char *opt)
 
 void parse_args(const char *args)
 {
+	if (!args || args[0] == '\0')
+		return;
+
 	char *a = strdup(args);
 	if (!a)
 		return;


### PR DESCRIPTION
If enclave debug is not explicitly disabled, the "debug"
enclave runtime argument will enable enclave debug.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>