### PR TITLE
epm/dist/deb/postrm && postinst: fix the systemctl not found in ubuntu containers

### DIFF
--- a/epm/dist/deb/debian/postinst
+++ b/epm/dist/deb/debian/postinst
@@ -15,27 +15,6 @@ db_timeout = 10
   max_recv_message_size = 16777216
   max_send_message_size = 16777216
 EOF
-cat << EOF > /etc/systemd/system/epm.service
-[Unit]
-Description=epm
-Documentation=https://inclavare-containers.io
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/epm --config /etc/epm/config.toml --stderrthreshold=0
-Restart=always
-RestartSec=5
-Delegate=yes
-KillMode=process
-OOMScoreAdjust=-999
-LimitNOFILE=1048576
-LimitNPROC=infinity
-LimitCORE=infinity
-
-[Install]
-WantedBy=multi-user.target
-EOF
 
 mkdir -p /var/local/epm
-systemctl enable epm
-systemctl start epm
+/usr/local/bin/epm --config /etc/epm/config.toml --stderrthreshold=0 &

--- a/epm/dist/deb/debian/postrm
+++ b/epm/dist/deb/debian/postrm
@@ -2,5 +2,4 @@
 
 EPM_CONFIG_DIR=/etc/epm
 rm -f $EPM_CONFIG_DIR/config.toml
-systemctl disable epm
-systemctl stop epm
+kill $(pgrep -x epm)


### PR DESCRIPTION
Fixes: #679
Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com