### PR TITLE
 CI/CD: avoid building the inclavared rpm package in the pr tests and nightly tests

### DIFF
--- a/.github/workflows/nightly-centos-sgx1.yml
+++ b/.github/workflows/nightly-centos-sgx1.yml
@@ -95,6 +95,7 @@ jobs:
         cp $WORK_DIR/v$RUNE_VERSION.tar.gz $WORK_DIR/rpmbuild/SOURCES/
         source /etc/profile
         sed -i 's/shelter//g' Makefile
+        sed -i 's/inclavared//g' Makefile
         make package RPMBUILD_DIR=$WORK_DIR/rpmbuild RELEASE_TARBALL_FILE=$WORK_DIR/rpmbuild/SOURCES/v$RUNE_VERSION.tar.gz RELEASE_TARBALL_EXIST=y -j${CPU_NUM}
         rpm -ivh rune-$RUNE_VERSION*.rpm
         rpm -ivh shim-rune-$RUNE_VERSION*.rpm

--- a/.github/workflows/pr_epm.yml
+++ b/.github/workflows/pr_epm.yml
@@ -44,6 +44,7 @@ jobs:
         cp -f /root/v$RUNE_VERSION.tar.gz /root/rpmbuild/SOURCES;
         find ./ -path '*dist/Makefile' | xargs -I files sed -i '16 d' files;
         sed -i 's/shelter//g' Makefile;
+        sed -i 's/inclavared//g' Makefile;
         make package RPMBUILD_DIR=/root/rpmbuild RELEASE_TARBALL_FILE=/root/rpmbuild/SOURCES/v$RUNE_VERSION.tar.gz RELEASE_TARBALL_EXIST=y -j${CPU_NUM};
         mv *.rpm /root/inclavare-containers/${{ matrix.tag }}"
 
@@ -57,6 +58,7 @@ jobs:
         find ./ -path "*deb/build.sh" | xargs -I files sed -i '17 d' files;
         find ./ -path "*deb/build.sh" | xargs -I files sed -i '17icp /root/v*.tar.gz \$DEBBUILD_DIR' files;
         sed -i 's/shelter//g' Makefile;
+        sed -i 's/inclavared//g' Makefile;
         make package -j${CPU_NUM};
         mv *.deb /root/inclavare-containers/${{ matrix.tag }}"
 

--- a/.github/workflows/pr_skeleton.yml
+++ b/.github/workflows/pr_skeleton.yml
@@ -45,6 +45,7 @@ jobs:
         cp -f /root/v$RUNE_VERSION.tar.gz /root/rpmbuild/SOURCES;
         find ./ -path '*dist/Makefile' | xargs -I files sed -i '16 d' files;
         sed -i 's/shelter//g' Makefile;
+        sed -i 's/inclavared//g' Makefile;
         make package RPMBUILD_DIR=/root/rpmbuild RELEASE_TARBALL_FILE=/root/rpmbuild/SOURCES/v$RUNE_VERSION.tar.gz RELEASE_TARBALL_EXIST=y -j${CPU_NUM};
         mv *.rpm /root/inclavare-containers/${{ matrix.tag }}"
 
@@ -58,6 +59,7 @@ jobs:
         find ./ -path "*deb/build.sh" | xargs -I files sed -i '17 d' files;
         find ./ -path "*deb/build.sh" | xargs -I files sed -i '17icp /root/v*.tar.gz \$DEBBUILD_DIR' files;
         sed -i 's/shelter//g' Makefile;
+        sed -i 's/inclavared//g' Makefile;
         make package -j${CPU_NUM};
         mv *.deb /root/inclavare-containers/${{ matrix.tag }}"
 


### PR DESCRIPTION
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>