### PR TITLE
workflows/docker: change to use the Alibaba Cloud teesdk and protobuf 2.5.0 in the alinux2 compilation test dockerfile

### DIFF
--- a/.github/workflows/docker/Dockerfile-compilation-testing-alinux2
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-alinux2
@@ -6,10 +6,12 @@ LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 # the issue "Error: Package: glibc-2.17-323.1.al7.i686 (updates)"
 RUN yum install -y alinux-release-experimentals
 
+ENV PROTOBUF_VERSION 2.5.0
+
 RUN yum install -y \
     which wget git make autoconf libtool openssl yum-utils \
-    libseccomp-devel binutils-devel protobuf-devel protobuf-c-devel openssl-devel \
-    devtoolset-9-toolchain
+    libseccomp-devel binutils-devel openssl-devel devtoolset-9-toolchain \
+    protobuf-devel-$PROTOBUF_VERSION protobuf-c-devel-$PROTOBUF_VERSION
 
 RUN echo "source /opt/rh/devtoolset-9/enable" > /root/.bashrc
 
@@ -27,14 +29,19 @@ ENV PATH         $PATH:$GOROOT/bin:$GOPATH/bin
 ENV GOPROXY      "https://mirrors.aliyun.com/goproxy,direct"
 ENV GO111MODULE  on
 
-# install SGX
-RUN wget https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_linux_x64_sdk_2.13.100.4.bin && \
-    chmod +x sgx_linux_x64_sdk_2.13.100.4.bin && echo -e 'no\n/opt/intel\n' | ./sgx_linux_x64_sdk_2.13.100.4.bin && \
-    rm -rf sgx_linux_x64_sdk_2.13.100.4.bin
+# Configure Alibaba Cloud TEE SDK yum repo
+RUN yum-config-manager --add-repo \
+	https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo
 
-RUN wget https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz && \
-    tar xzf sgx_rpm_local_repo.tar.gz && \
-    yum-config-manager --add-repo file:/root/sgx_rpm_local_repo && \
-    yum makecache && rm -rf sgx_rpm_local_repo.tar.gz
+# Install SGX Runtime
+RUN yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+    libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+    libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+    libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+    libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+    sgx-aesm-service
 
-RUN yum install --nogpgcheck -y libsgx-dcap-quote-verify-devel libsgx-dcap-ql-devel libsgx-uae-service
+# Install Alibaba Cloud TEE SDK
+RUN yum install --nogpgcheck -y teesdk
+
+RUN echo "source /opt/alibaba/teesdk/intel/sgxsdk/environment" >> /root/.bashrc


### PR DESCRIPTION
Alibaba Cloud teesdk(https://help.aliyun.com/document_detail/208095.html) is owned by
Alibaba Cloud and supports the Alibaba Cloud Linux 2 OS image, so we change to use the
Alibaba Cloud teesdk and protobuf 2.5.0 in the Alibaba Cloud Linux 2 compilation test dockerfile.

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com