### PR TITLE
shelter/Makefile: support SGX SDK installed in the non-standard path

### DIFF
--- a/shelter/Makefile
+++ b/shelter/Makefile
@@ -1,6 +1,6 @@
 CURRENTDIR := $(shell readlink -f .)
 TOPDIR := $(shell readlink -f ..)
-SGX_SDK := /opt/intel/sgxsdk
+SGX_SDK ?= /opt/intel/sgxsdk
 SGX_DCAP_INC ?=
 INCDIR ?=
 DEBUG ?= 0


### PR DESCRIPTION
SGX SDX can be installed in the standard patch(such as '/opt/intel/sgxsdk') and
can be also installed in the non-standard patch(such as
'/opt/alibaba/teesdk/intel/sgxsdk' in the Alibaba teesdk). So we use the
'?=' to replace the ':=' to support both the standard and non-standard
installed path.

Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com