### PR TITLE
enclave-tls: implement enclave tls server application in Occlum

### DIFF
--- a/enclave-tls/samples/enclave-tls-client/client.c
+++ b/enclave-tls/samples/enclave-tls-client/client.c
@@ -10,7 +10,9 @@
 
 #define DEFAULT_PORT 1234
 
-#ifndef OCCLUM
+#ifdef OCCLUM
+#include <sgx_report.h>
+#else
 #include <sgx_urts.h>
 #include <sgx_quote.h>
 


### PR DESCRIPTION
The enclave-tls server in Occlum will transmit mrencalve and mrsigner
value of enclave to inclavared. The buff[0:31] is mrencalve value,
buff[32:63] is mrsigner value.

Fixes: #651
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>