### PR TITLE
CI/CD: use yum to replace rpm to install the sgxsdk and dcap in the compile-check images

### DIFF
--- a/.github/workflows/docker/Dockerfile-compile-check-centos8.1
+++ b/.github/workflows/docker/Dockerfile-compile-check-centos8.1
@@ -5,7 +5,7 @@ LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 RUN dnf clean all && rm -r /var/cache/dnf && \
     dnf --enablerepo=PowerTools install -y which wget git \
     make gcc gcc-c++ libseccomp-devel binutils-devel protobuf \
-    protobuf-devel protobuf-c-devel openssl openssl-devel
+    protobuf-devel protobuf-c-devel openssl openssl-devel yum-utils
 
 WORKDIR /root
 
@@ -21,6 +21,11 @@ ENV PATH         $PATH:$GOROOT/bin:$GOPATH/bin
 ENV GOPROXY      "https://mirrors.aliyun.com/goproxy,direct"
 ENV GO111MODULE  on
 
-# install dcap
-RUN wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/centos8.2-server/sgx_rpm_local_repo.tgz && \
-    tar -zxvf sgx_rpm_local_repo.tgz && rm sgx_rpm_local_repo.tgz && cd sgx_rpm_local_repo && rpm -ivh libsgx-headers*.rpm libsgx-dcap-quote-verify*.rpm && rm -rf sgx_rpm_local_repo
+# install SGX
+RUN [ ! -f sgx_rpm_local_repo.tgz ] && \
+    wget -c https://download.01.org/intel-sgx/latest/linux-latest/distro/centos8.2-server/sgx_rpm_local_repo.tgz && \
+    tar xzf sgx_rpm_local_repo.tgz && \
+    yum-config-manager --add-repo sgx_rpm_local_repo && \
+    yum makecache && rm sgx_rpm_local_repo.tgz
+
+RUN yum install --nogpgcheck -y libsgx-dcap-quote-verify-devel


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>