### PR TITLE
enclave-tls: change sgx local attestation's verification mode

### DIFF
--- a/enclave-tls/src/enclave_quotes/sgx-la/ecalls.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/ecalls.c
@@ -3,41 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
-#include <enclave-tls/enclave_quote.h>
-#include "sgx_report.h"
-#include "sgx_stub_t.h"
-#include "sgx_utils.h"
-
-sgx_status_t ecall_sgx_la_collect_evidence(attestation_evidence_t *evidence,
-					   uint8_t *hash)
-{
-	sgx_status_t status;
-	sgx_report_t report;
-	sgx_target_info_t target_info;
-	sgx_report_data_t report_data = { 0, };
-
-	memcpy(report_data.d, hash, sizeof(hash));
-
-	status = sgx_self_target(&target_info);
-	if (status != SGX_SUCCESS)
-		return status;
-
-	status = sgx_create_report(&target_info, &report_data, &report);
-	if (status != SGX_SUCCESS)
-		return status;
-
-	memcpy(evidence->la.report, &report, sizeof(report));
-	evidence->la.report_len = sizeof(report);
-
-	return SGX_SUCCESS;
+/* This function only exists to make edger8r happy. There must be at
+   least one trusted (ECALL) function. */
+void dummy(void) {
 }
 
-sgx_status_t ecall_sgx_la_verify_report(sgx_report_t *report)
-{
-	sgx_report_t report_t;
-	memcpy(&report_t, report, sizeof(sgx_report_t));
-	sgx_status_t status = sgx_verify_report(&report_t);
-
-	return status;
-}

--- a/enclave-tls/src/enclave_quotes/sgx-la/sgx_la.edl
+++ b/enclave-tls/src/enclave_quotes/sgx-la/sgx_la.edl
@@ -1,10 +1,5 @@
 enclave {
-    include "enclave-tls/err.h"
-    include "enclave-tls/tls_wrapper.h"
-    include "sgx_report.h"
-
-    trusted {
-	public sgx_status_t ecall_sgx_la_collect_evidence([user_check] attestation_evidence_t *evidence,
-                [user_check] uint8_t *hash);
-    };
+	trusted {
+		 public void dummy(void);
+	};
 };

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/wolfssl_sgx.edl
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/wolfssl_sgx.edl
@@ -23,14 +23,10 @@ enclave {
 							       [user_check] void *buf,
 							       [user_check] size_t *buf_size);
 		public tls_wrapper_err_t ecall_wolfssl_cleanup([user_check] tls_wrapper_ctx_t *ctx);
-
-		/* This ecall function need be invoked by ocall_verify_certificate */
-		public sgx_status_t ecall_sgx_la_verify_report([in] sgx_report_t *report);
 	};
 
 	untrusted {
-		int ocall_verify_certificate([in, out, size=der_crt_len] uint8_t *der_crt, uint32_t der_crt_len)
-			allow (ecall_sgx_la_verify_report);
+		int ocall_verify_certificate([in, out, size=der_crt_len] uint8_t *der_crt, uint32_t der_crt_len);
 		size_t ocall_recv(int sockfd, [out, size=len] void *buf, size_t len,
 				  int flags) propagate_errno;
 		size_t ocall_send(int sockfd, [in, size=len] const void *buf, size_t len,


### PR DESCRIPTION
Getting App enclave's local report taking QE's target info as parameter,
verifier can verify the report from attester by sgx_qe_get_quote indirectly.

Fixes: #813
Signed-off-by: Liang Yang <liang3.yang@intel.com>