### PR TITLE
skeleton/tls-server.c: fix the invalid response retrieved from enclave-tls server error

### DIFF
--- a/rune/libenclave/internal/runtime/pal/skeleton/tls-server.c
+++ b/rune/libenclave/internal/runtime/pal/skeleton/tls-server.c
@@ -14,7 +14,7 @@
 #include "tls-server.h"
 
 #define ENCLAVE_FILENAME "sgx_stub_enclave.signed.so"
-#define ENCLAVE_TLS_HELLO "Hello and welcome to enclave-tls!"
+#define ENCLAVE_TLS_HELLO "Hello and welcome to Enclave TLS!\n"
 
 extern sgx_status_t ecall_generate_evidence(sgx_enclave_id_t eid, sgx_status_t *retval, uint8_t *hash, sgx_report_t *report);
 


### PR DESCRIPTION
The ENCLAVE_TLS_HELLO string in the skeleton/tls-server.c should be
equal to the ENCLAVE_TLS_HELLO string in enclave-tls client and server.

Fixes: #895
Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com
Signed-off-by: Liang Yang <liang3.yang@intel.com>