### PR TITLE
enclave-tls/dist: fix build the debuginfo rpm package failed in the centos 8.x

### DIFF
--- a/enclave-tls/dist/rpm/enclave_tls.spec
+++ b/enclave-tls/dist/rpm/enclave_tls.spec
@@ -1,11 +1,9 @@
 %define centos_base_release 1
-%define _debugsource_template %{nil}
 
-%define __debug_install_post   \
-   %{_rpmconfigdir}/find-debuginfo.sh %{?_find_debuginfo_opts} "%{_builddir}/%{?buildsubdir}"\
-%{nil}
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%undefine _missing_build_ids_terminate_build
 
-%global _missing_build_ids_terminate_build 0
 %global PROJECT inclavare-containers
 
 Name: enclave-tls


### PR DESCRIPTION
Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>