### PR TITLE
rune/libenclave/epm: fix a typo about pathname of SGX device node

### DIFF
--- a/rune/libenclave/epm/procmaps.go
+++ b/rune/libenclave/epm/procmaps.go
@@ -62,7 +62,7 @@ func GetEnclaveFd(pid int) (int, error) {
 	}
 
 	for fd, n := range names {
-		if n == EnclavePath || n == EnclavePathPool || pathname == EnclaveNewPath || pathname == EnclaveNewPathPool {
+		if n == EnclavePath || n == EnclavePathPool || n == EnclaveNewPath || n == EnclaveNewPathPool {
 			return int(fd), err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Liang Yang <liang3.yang@intel.com>