### PR TITLE
enclave-tls: store handle-specific instance context

### DIFF
--- a/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
+++ b/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
@@ -35,6 +35,13 @@ enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx,
 		if (type && strcmp(type, crypto_ctx->opts->type))
 			continue;
 
+		crypto_wrapper_ctx_t *this_crypto_ctx = malloc(sizeof(*this_crypto_ctx));
+		if (!this_crypto_ctx)
+			return -ENCLAVE_TLS_ERR_NO_MEM;
+
+		*this_crypto_ctx = *crypto_ctx;
+		crypto_ctx = this_crypto_ctx;
+
 		/* Set necessary configurations from enclave_tls_init() to
 		 * make init() working correctly.
 		 */

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
@@ -37,6 +37,13 @@ enclave_tls_err_t etls_enclave_quote_select(etls_core_context_t *ctx,
 
 		if (type && strcmp(type, quote_ctx->opts->type))
 			continue;
+	
+		enclave_quote_ctx_t *this_quote_ctx = malloc(sizeof(*this_quote_ctx));
+		if (!this_quote_ctx)
+			 return -ENCLAVE_TLS_ERR_NO_MEM;
+		
+		memcpy(this_quote_ctx, quote_ctx, sizeof(*this_quote_ctx));
+		quote_ctx = this_quote_ctx;
 
 		/* Set necessary configurations from enclave_tls_init() to
 		 * make init() working correctly.

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
@@ -35,6 +35,13 @@ enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx,
 		if (type && strcmp(type, tls_ctx->opts->type))
 			continue;
 
+		tls_wrapper_ctx_t *this_tls_ctx = malloc(sizeof(*this_tls_ctx));
+		if (!this_tls_ctx)
+			return -ENCLAVE_TLS_ERR_NO_MEM;
+
+		*this_tls_ctx = *tls_ctx;
+		tls_ctx = this_tls_ctx;
+
 		/* Set necessary configurations from enclave_tls_init() to
 		 * make init() working correctly.
 		 */


### PR DESCRIPTION
The current context information is process granular, and it does not take
into account that multiple threads with multiple handle context information.
Use handle-specific instance context can solve this problem.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>