### PR TITLE
enclave-tls: add -std=c99 CFLAGS to fix gcc 4.8.5 compile error in alinux2

### DIFF
--- a/enclave-tls/samples/enclave-tls-client/Makefile
+++ b/enclave-tls/samples/enclave-tls-client/Makefile
@@ -8,7 +8,7 @@ include $(Topdir)/rules/build_env.mk
 
 Targets := $(Build_Bindir)/enclave-tls-client
 
-C_FLAGS += -pie -fPIE -I$(Topdir)/src/include
+C_FLAGS += -pie -fPIE -I$(Topdir)/src/include -std=c99
 CLIENT_LDFLAGS := \
   -L$(Topdir)/build/lib -lenclave_tls \
   -Wl,--rpath=/opt/enclave-tls/lib,--enable-new-dtags


### PR DESCRIPTION
The patch fixes the error "cc -pie -fPIE
-I/root/rpmbuild-rune/SOURCES/inclavare-containers-0.6.1/enclave-tls/src/include
client.c -o
/root/rpmbuild-rune/SOURCES/inclavare-containers-0.6.1/enclave-tls/build/bin/enclave-tls-client
-L/root/rpmbuild-rune/SOURCES/inclavare-containers-0.6.1/enclave-tls/build/lib
-lenclave_tls -Wl,--rpath=/opt/enclave-tls/lib,--enable-new-dtags
-lsgx_urts -lm
client.c: In function ‘enclave_tls_echo’:
client.c:102:3: error: ‘for’ loop initial declarations are only allowed
in C99 mode
   for (int i = 0; i < 32; ++i)
   ^
client.c:102:3: note: use option -std=c99 or -std=gnu99 to compile your
code
client.c:106:12: error: redefinition of ‘i’
   for (int i = 32; i < 64; ++i)
            ^
client.c:102:12: note: previous definition of ‘i’ was here
   for (int i = 0; i < 32; ++i)
            ^
client.c:106:3: error: ‘for’ loop initial declarations are only allowed
in C99 mode
   for (int i = 32; i < 64; ++i)"

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com