### PR TITLE
inclavared: Fix the failure of calling enclcave_tls_cleanup()

### DIFF
--- a/inclavared/app/src/main.rs
+++ b/inclavared/app/src/main.rs
@@ -68,6 +68,8 @@ fn enclave_info_fetch(sockfd: RawFd, buf: &mut [u8],
 
     let n = tls.receive(buf).unwrap();
 
+    /* XXX TODO: tls must be droped before enclave */
+    drop(tls);
     enclave.destroy();
 
     n
@@ -150,6 +152,8 @@ fn handle_client(sockfd: RawFd, upstream: &Option<String>,
         assert!(n > 0);
     }
 
+    /* XXX TODO: tls must be droped before enclave */
+    drop(tls);
     enclave.destroy();
 }
 


### PR DESCRIPTION
Because the enclave associated with the tls handle is freed before
the tls handle, the ecall in cleanup() fails. so the tls handle is
freed in advance, instead of being freed automatically by the
compiler after leaving the scope.

Fixes: #969
Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>