### PR TITLE
rune && sgx-tools: update dependency in README.md, rpm spec, and deb control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git clone https://github.com/alibaba/inclavare-containers
 - `libseccomp`.
 - [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives): please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
 	- libsgx-dcap-quote-verify: both for centos and ubuntu
-	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devev(centos)
+	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 3. Build Inclavare Containers
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ git clone https://github.com/alibaba/inclavare-containers
 - Go version 1.14 or higher.
 - `libseccomp`.
 - [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives): please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
-	- libsgx-dcap-quote-verify: both for centos and ubuntu
 	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 3. Build Inclavare Containers

--- a/rune/README.md
+++ b/rune/README.md
@@ -10,7 +10,7 @@ Additionally, `rune` by default enables seccomp support as [runc](https://github
 
 Besides, `rune` depends on [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives). Please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
 - libsgx-dcap-quote-verify: both for centos and ubuntu
-- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devev(centos)
+- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 ```bash
 # create $WORKSPACE folder

--- a/rune/README.md
+++ b/rune/README.md
@@ -9,7 +9,6 @@
 Additionally, `rune` by default enables seccomp support as [runc](https://github.com/opencontainers/runc#building) so you need to install libseccomp on your platform.
 
 Besides, `rune` depends on [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives). Please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
-- libsgx-dcap-quote-verify: both for centos and ubuntu
 - libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 ```bash

--- a/rune/dist/deb/debian/control
+++ b/rune/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: rune
 Section: devel
 Priority: extra
 Maintainer: shirong <shirong@linux.alibaba.com>
-Build-Depends: debhelper (>=9), libseccomp-dev, libsgx-dcap-quote-verify, libsgx-dcap-quote-verify-dev
+Build-Depends: debhelper (>=9), libseccomp-dev, libsgx-dcap-quote-verify-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/rune/dist/rpm/rune.spec
+++ b/rune/dist/rpm/rune.spec
@@ -15,7 +15,6 @@ URL: https://github.com/alibaba/%{PROJECT}
 Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
 
 BuildRequires: libseccomp-devel
-BuildRequires: libsgx-dcap-quote-verify
 BuildRequires: libsgx-dcap-quote-verify-devel
 ExclusiveArch: x86_64
 

--- a/sgx-tools/README.md
+++ b/sgx-tools/README.md
@@ -31,7 +31,6 @@
 
 - golang 1.14 or above.
 - [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives): please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
-	- libsgx-dcap-quote-verify: both for centos and ubuntu
 	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 ## Build

--- a/sgx-tools/README.md
+++ b/sgx-tools/README.md
@@ -32,7 +32,7 @@
 - golang 1.14 or above.
 - [SGX DCAP](https://github.com/intel/SGXDataCenterAttestationPrimitives): please download and install the rpm(centos) or deb(ubuntu) from "https://download.01.org/intel-sgx/sgx-dcap/#version#linux/distro"
 	- libsgx-dcap-quote-verify: both for centos and ubuntu
-	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devev(centos)
+	- libsgx-dcap-quote-verify-dev(ubuntu) or libsgx-dcap-quote-verify-devel(centos)
 
 ## Build
 

--- a/sgx-tools/dist/deb/debian/control
+++ b/sgx-tools/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: sgx-tools
 Section: devel
 Priority: extra
 Maintainer: shirong <shirong@linux.alibaba.com>
-Build-Depends: debhelper (>=9), libsgx-dcap-quote-verify, libsgx-dcap-quote-verify-dev
+Build-Depends: debhelper (>=9), libsgx-dcap-quote-verify-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/sgx-tools/dist/rpm/sgx-tools.spec
+++ b/sgx-tools/dist/rpm/sgx-tools.spec
@@ -14,7 +14,6 @@ License: Apache License 2.0
 URL: https://github.com/alibaba/%{PROJECT}
 Source0: https://github.com/alibaba/%{PROJECT}/archive/v%{version}.tar.gz
 
-BuildRequires: libsgx-dcap-quote-verify
 BuildRequires: libsgx-dcap-quote-verify-devel
 ExclusiveArch: x86_64
 


### PR DESCRIPTION
1. rune && sgx-tools: fix a spelling error in README.md.
2. rune/dist && sgx-tools/dist: remove the indirect libsgx-dcap-quote-verify dependency.
3. rune && sgx-tools: remove the indirect libsgx-dcap-quote-verify dependency in README.md.

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com