### PR TITLE
CI/CD: Minor fixes

### DIFF
--- a/.github/workflows/docker/Dockerfile-compilation-testing-alinux2
+++ b/.github/workflows/docker/Dockerfile-compilation-testing-alinux2
@@ -7,11 +7,12 @@ LABEL maintainer="Shirong Hao <shirong@linux.alibaba.com>"
 RUN yum install -y alinux-release-experimentals
 
 ENV PROTOBUF_VERSION 2.5.0
+ENV PROTOBUF_C_VERSION 1.0.2
 
 RUN yum install -y \
     which wget git make autoconf libtool openssl yum-utils \
     libseccomp-devel binutils-devel openssl-devel devtoolset-9-toolchain \
-    protobuf-devel-$PROTOBUF_VERSION protobuf-c-devel-$PROTOBUF_VERSION
+    protobuf-devel-$PROTOBUF_VERSION protobuf-c-devel-$PROTOBUF_C_VERSION
 
 RUN echo "source /opt/rh/devtoolset-9/enable" > /root/.bashrc
 

--- a/.github/workflows/pr_basic_compilation_check.yml
+++ b/.github/workflows/pr_basic_compilation_check.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Compile "rune shim-rune sgx-tools epm pal"
         run:
-          make -j${CPU_NUM} && make install -j${CPU_NUM};
+          source /root/.bashrc && make -j${CPU_NUM} && make install -j${CPU_NUM};
           cd rune/libenclave/internal/runtime/pal/skeleton &&
             make -j${CPU_NUM} && ls liberpal-skeleton-v*.so;
           cd ../nitro_enclaves && make -j${CPU_NUM} && ls libpal_ne.so;


### PR DESCRIPTION
- workflows/docker: fix the protobuf-c-devel version error
      - The protobuf 2.5.0 corresponding protobuf-c-devel is 1.0.2
- CI/CD: add source /root/.bashrc in the compilation checks