### PR TITLE
CI/CD: drop unnecessary soft link about sgx_attributes.h in Dockerfile-ubuntu18.04

### DIFF
--- a/.github/workflows/docker/Dockerfile-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-ubuntu18.04
@@ -36,6 +36,3 @@ RUN apt-get install -y apt-transport-https ca-certificates curl software-propert
 # configure docker
 RUN mkdir -p /etc/docker && \
     echo "{\n\t\"runtimes\": {\n\t\t\"rune\": {\n\t\t\t\"path\": \"/usr/local/bin/rune\",\n\t\t\t\"runtimeArgs\": []\n\t\t}\n\t},\n\t\"storage-driver\": \"vfs\"\n}" >> /etc/docker/daemon.json
-
-# configure sgxsdk 2.11 and dcap 1.8
-RUN [ ! -e /usr/include/sgx_attributes.h ] && ln -sfn /opt/intel/sgxsdk/include/sgx_attributes.h /usr/include/sgx_attributes.h


### PR DESCRIPTION
If you want to include <sgx_attributes.h>, you cen use
-I/opt/intel/sgxsdk/include rather than installing libsgx-headers or the
soft link about sgx_attributes.h.

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com