### PR TITLE
ra-tls/elv: fix failure on la report

### DIFF
--- a/inclavared/app.wolfssl/Makefile
+++ b/inclavared/app.wolfssl/Makefile
@@ -2,12 +2,20 @@ Rust_App_Name := app
 Rust_App_Files := $(wildcard src/*.rs)
 SGX_DEBUG ?=
 
-ifdef ECDSA
-	BUILD_FLAGS = --features=RATLS_ECDSA
-else LA
-	BUILD_FLAGS = --features=LA_REPORT
+ifneq ($(SGX_DEBUG), 1)
+	TARGET_DIR = release
+	BUILD_FLAGS = --release
 else
-	BUILD_FLAGS = --features=RATLS_EPID
+	TARGET_DIR = debug
+	BUILD_FLAGS =
+endif
+
+ifdef ECDSA
+	BUILD_FLAGS += --features=RATLS_ECDSA
+else ifdef LA
+	BUILD_FLAGS += --features=LA_REPORT
+else
+	BUILD_FLAGS += --features=RATLS_EPID
 endif
 
 .PHONY: all
@@ -15,17 +23,10 @@ endif
 all: $(Rust_App_Name)
 
 $(Rust_App_Name): $(Rust_App_Files)
-ifneq ($(SGX_DEBUG), 1)
-	cargo build --release $(BUILD_FLAGS)
-else
 	cargo build $(BUILD_FLAGS)
-endif
 	[ ! -d ../bin ] && mkdir ../bin || true
-ifneq ($(SGX_DEBUG), 1)
-	cp ./target/release/inclavared ../bin/inclavared
-else
-	cp ./target/debug/inclavared ../bin/inclavared
-endif
+	cp ./target/$(TARGET_DIR)/inclavared ../bin/
+	cp ../../ra-tls/build/bin/Wolfssl_Enclave.signed.so ../bin/
 
 clean:
 	@cargo clean

--- a/inclavared/stub-enclave.wolfssl/Makefile
+++ b/inclavared/stub-enclave.wolfssl/Makefile
@@ -11,7 +11,7 @@ endif
 
 ifdef ECDSA
 	BUILD_FLAGS = --features=RATLS_ECDSA
-else LA
+else ifdef LA
 	BUILD_FLAGS = --features=LA_REPORT
 else
 	BUILD_FLAGS = --features=RATLS_EPID

--- a/ra-tls/elv/Makefile
+++ b/ra-tls/elv/Makefile
@@ -61,7 +61,7 @@ GO_BUILD := CGO_ENABLED=1 $(GO) build $(MOD_VENDOR) -buildmode=pie $(GCFLAGS) $(
 
 ifdef LA
 elv: $(LIBDIR)/liberpal-stub.a libra-tls-client.a $(LIBDIR)/libra-challenger.a $(LIBDIR)/libwolfssl.a
-	$(GO_BUILD) -o $@ .
+	$(GO_BUILD) -tags "lareport" -o $@ .
 else
 elv: libra-tls-client.a $(LIBDIR)/libra-challenger.a $(LIBDIR)/libwolfssl.a
 	$(GO_BUILD) -o $@ .

--- a/ra-tls/elv/echo-la.go
+++ b/ra-tls/elv/echo-la.go
@@ -1,0 +1,10 @@
+// +build lareport
+
+package main
+
+/*
+#cgo CFLAGS: -I../build/include -I/opt/intel/sgxsdk/include -I../sgx-ra-tls -I../wolfssl/
+#cgo CFLAGS: -DLA_REPORT=1
+#cgo LDFLAGS: -L../build/lib -l:libra-challenger.a -l:libwolfssl.a -lsgx_urts -lm
+*/
+import "C"

--- a/ra-tls/elv/ra-tls-client.c
+++ b/ra-tls/elv/ra-tls-client.c
@@ -64,7 +64,7 @@ static sgx_enclave_id_t load_enclave(void)
         int ret = sgx_create_enclave("Wolfssl_Enclave.signed.so", 1, &t, &updated, &id, NULL);
         if (ret != SGX_SUCCESS) {
                 fprintf(stderr, "Failed to create Enclave: error %d\n", ret);
-				return -1;
+				exit(EXIT_FAILURE);
         }
 
         return id;
@@ -119,6 +119,10 @@ int ra_tls_send(int sockfd, const void *bufsnd, size_t sz_bufsnd, void *bufrcv, 
 	assert(SSL_SUCCESS == ret);
 #endif
 
+#ifdef LA_REPORT
+	g_eid = load_enclave();
+#endif
+
 	wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, cert_verify_callback);
 
 	WOLFSSL *ssl = wolfSSL_new(ctx);
@@ -152,8 +156,6 @@ int ra_tls_send(int sockfd, const void *bufsnd, size_t sz_bufsnd, void *bufrcv, 
         la_get_report_from_cert(der, derSz, &report);
         body = &report.body;
         printf("Local report verification\n");
-
-        g_eid = load_enclave();
 #else
 	uint8_t quote_buff[8192] = {0,};
 	get_quote_from_cert(der, derSz, (sgx_quote_t*)quote_buff);


### PR DESCRIPTION
Fix the conditional compilation failure in cgo and advance the
creation of enclave before the TLS handshake.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>