### PR TITLE
rune/libenclave/epm: add support for sgx kernel driver upstreamed

### DIFF
--- a/rune/libenclave/epm/procmaps.go
+++ b/rune/libenclave/epm/procmaps.go
@@ -11,8 +11,10 @@ import (
  * info correctly by this kind of pathname.
  */
 const (
-	EnclavePath     = "/dev/sgx/enclave"
-	EnclavePathPool = "/sgx/enclave"
+	EnclavePath        = "/dev/sgx/enclave"
+	EnclaveNewPath     = "/dev/sgx_enclave"
+	EnclavePathPool    = "/sgx/enclave"
+	EnclaveNewPathPool = "/sgx_enclave"
 )
 
 func GetEnclProcMaps(pid int) ([]*procfs.ProcMap, error) {
@@ -35,7 +37,7 @@ func GetEnclProcMaps(pid int) ([]*procfs.ProcMap, error) {
 
 	for idx := range maps {
 		pathname := maps[idx].Pathname
-		if pathname == EnclavePath || pathname == EnclavePathPool {
+		if pathname == EnclavePath || pathname == EnclavePathPool || pathname == EnclaveNewPath || pathname == EnclaveNewPathPool {
 			enclprocmaps = append(enclprocmaps, maps[idx])
 		}
 	}
@@ -60,7 +62,7 @@ func GetEnclaveFd(pid int) (int, error) {
 	}
 
 	for fd, n := range names {
-		if n == EnclavePath || n == EnclavePathPool {
+		if n == EnclavePath || n == EnclavePathPool || pathname == EnclaveNewPath || pathname == EnclaveNewPathPool {
 			return int(fd), err
 		}
 	}


### PR DESCRIPTION
SGX device node has been changed from /dev/sgx/enclave to /dev/sgx_enclave.
This implementation matches with this change.

Fixes: #638
Signed-off-by: Liang Yang <liang3.yang@intel.com>