### PR TITLE
shelter/README.md: fix the dependent go version error

### DIFF
--- a/shelter/README.md
+++ b/shelter/README.md
@@ -12,7 +12,7 @@ The verifying process is as below:
 
 ## Prerequisite
 
-Go 1.13.x or above.
+Go 1.14.x or above.
 
 ## Build
 


### PR DESCRIPTION
In the go.mod file of shelter, shelter depends on golang 1.14 or above.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>