### PR TITLE
CI/CD: support Alibaba teesdk in the pr test

### DIFF
--- a/.github/workflows/pr_enclave_tls.yml
+++ b/.github/workflows/pr_enclave_tls.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: labeled
 
+env:
+  ALINUX2_PROTOBUF_C_VERSION: 1.0.2
+
 jobs:
   rune_enclave_tls:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
@@ -81,14 +84,17 @@ jobs:
 
     - name: Install alinux dependency
       if: ${{ contains(matrix.tag, 'alinux') }}
-      run: docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
-        yum -y install yum-utils wget tar procps alinux-release-experimentals  protobuf-c-devel;
-        wget -c https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz;
-        tar xzf sgx_rpm_local_repo.tar.gz;
-        yum-config-manager --add-repo file:/root/inclavare-containers/${{ matrix.tag }}/sgx_rpm_local_repo;
+      run: |
+        docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
+        yum -y install yum-utils wget tar procps alinux-release-experimentals  protobuf-c-devel-${{ env.ALINUX2_PROTOBUF_C_VERSION }};
+        yum-config-manager --add-repo https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo;
         yum makecache;
-        yum install --nogpgcheck -y libsgx-dcap-quote-verify libsgx-dcap-default-qpl libsgx-dcap-ql-devel libsgx-uae-service;
-        rm -f sgx_rpm_local_repo.tar.gz;
+        yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+          libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+          libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+          libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+          libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+          sgx-aesm-service;
         mv /root/inclavare-containers/${{ matrix.tag }}/enclave-tls /opt'
 
     - id: random-port-generator1

--- a/.github/workflows/pr_epm.yml
+++ b/.github/workflows/pr_epm.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: labeled
 
+env:
+    ALINUX2_PROTOBUF_C_VERSION: 1.0.2
+
 jobs:
   rune_skeleton:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
@@ -148,18 +151,21 @@ jobs:
 
     - name: Install alinux dependency
       if: ${{ contains(matrix.tag, 'alinux') }}
-      run: docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
+      run: |
+        docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
          yum install -y alinux-release-experimentals;
-         yum install -y yum-utils wget tar gcc iptables protobuf-c libseccomp-devel;
-         wget -c https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz;
-         tar xzf sgx_rpm_local_repo.tar.gz;
-         yum-config-manager --add-repo file:/root/inclavare-containers/${{ matrix.tag }}/sgx_rpm_local_repo;
+         yum install -y yum-utils wget tar gcc iptables protobuf-c-${{ env.ALINUX2_PROTOBUF_C_VERSION }} libseccomp-devel;
+         yum-config-manager --add-repo https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo;
          yum makecache;
          rm -f /var/lib/rpm/__db.*;
          rpm --rebuilddb;
          yum clean all;
-         yum install --nogpgcheck -y libsgx-dcap-quote-verify libsgx-dcap-default-qpl;
-         rm -f sgx_rpm_local_repo.tar.gz;
+         yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+           libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+           libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+           libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+           libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+           sgx-aesm-service;
          cd /root/inclavare-containers/${{ matrix.tag }};
          rpm -ivh *.rpm'
 

--- a/.github/workflows/pr_shelter.yml
+++ b/.github/workflows/pr_shelter.yml
@@ -147,7 +147,7 @@ jobs:
       if: ${{ contains(matrix.sgx, 'SGX2') }}
       run: |
         docker cp /etc/sgx_default_qcnl.conf  $inclavare_test:/etc/;
-        docker exec $inclavare_test bash -c 'cd /opt/enclave-tls/bin/ && ./enclave-tls-server -l debug -a sgx_la -t wolfssl_sgx -c wolfcrypt' -i 127.0.0.1 -p ${{ steps.random-port-generator3.outputs.random-port }}' &
+        docker exec $inclavare_test bash -c 'cd /opt/enclave-tls/bin/ && ./enclave-tls-server -l debug -a sgx_la -t wolfssl_sgx -c wolfcrypt -i 127.0.0.1 -p ${{ steps.random-port-generator3.outputs.random-port }}' &
 
     - name: Run enclave tls server for sgx_la
       if: ${{ contains(matrix.sgx, 'SGX2') }}

--- a/.github/workflows/pr_shelter.yml
+++ b/.github/workflows/pr_shelter.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: labeled
 
+env:
+  ALINUX2_PROTOBUF_C_VERSION: 1.0.2
+
 jobs:
   rune_shelter:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
@@ -45,7 +48,7 @@ jobs:
         cp -rf /opt/enclave-tls /root/inclavare-containers/${{ matrix.tag }}'
 
     - name: Build shelter
-      run: docker exec $inclavare_dev bash -c 'cd /root && source /etc/profile;
+      run: docker exec $inclavare_dev bash -c 'cd /root && source /root/.bashrc;source /etc/profile;
         cd inclavare-containers-$RUNE_VERSION/shelter;
         make;
         cd ..;
@@ -91,14 +94,17 @@ jobs:
 
     - name: Install alinux dependency
       if: ${{ contains(matrix.tag, 'alinux') }}
-      run: docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
-        yum -y install yum-utils wget tar procps alinux-release-experimentals  protobuf-c-devel;
-        wget -c https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz;
-        tar xzf sgx_rpm_local_repo.tar.gz;
-        yum-config-manager --add-repo file:/root/inclavare-containers/${{ matrix.tag }}/sgx_rpm_local_repo;
+      run: |
+        docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
+        yum -y install yum-utils wget tar procps alinux-release-experimentals  protobuf-c-devel-${{ env.ALINUX2_PROTOBUF_C_VERSION }};
+        yum-config-manager --add-repo https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo;
         yum makecache;
-        yum install --nogpgcheck -y libsgx-dcap-quote-verify libsgx-dcap-default-qpl libsgx-dcap-ql-devel libsgx-uae-service;
-        rm -f sgx_rpm_local_repo.tar.gz;
+        yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+          libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+          libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+          libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+          libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+          sgx-aesm-service;
         mv /root/inclavare-containers/${{ matrix.tag }}/enclave-tls /opt'
 
     - id: random-port-generator1

--- a/.github/workflows/pr_skeleton.yml
+++ b/.github/workflows/pr_skeleton.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: labeled
 
+env:
+  ALINUX2_PROTOBUF_VERSION: 2.5.0
+  ALINUX2_PROTOBUF_C_VERSION: 1.0.2
+
 jobs:
   rune_skeleton:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'testing-before-checkin') }}
@@ -125,20 +129,24 @@ jobs:
 
     - name: Install alinux dependency
       if: ${{ contains(matrix.tag, 'alinux') }}
-      run: docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
+      run: |
+         docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
          yum install -y alinux-release-experimentals;
          yum install -y yum-utils wget tar gcc iptables libseccomp-devel make;
-         yum install -y libprotoc-devel binutils-devel autoconf libtool gcc-c++ pkg-config protobuf-compiler protobuf-devel;
-         yum install -y protobuf-c protobuf-c-devel;
-         wget -c https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz;
-         tar xzf sgx_rpm_local_repo.tar.gz;
-         yum-config-manager --add-repo file:/root/inclavare-containers/${{ matrix.tag }}/sgx_rpm_local_repo;
+         yum install -y libprotoc-devel binutils-devel autoconf libtool gcc-c++ pkg-config;
+         yum install -y protobuf-compiler-${{ env.ALINUX2_PROTOBUF_VERSION }} protobuf-devel-${{ env.ALINUX2_PROTOBUF_VERSION }};
+         yum install -y protobuf-c-${{ env.ALINUX2_PROTOBUF_C_VERSION }} protobuf-c-devel-${{ env.ALINUX2_PROTOBUF_C_VERSION }};
+         yum-config-manager --add-repo https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo;
          yum makecache;
          rm -f /var/lib/rpm/__db.*;
          rpm --rebuilddb;
          yum clean all;
-         yum install --nogpgcheck -y libsgx-dcap-quote-verify libsgx-dcap-default-qpl;
-         rm -f sgx_rpm_local_repo.tar.gz;
+         yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+           libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+           libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+           libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+           libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+           sgx-aesm-service;
          cd /root/inclavare-containers/${{ matrix.tag }};
          rpm -ivh *.rpm'
 

--- a/tools/docker/Dockerfile-inclavare-dev-alinux2
+++ b/tools/docker/Dockerfile-inclavare-dev-alinux2
@@ -2,13 +2,18 @@ FROM registry.cn-hangzhou.aliyuncs.com/alinux/aliyunlinux
 
 LABEL maintainer="YiLin Li <YiLin.Li@linux.alibaba.com>"
 
+# Install alinux-release-experimentals prior to others to work around
+# the issue "Error: Package: glibc-2.17-323.1.al7.i686 (updates)"
 RUN yum clean all && yum install -y alinux-release-experimentals
 
-RUN yum install -y wget make libseccomp-devel openssl git \
-    openssl-devel binutils-devel protobuf-c-devel rpm-build yum-utils protobuf-c \
-    devtoolset-10-toolchain autoconf libtool
+ENV PROTOBUF_VERSION 2.5.0
+ENV PROTOBUF_C_VERSION 1.0.2
 
-RUN echo "source /opt/rh/devtoolset-10/enable" > /root/.bashrc
+RUN yum install -y wget make libseccomp-devel openssl git autoconf libtool \
+    openssl-devel binutils-devel rpm-build yum-utils devtoolset-9-toolchain \
+    protobuf-c-devel-$PROTOBUF_C_VERSION protobuf-c-$PROTOBUF_C_VERSION
+
+RUN echo "source /opt/rh/devtoolset-9/enable" > /root/.bashrc
 
 WORKDIR /root
 
@@ -34,16 +39,19 @@ RUN yum install -y iptables && \
 RUN mkdir -p /etc/docker && \
     echo -e "{\n\t\"runtimes\": {\n\t\t\"rune\": {\n\t\t\t\"path\": \"/usr/local/bin/rune\",\n\t\t\t\"runtimeArgs\": []\n\t\t}\n\t}\n}" >> /etc/docker/daemon.json
 
-# install SGX
-RUN [ ! -f sgx_linux_x64_sdk_2.13.100.4.bin ] && \
-    wget https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_linux_x64_sdk_2.13.100.4.bin && \
-    chmod +x sgx_linux_x64_sdk_2.13.100.4.bin && echo -e 'no\n/opt/intel\n' | ./sgx_linux_x64_sdk_2.13.100.4.bin && \
-    rm -rf sgx_linux_x64_sdk_2.13.100.4.bin
+# configure Alibaba Cloud TEE SDK yum repo
+RUN yum-config-manager --add-repo \
+	https://enclave-cn-beijing.oss-cn-beijing.aliyuncs.com/repo/alinux/enclave-expr.repo
 
-RUN [ ! -f sgx_rpm_local_repo.tar.gz ] && \
-    wget -c https://mirrors.openanolis.org/inclavare-containers/alinux2/sgx_rpm_local_repo.tar.gz && \
-    tar xzf sgx_rpm_local_repo.tar.gz && \
-    yum-config-manager --add-repo file:/root/sgx_rpm_local_repo && \
-    yum makecache && rm sgx_rpm_local_repo.tar.gz
+# install SGX Runtime
+RUN yum install --nogpgcheck -y libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \
+    libsgx-aesm-ecdsa-plugin libsgx-aesm-launch-plugin libsgx-aesm-pce-plugin libsgx-aesm-quote-ex-plugin \
+    libsgx-dcap-default-qpl libsgx-dcap-ql libsgx-dcap-quote-verify \
+    libsgx-enclave-common libsgx-launch libsgx-pce-logic libsgx-qe3-logic libsgx-quote-ex \
+    libsgx-ra-network libsgx-ra-uefi libsgx-uae-service libsgx-urts sgx-ra-service \
+    sgx-aesm-service
 
-RUN yum install --nogpgcheck -y libsgx-dcap-quote-verify-devel libsgx-dcap-ql-devel libsgx-uae-service
+# install Alibaba Cloud TEE SDK
+RUN yum install --nogpgcheck -y teesdk
+
+RUN echo "source /opt/alibaba/teesdk/intel/sgxsdk/environment" >> /root/.bashrc


### PR DESCRIPTION
1. tools/docker: change to use the Alibaba Cloud teesdk and protobuf 2.5.0 in the alinux2 inclavare dev dockerfile
2. CI/CD: use Alibaba teesdk in the alinux2 pr tests
3. CI/CD: fix run enclave tls server for sgx_la error

Fixes: #891
Fixes: #889 
Fixes: #921
Signed-off-by: Yilin Li YiLin.Li@linux.alibaba.com