### PR TITLE
CI/CD: adapte to occlum 0.21.0 with centos8.2 and ubuntu 18.04

### DIFF
--- a/.github/workflows/commit_crictl.yml
+++ b/.github/workflows/commit_crictl.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Create container
       run: |
         if [ '${{ matrix.sgx }}' = '[self-hosted, SGX1]' ]; then
-          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/isgx -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.1)
+          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/isgx -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.2)
         else
-          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.1)
+          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.2)
         fi;
         echo "rune_test=$rune_test" >> $GITHUB_ENV
 

--- a/.github/workflows/commit_epm.yml
+++ b/.github/workflows/commit_epm.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, SGX2]
     strategy:
       matrix:
-        tag: [ubuntu18.04, centos8.1]
+        tag: [ubuntu18.04, centos8.2]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/commit_occlum.yml
+++ b/.github/workflows/commit_occlum.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         sgx: [[self-hosted, SGX1], [self-hosted, SGX2]]
-        tag: [ubuntu18.04, centos8.1]
+        tag: [ubuntu18.04, centos8.2]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/commit_shelter.yml
+++ b/.github/workflows/commit_shelter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, SGX1]
     strategy:
       matrix:
-        tag: [ubuntu18.04, centos8.1]
+        tag: [ubuntu18.04, centos8.2]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/commit_skeleton.yml
+++ b/.github/workflows/commit_skeleton.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         sgx: [[self-hosted, SGX1], [self-hosted, SGX2]]
-        tag: [ubuntu18.04, centos8.1]
+        tag: [ubuntu18.04, centos8.2]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/docker/Dockerfile-centos8.2
+++ b/.github/workflows/docker/Dockerfile-centos8.2
@@ -1,6 +1,6 @@
-FROM inclavarecontainers/test:crictl-bin-centos8.1 AS crictl-src
+FROM inclavarecontainers/test:crictl-bin-centos8.2 AS crictl-src
 
-FROM occlum/occlum:OCCLUM_VERSION-centos8.1
+FROM occlum/occlum:OCCLUM_VERSION-centos8.2
 
 LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 
@@ -33,7 +33,7 @@ COPY hello_world.c                                          /root
 # install docker-ce
 RUN yum install -y yum-utils device-mapper-persistent-data lvm2 && \
     yum-config-manager --add-repo http://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo && \
-    yum -y install docker-ce-18.03.0.ce
+    yum makecache && yum -y install docker-ce
 
 # configure docker
 RUN mkdir -p /etc/docker && \

--- a/.github/workflows/docker/Dockerfile-ubuntu18.04
+++ b/.github/workflows/docker/Dockerfile-ubuntu18.04
@@ -29,13 +29,10 @@ COPY hello_world.c                                          /root
 # install docker-ce
 RUN apt-get install -y apt-transport-https ca-certificates curl software-properties-common && \
     curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository 'deb [arch=amd64] https://mirrors.aliyun.com/docker-ce/linux/ubuntu bionic stable' && \
+    add-apt-repository 'deb [arch=amd64] https://mirrors.ustc.edu.cn/docker-ce/linux/ubuntu bionic stable' && \
     apt-get update && apt-get install -y docker-ce
 
 
 # configure docker
 RUN mkdir -p /etc/docker && \
     echo "{\n\t\"runtimes\": {\n\t\t\"rune\": {\n\t\t\t\"path\": \"/usr/local/bin/rune\",\n\t\t\t\"runtimeArgs\": []\n\t\t}\n\t},\n\t\"storage-driver\": \"vfs\"\n}" >> /etc/docker/daemon.json
-
-# configure sgxsdk 2.11 and dcap 1.8
-RUN [ ! -e /usr/include/sgx_attributes.h ] && ln -sfn /opt/intel/sgxsdk/include/sgx_attributes.h /usr/include/sgx_attributes.h

--- a/.github/workflows/manually_centos_test_image.yml
+++ b/.github/workflows/manually_centos_test_image.yml
@@ -18,13 +18,13 @@ jobs:
 
       - name: Build images
         run: cd $GITHUB_WORKSPACE/.github/workflows/docker;
-          sed -i "s/OCCLUM_VERSION/${{ github.event.inputs.occlum_version }}/" Dockerfile-centos8.1;
-          docker build . -t crictl-centos8.1 -f Dockerfile-centos8.1
+          sed -i "s/OCCLUM_VERSION/${{ github.event.inputs.occlum_version }}/" Dockerfile-centos8.2;
+          docker build . -t crictl-centos8.2 -f Dockerfile-centos8.2;
 
       # Dockerfile doesn't support start up containerd
       - name: Download various images in advance to speed up testing
         run: |
-          docker run -itd --privileged --name=centos crictl-centos8.1;
+          docker run -itd --privileged --name=centos crictl-centos8.2;
           docker exec centos bash -c "containerd" &
           docker exec centos bash -c "crictl pull registry.cn-hangzhou.aliyuncs.com/acs/pause-amd64:3.1;
           crictl pull docker.io/inclavarecontainers/occlum-hello-world:scratch;
@@ -32,8 +32,8 @@ jobs:
           crictl pull docker.io/inclavarecontainers/occlum-java-web:scratch;
           crictl pull docker.io/inclavarecontainers/occlum-golang-web:0.16.0-scratch"
           docker exec centos bash -c "pkill -9 containerd"
-          docker commit centos inclavarecontainers/test:centos8.1-occlum-${{ github.event.inputs.occlum_version }}
+          docker commit centos inclavarecontainers/test:centos8.2-occlum-${{ github.event.inputs.occlum_version }}
 
       - name: Push crictl image to Dockerhub
         run: docker login -p ${{ secrets.DOCKER_PASSWORD }} -u ${{ secrets.DOCKER_USERNAME }};
-          docker push inclavarecontainers/test:centos8.1-occlum-${{ github.event.inputs.occlum_version }}
+          docker push inclavarecontainers/test:centos8.2-occlum-${{ github.event.inputs.occlum_version }}

--- a/.github/workflows/manually_repository_setup.yml
+++ b/.github/workflows/manually_repository_setup.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create centos container
       run: |
         docker rm -f make-rpm || true;
-        docker run -itd --name=make-rpm -v $GITHUB_WORKSPACE:/root/inclavare-containers -v /root/repos:/root/repos rune-test:centos8.1
+        docker run -itd --name=make-rpm -v $GITHUB_WORKSPACE:/root/inclavare-containers -v /root/repos:/root/repos rune-test:centos8.2
 
     - name: Build rpm packages
       run: docker exec make-rpm bash -c "cp -r inclavare-containers inclavare-containers-$RUNE_VERSION;
@@ -111,7 +111,7 @@ jobs:
         apt-get install -y rune"
 
     - name: Create a clean centos container
-      run: docker run -itd --name=test-rpm centos:centos8.1.1911
+      run: docker run -itd --name=test-rpm centos:8.2.2004
 
     - name: Test rpm repository
       run: |


### PR DESCRIPTION
Update test images to occlum 0.21.0:centos8.2 and occlum 0.21.0:ubuntu 18.04. In addition, update the install method of docker to adapt new images.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>