### PR TITLE
CI/CD: avoid building the shelter rpm package in the nightly centos SGX1 test

### DIFF
--- a/.github/workflows/nightly-centos-sgx1.yml
+++ b/.github/workflows/nightly-centos-sgx1.yml
@@ -94,6 +94,7 @@ jobs:
         mkdir -p $WORK_DIR/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
         cp $WORK_DIR/v$RUNE_VERSION.tar.gz $WORK_DIR/rpmbuild/SOURCES/
         source /etc/profile
+        sed -i 's/shelter//g' Makefile
         make package RPMBUILD_DIR=$WORK_DIR/rpmbuild RELEASE_TARBALL_FILE=$WORK_DIR/rpmbuild/SOURCES/v$RUNE_VERSION.tar.gz RELEASE_TARBALL_EXIST=y -j${CPU_NUM}
         rpm -ivh rune-$RUNE_VERSION*.rpm
         rpm -ivh shim-rune-$RUNE_VERSION*.rpm


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>