### PR TITLE
shelter/remoteattestation: add -std=gnu11 CGO FLAGS to fix gcc 4.8.5 compile error in alinux2

### DIFF
--- a/shelter/remoteattestation/securitychannel.go
+++ b/shelter/remoteattestation/securitychannel.go
@@ -1,7 +1,7 @@
 package remoteattestation
 
 /*
-#cgo CFLAGS: -I/opt/enclave-tls/include
+#cgo CFLAGS: -I/opt/enclave-tls/include -std=gnu11
 #cgo LDFLAGS: -L/opt/enclave-tls/lib -lenclave_tls -Wl,-rpath,/opt/enclave-tls/lib -lm
 #include <enclave-tls/api.h>
 extern int ra_tls_echo(int, enclave_tls_log_level_t, char *, char *, char *, char *, bool);


### PR DESCRIPTION
The patch fixes the error "
CGO_ENABLED=1 go build "-mod=vendor" -buildmode=pie   -ldflags "" -o shelter .
ratlsclient.c: In function ‘ra_tls_echo’:
ratlsclient.c:67:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (int i = 0; i < 32; ++i)
   ^
ratlsclient.c:67:3: note: use option -std=c99 or -std=gnu99 to compile your code
ratlsclient.c:71:12: error: redefinition of ‘i’
   for (int i = 32; i < 64; ++i)
            ^
ratlsclient.c:67:12: note: previous definition of ‘i’ was here
   for (int i = 0; i < 32; ++i)
            ^
ratlsclient.c:71:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (int i = 32; i < 64; ++i)
   ^
make: *** [shelter] Error 2"

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>
Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>