### PR TITLE
rune: fix unable to mount sgx device pointing to the relative path

### DIFF
--- a/rune/libenclave/check.go
+++ b/rune/libenclave/check.go
@@ -3,6 +3,7 @@ package libenclave // import "github.com/inclavare-containers/rune/libenclave"
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	enclaveConfigs "github.com/inclavare-containers/rune/libenclave/configs"
@@ -87,7 +88,7 @@ func enclaveMiscDev(device *configs.Device) (*configs.Device, error) {
 	var path string
 	var err error
 	if device.Type == 'l' {
-		path, err = os.Readlink(device.Path)
+		path, err = filepath.EvalSymlinks(device.Path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>