### PR TITLE
inclavared: specify the parameters of enclave tls through cmdline

### DIFF
--- a/inclavared/README.md
+++ b/inclavared/README.md
@@ -34,7 +34,6 @@ brew install clang
 git clone https://github.com/alibaba/inclavare-containers.git
 cd inclavare-containers/
 export ROOT_DIR=`pwd`
-
 ```
 
 ### Based On Enclave-TLS
@@ -64,6 +63,9 @@ recv data from sockaddr1 and send to sockaddr2, and recv data from sockaddr2 and
 
 ```bash
 ${ROOT_DIR}/inclavared/bin/inclavared --listen <sockaddr1> --xfer <sockaddr2>
+
+# enable mutual for xfer stream
+${ROOT_DIR}/inclavared/bin/inclavared --listen <sockaddr1> --xfer <sockaddr2> --mutual
 ```
 
 * Run as client

--- a/inclavared/app/src/enclave-tls.rs
+++ b/inclavared/app/src/enclave-tls.rs
@@ -59,20 +59,32 @@ impl DerefMut for EnclaveTls {
 impl EnclaveTls {
     fn new(server: bool,
             enclave_id: u64,
-            tls_type: &str,
-            attester_type: &str,
-            verifier_type: &str
+            tls_type: &Option<String>,
+            crypto: &Option<String>,
+            attester: &Option<String>,
+            verifier: &Option<String>,
+            mutual: bool
             ) -> Result<EnclaveTls, enclave_tls_err_t> {
         let mut conf: enclave_tls_conf_t = Default::default();
         conf.api_version = ENCLAVE_TLS_API_VERSION_DEFAULT;
         conf.log_level = ENCLAVE_TLS_LOG_LEVEL_DEBUG;
-        conf.tls_type[..tls_type.len()].copy_from_slice(tls_type.as_bytes());
-        conf.attester_type[..attester_type.len()].copy_from_slice(attester_type.as_bytes());
-        conf.verifier_type[..verifier_type.len()].copy_from_slice(verifier_type.as_bytes());
-        conf.crypto_type[.."wolfcrypt_sgx".len()].copy_from_slice("wolfcrypt_sgx".as_bytes());
+        if let Some(tls_type) = tls_type {
+            conf.tls_type[..tls_type.len()].copy_from_slice(tls_type.as_bytes());
+        }
+        if let Some(crypto) = crypto {
+            conf.crypto_type[..crypto.len()].copy_from_slice(crypto.as_bytes());
+        }
+        if let Some(attester) = attester {
+            conf.attester_type[..attester.len()].copy_from_slice(attester.as_bytes());
+        }
+        if let Some(verifier) = verifier {
+            conf.verifier_type[..verifier.len()].copy_from_slice(verifier.as_bytes());
+        }
         conf.cert_algo = ENCLAVE_TLS_CERT_ALGO_DEFAULT;
         conf.enclave_id = enclave_id;
-        conf.flags = ENCLAVE_TLS_CONF_FLAGS_MUTUAL;
+        if mutual {
+            conf.flags |= ENCLAVE_TLS_CONF_FLAGS_MUTUAL;
+        }
         if server {
             conf.flags |= ENCLAVE_TLS_CONF_FLAGS_SERVER;
         }


### PR DESCRIPTION
Support specifying tls type, crypto type, attester type, verifier
type and mutual mode parameters.

Fixes: #947
Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>