### PR TITLE
CI/CD: add rm -rf /var/run/epm in the nightly test

### DIFF
--- a/.github/workflows/nightly-centos-sgx1.yml
+++ b/.github/workflows/nightly-centos-sgx1.yml
@@ -44,10 +44,11 @@ jobs:
         sudo rm -fr /etc/inclavare-containers/
         sudo rm -rf ~/.kube/
         sudo rm -rf /etc/kubernetes
-        sudo rm -fr /etc/epm
         sudo rm -fr /var/lib/etcd
         sudo rm -f /etc/yum.repos.d/occlum.repo
         sudo rm -f /etc/yum.repos.d/kubernetes.repo
+        sudo rm -fr /etc/epm
+        sudo rm -fr /var/run/epm
         sudo rm -fr /var/local/epm
         sudo ip link set cni0 down || true
         sudo ip link delete cni0 || true
@@ -433,10 +434,11 @@ jobs:
         sudo rm -fr /etc/inclavare-containers/
         sudo rm -rf ~/.kube/
         sudo rm -rf /etc/kubernetes
-        sudo rm -fr /etc/epm
         sudo rm -fr /var/lib/etcd
         sudo rm -f /etc/yum.repos.d/occlum.repo
         sudo rm -f /etc/yum.repos.d/kubernetes.repo
+        sudo rm -fr /etc/epm
+        sudo rm -fr /var/run/epm
         sudo rm -fr /var/local/epm
         sudo ip link set cni0 down || true
         sudo ip link delete cni0 || true

--- a/.github/workflows/nightly-ubuntu-sgx1.yml
+++ b/.github/workflows/nightly-ubuntu-sgx1.yml
@@ -78,9 +78,10 @@ jobs:
           sudo rm -fr /etc/inclavare-containers/
           sudo rm -rf ~/.kube/
           sudo rm -rf /etc/kubernetes
-          sudo rm -fr /etc/epm
           sudo rm -fr /var/lib/etcd
           sudo rm -fr /usr/bin/go
+          sudo rm -fr /etc/epm
+          sudo rm -fr /var/run/epm
           sudo rm -fr /var/local/epm
           sudo ip link set cni0 down || true
           sudo ip link delete cni0 || true
@@ -502,9 +503,10 @@ jobs:
           sudo rm -fr /etc/inclavare-containers/
           sudo rm -rf ~/.kube/
           sudo rm -rf /etc/kubernetes
-          sudo rm -fr /etc/epm
           sudo rm -fr /var/lib/etcd
           sudo rm -fr /usr/bin/go
+          sudo rm -fr /etc/epm
+          sudo rm -fr /var/run/epm
           sudo rm -fr /var/local/epm
           sudo ip link set cni0 down || true
           sudo ip link delete cni0 || true


### PR DESCRIPTION
There are two reasons to remove /var/run/epm:
- epm deb and rpm package will mkdir /var/run/epm automatically.
- the default centos 8.2 and ubuntu 18.04 don't have a /var/run/epm directory any more.

Fixes: #690
Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com