### PR TITLE
CI/CD: update sgx DCAP driver to version 1.41

### DIFF
--- a/.github/workflows/commit_crictl.yml
+++ b/.github/workflows/commit_crictl.yml
@@ -26,7 +26,7 @@ jobs:
         if [ '${{ matrix.sgx }}' = '[self-hosted, SGX1]' ]; then
           rune_test=$(docker run -itd --privileged --rm --net host --device /dev/isgx -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.2)
         else
-          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.2)
+          rune_test=$(docker run -itd --privileged --rm --net host -v /dev/sgx_enclave:/dev/sgx/enclave -v /dev/sgx_provision:/dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:centos8.2)
         fi;
         echo "rune_test=$rune_test" >> $GITHUB_ENV
 

--- a/.github/workflows/commit_epm.yml
+++ b/.github/workflows/commit_epm.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Create container
       run: |
-        rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }});
+        rune_test=$(docker run -itd --privileged --rm --net host -v /dev/sgx_enclave:/dev/sgx/enclave -v /dev/sgx_provision:/dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }});
         echo "rune_test=$rune_test" >> $GITHUB_ENV
 
     - name: Build install packages and run epm service

--- a/.github/workflows/commit_occlum.yml
+++ b/.github/workflows/commit_occlum.yml
@@ -26,7 +26,7 @@ jobs:
         if [ '${{ matrix.sgx }}' = '[self-hosted, SGX1]' ]; then
           rune_test=$(docker run -itd --privileged --rm --net host --device /dev/isgx -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
         else
-          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
+          rune_test=$(docker run -itd --privileged --rm --net host -v /dev/sgx_enclave:/dev/sgx/enclave -v /dev/sgx_provision:/dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
         fi;
         echo "rune_test=$rune_test" >> $GITHUB_ENV
 

--- a/.github/workflows/commit_skeleton.yml
+++ b/.github/workflows/commit_skeleton.yml
@@ -26,7 +26,7 @@ jobs:
         if [ '${{ matrix.sgx }}' = '[self-hosted, SGX1]' ]; then
           rune_test=$(docker run -itd --privileged --rm --net host --device /dev/isgx -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
         else
-          rune_test=$(docker run -itd --privileged --rm --net host --device /dev/sgx/enclave --device /dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
+          rune_test=$(docker run -itd --privileged --rm --net host -v /dev/sgx_enclave:/dev/sgx/enclave -v /dev/sgx_provision:/dev/sgx/provision -v $GITHUB_WORKSPACE:/root/inclavare-containers rune-test:${{ matrix.tag }})
         fi;
         echo "rune_test=$rune_test" >> $GITHUB_ENV
 


### PR DESCRIPTION
Current CI/CD uses `sgxsdk 2.13` and `DCAP 1.10` which is corresponding to
version `1.41 DCAP driver`. In the [1.41 DCAP
driver](https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/DCAP_1.10/driver/linux/driver.c),
the `.nodename` of `struct miscdevice sgx_dev_enclave` and `struct miscdevice sgx_dev_provision`
are `sgx_enclave` and `sgx_provision` rather than `sgx/enclave` and `sgx/provision`.

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com