### PR TITLE
enclave-tls: set the debug flag used in sgx_create_enclave() in smart  way

### DIFF
--- a/enclave-tls/README.md
+++ b/enclave-tls/README.md
@@ -79,6 +79,7 @@ OPTIONS:
    --log-level/-l        set the log level
    --ip/-i               set the listening ip address
    --port/-p             set the listening tcp port
+   --debug-enclave/-D    set to enable enclave debugging
 ```
 
 You can set command line parameters to specify different configurations.

--- a/enclave-tls/samples/enclave-tls-server/server.c
+++ b/enclave-tls/samples/enclave-tls-server/server.c
@@ -29,7 +29,7 @@
 
 #define ENCLAVE_FILENAME     "sgx_stub_enclave.signed.so"
 
-static sgx_enclave_id_t load_enclave(void)
+static sgx_enclave_id_t load_enclave(bool debug_enclave)
 {
 	sgx_launch_token_t t;
 
@@ -37,7 +37,7 @@ static sgx_enclave_id_t load_enclave(void)
 
 	sgx_enclave_id_t eid;
 	int updated = 0;
-	int ret = sgx_create_enclave(ENCLAVE_FILENAME, 1, &t, &updated, &eid, NULL);
+	int ret = sgx_create_enclave(ENCLAVE_FILENAME, debug_enclave, &t, &updated, &eid, NULL);
 	if (ret != SGX_SUCCESS) {
 		ETLS_ERR("Failed to load enclave %d\n", ret);
 		return -1;
@@ -94,7 +94,8 @@ static int sgx_create_report(sgx_report_t *report)
 
 int enclave_tls_server_startup(int sockfd, enclave_tls_log_level_t log_level,
 			       char *attester_type, char *verifier_type,
-			       char *tls_type, char *crypto_type, bool mutual)
+			       char *tls_type, char *crypto_type, bool mutual,
+			       bool debug_enclave)
 {
 	enclave_tls_conf_t conf;
 
@@ -105,7 +106,7 @@ int enclave_tls_server_startup(int sockfd, enclave_tls_log_level_t log_level,
 	strcpy(conf.tls_type, tls_type);
 	strcpy(conf.crypto_type, crypto_type);
 #ifdef SGX
-	conf.enclave_id = load_enclave();
+	conf.enclave_id = load_enclave(debug_enclave);
 #endif
 	conf.flags |= ENCLAVE_TLS_CONF_FLAGS_SERVER;
 	if (mutual)
@@ -190,7 +191,7 @@ int main(int argc, char **argv)
 {
 	printf("    - Welcome to Enclave-TLS sample server program\n");
 
-	char *const short_options = "a:v:t:c:ml:i:p:";
+	char *const short_options = "a:v:t:c:ml:i:p:D";
 	struct option long_options[] = {
 		{"attester", required_argument, NULL, 'a'},
 		{"verifier", required_argument, NULL, 'v'},
@@ -200,6 +201,7 @@ int main(int argc, char **argv)
 		{"log-level", required_argument, NULL, 'l'},
 		{"ip", required_argument, NULL, 'i'},
 		{"port", required_argument, NULL, 'p'},
+		{"debug-enclave", no_argument, NULL, 'D'},
 		{0, 0, 0, 0}
 	};
 
@@ -211,6 +213,7 @@ int main(int argc, char **argv)
 	enclave_tls_log_level_t log_level = ENCLAVE_TLS_LOG_LEVEL_INFO;
 	char *ip = DEFAULT_IP;
 	int port = DEFAULT_PORT;
+	bool debug_enclave = false;
 	int opt;
 
 	do {
@@ -251,6 +254,9 @@ int main(int argc, char **argv)
 			break;
 		case 'p':
 			port = atoi(optarg);
+			break;
+		case 'D':
+			debug_enclave = true;
 			break;
 		case -1:
 			break;
@@ -293,5 +299,5 @@ int main(int argc, char **argv)
 
 	return enclave_tls_server_startup(sockfd, log_level,
 					  attester_type, verifier_type,
-					  tls_type, crypto_type, mutual);
+					  tls_type, crypto_type, mutual, debug_enclave);
 }


### PR DESCRIPTION
Fixes: #547
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>