### PR TITLE
enclave-tls/wolfssl: fix build warnings in wolfssl

### DIFF
--- a/enclave-tls/src/external/wolfssl/patch/wolfssl.patch
+++ b/enclave-tls/src/external/wolfssl/patch/wolfssl.patch
@@ -1,19 +1,21 @@
-From c8cfcd361f69c6571850562ef688c2023d799209 Mon Sep 17 00:00:00 2001
+From 7c15d5371cefd49e500571b61090598ccfd6c479 Mon Sep 17 00:00:00 2001
 From: Liang Yang <liang3.yang@intel.com>
-Date: Fri, 19 Feb 2021 19:46:31 +0800
+Date: Tue, 11 May 2021 08:36:24 +0800
 Subject: [PATCH v1] wolfssl-sgx patch
 
+Signed-off-by: Liang Yang <liang3.yang@intel.com>
 ---
  IDE/LINUX-SGX/sgx_t_static.mk  |   3 +-
  configure.ac                   |   2 +-
  m4/ax_vcs_checkout.m4          |   1 -
  pre-commit.sh                  |   6 +-
- wolfcrypt/src/asn.c            | 221 ++++++++++++++++++++++++++++++++-
+ wolfcrypt/src/asn.c            | 222 ++++++++++++++++++++++++++++++++-
  wolfssl/internal.h             |   2 +-
  wolfssl/wolfcrypt/asn_public.h |  18 +++
  wolfssl/wolfcrypt/settings.h   |   2 +
+ wolfssl/wolfcrypt/types.h      |   1 +
  wolfssl/wolfcrypt/wc_port.h    |   2 +-
- 9 files changed, 247 insertions(+), 10 deletions(-)
+ 10 files changed, 249 insertions(+), 10 deletions(-)
 
 diff --git a/IDE/LINUX-SGX/sgx_t_static.mk b/IDE/LINUX-SGX/sgx_t_static.mk
 index 41ff666f2..1767078e2 100644
@@ -89,7 +91,7 @@ index 9c76f4b30..992ecfe2a 100755
  make -j 8 >/dev/null 2>&1
  
 diff --git a/wolfcrypt/src/asn.c b/wolfcrypt/src/asn.c
-index 12ada17af..aac102f2c 100644
+index 12ada17af..7ee415ccb 100644
 --- a/wolfcrypt/src/asn.c
 +++ b/wolfcrypt/src/asn.c
 @@ -18,7 +18,7 @@
@@ -101,15 +103,16 @@ index 12ada17af..aac102f2c 100644
  /*
  
  DESCRIPTION
-@@ -76,6 +76,7 @@ ASN Options:
+@@ -76,6 +76,8 @@ ASN Options:
  #include <wolfssl/wolfcrypt/rc2.h>
  #include <wolfssl/wolfcrypt/wc_encrypt.h>
  #include <wolfssl/wolfcrypt/logging.h>
 +#include <wolfssl/wolfcrypt/wc_port.h>
++#include <wolfssl/wolfcrypt/types.h>
  
  #include <wolfssl/wolfcrypt/random.h>
  #include <wolfssl/wolfcrypt/hash.h>
-@@ -167,6 +168,7 @@ int tsip_tls_CertVerify(const byte *cert, word32 certSz,
+@@ -167,6 +169,7 @@ int tsip_tls_CertVerify(const byte *cert, word32 certSz,
                          word32 key_e_start, word32 key_e_len,
                          byte *tsip_encRsaKeyIdx);
  #endif
@@ -117,7 +120,7 @@ index 12ada17af..aac102f2c 100644
  int GetLength(const byte* input, word32* inOutIdx, int* len,
                             word32 maxIdx)
  {
-@@ -6458,6 +6460,18 @@ static WC_INLINE int DateLessThan(const struct tm* a, const struct tm* b)
+@@ -6458,6 +6461,18 @@ static WC_INLINE int DateLessThan(const struct tm* a, const struct tm* b)
      return DateGreaterThan(b,a);
  }
  
@@ -136,7 +139,7 @@ index 12ada17af..aac102f2c 100644
  /* like atoi but only use first byte */
  /* Make sure before and after dates are valid */
  int wc_ValidateDate(const byte* date, byte format, int dateType)
-@@ -11448,7 +11462,10 @@ int wc_PemPubKeyToDer(const char* fileName,
+@@ -11448,7 +11463,10 @@ int wc_PemPubKeyToDer(const char* fileName,
  /* USER RSA ifdef portions used instead of refactor in consideration for
     possible fips build */
  /* Write a public RSA key to output */
@@ -148,7 +151,7 @@ index 12ada17af..aac102f2c 100644
                             int outLen, int with_header)
  {
  #ifdef WOLFSSL_SMALL_STACK
-@@ -11851,6 +11868,14 @@ typedef struct DerCert {
+@@ -11851,6 +11869,14 @@ typedef struct DerCert {
      byte extKeyUsage[MAX_EXTKEYUSAGE_SZ]; /* Extended Key Usage extension */
      byte certPolicies[MAX_CERTPOL_NB*MAX_CERTPOL_SZ]; /* Certificate Policies */
  #endif
@@ -163,7 +166,7 @@ index 12ada17af..aac102f2c 100644
  #ifdef WOLFSSL_CERT_REQ
      byte attrib[MAX_ATTRIB_SZ];        /* Cert req attributes encoded */
  #endif
-@@ -11873,6 +11898,14 @@ typedef struct DerCert {
+@@ -11873,6 +11899,14 @@ typedef struct DerCert {
      int  extKeyUsageSz;                /* encoded ExtendedKeyUsage extension length */
      int  certPoliciesSz;               /* encoded CertPolicies extension length*/
  #endif
@@ -178,7 +181,7 @@ index 12ada17af..aac102f2c 100644
  #ifdef WOLFSSL_ALT_NAMES
      int  altNamesSz;                   /* encoded AltNames extension length */
  #endif
-@@ -12736,7 +12769,16 @@ static int SetKeyUsage(byte* output, word32 outSz, word16 input)
+@@ -12736,7 +12770,16 @@ static int SetKeyUsage(byte* output, word32 outSz, word16 input)
                         ku, idx);
  }
  
@@ -196,7 +199,7 @@ index 12ada17af..aac102f2c 100644
      const byte* oid, word32 oidSz)
  {
      /* verify room */
-@@ -12750,6 +12792,53 @@ static int SetOjectIdValue(byte* output, word32 outSz, int* idx,
+@@ -12750,6 +12793,53 @@ static int SetOjectIdValue(byte* output, word32 outSz, int* idx,
      return 0;
  }
  
@@ -250,7 +253,7 @@ index 12ada17af..aac102f2c 100644
  /* encode Extended Key Usage (RFC 5280 4.2.1.12), return total bytes written */
  static int SetExtKeyUsage(Cert* cert, byte* output, word32 outSz, byte input)
  {
-@@ -13431,6 +13520,17 @@ static int SetValidity(byte* output, int daysValid)
+@@ -13431,6 +13521,17 @@ static int SetValidity(byte* output, int daysValid)
      localTime.tm_year += 1900;
      localTime.tm_mon +=    1;
  
@@ -268,7 +271,7 @@ index 12ada17af..aac102f2c 100644
      SetTime(&localTime, before + beforeSz);
      beforeSz += ASN_GEN_TIME_SZ;
  
-@@ -13450,6 +13550,15 @@ static int SetValidity(byte* output, int daysValid)
+@@ -13450,6 +13551,15 @@ static int SetValidity(byte* output, int daysValid)
      localTime.tm_year += 1900;
      localTime.tm_mon  +=    1;
  
@@ -284,7 +287,7 @@ index 12ada17af..aac102f2c 100644
      SetTime(&localTime, after + afterSz);
      afterSz += ASN_GEN_TIME_SZ;
  
-@@ -13751,6 +13860,65 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
+@@ -13751,6 +13861,65 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
      else
          der->certPoliciesSz = 0;
  #endif /* WOLFSSL_CERT_EXT */
@@ -350,7 +353,7 @@ index 12ada17af..aac102f2c 100644
  
      /* put extensions */
      if (der->extensionsSz > 0) {
-@@ -13828,6 +13996,53 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
+@@ -13828,6 +13997,53 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
                  return EXTENSIONS_E;
          }
  #endif /* WOLFSSL_CERT_EXT */
@@ -418,7 +421,7 @@ index 73581fe90..03c7aaae1 100644
  
  #ifndef SESSION_TICKET_LEN
 diff --git a/wolfssl/wolfcrypt/asn_public.h b/wolfssl/wolfcrypt/asn_public.h
-index 480b64f64..e67661416 100644
+index 480b64f64..882969ee9 100644
 --- a/wolfssl/wolfcrypt/asn_public.h
 +++ b/wolfssl/wolfcrypt/asn_public.h
 @@ -332,6 +332,20 @@ typedef struct Cert {
@@ -467,6 +470,18 @@ index 7e6fa8b06..1893b8c1f 100644
      #define HAVE_AESGCM
      #define USE_CERT_BUFFERS_2048
      #define USE_FAST_MATH
+diff --git a/wolfssl/wolfcrypt/types.h b/wolfssl/wolfcrypt/types.h
+index 7148e1d24..cab271881 100644
+--- a/wolfssl/wolfcrypt/types.h
++++ b/wolfssl/wolfcrypt/types.h
+@@ -31,6 +31,7 @@ decouple library dependencies with standard string, memory and so on.
+ #ifndef WOLF_CRYPT_TYPES_H
+ #define WOLF_CRYPT_TYPES_H
+ 
++    #include <stdio.h>
+     #include <wolfssl/wolfcrypt/settings.h>
+     #include <wolfssl/wolfcrypt/wc_port.h>
+ 
 diff --git a/wolfssl/wolfcrypt/wc_port.h b/wolfssl/wolfcrypt/wc_port.h
 index da89676bf..baf165f1b 100644
 --- a/wolfssl/wolfcrypt/wc_port.h
@@ -481,5 +496,5 @@ index da89676bf..baf165f1b 100644
  #endif
  #if !defined(XGMTIME) && !defined(TIME_OVERRIDES)
 -- 
-2.17.1
+2.27.0
 


### PR DESCRIPTION
enclave-tls/src/external/wolfssl/wolfssl/wolfssl/wolfcrypt/types.h:571:35: warning: incompatible implicit declaration of built-in function ‘snprintf’
                 #define XSNPRINTF snprintf
                                   ^~~~~~~~
enclave-tls/src/external/wolfssl/wolfssl/wolfcrypt/src/asn.c:8752:9: note: in expansion of macro ‘XSNPRINTF’
     w = XSNPRINTF(out, outSz, "%u.%u", val / 40, val % 40);
enclave-tls/src/external/wolfssl/wolfssl/wolfssl/wolfcrypt/types.h:571:35: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
                 #define XSNPRINTF snprintf
                                   ^~~~~~~~
enclave-tls/src/external/wolfssl/wolfssl/wolfcrypt/src/asn.c:8752:9: note: in expansion of macro ‘XSNPRINTF’
     w = XSNPRINTF(out, outSz, "%u.%u", val / 40, val % 40);
         ^~~~~~~~~

Fixes: #740
Signed-off-by: Liang Yang <liang3.yang@intel.com>