### PR TITLE
shelter/dist: minor fixes in the deb package control and rules

### DIFF
--- a/shelter/dist/deb/build.sh
+++ b/shelter/dist/deb/build.sh
@@ -36,6 +36,6 @@ fi
 # build_deb_package
 cp -rf  $SCRIPT_DIR/debian $DEB_BUILD_FOLDER
 cd $DEB_BUILD_FOLDER
-dpkg-buildpackage -us -uc
+DEB_CFLAGS_SET="-std=gnu11 -fPIC" DEB_CXXFLAGS_SET="-std=c++11 -fPIC" DEB_LDFLAGS_SET="-fPIC" dpkg-buildpackage -us -uc
 cp $DEBBUILD_DIR/*.*deb $PROJECT_DIR
 rm -rf $DEBBUILD_DIR

--- a/shelter/dist/deb/debian/control
+++ b/shelter/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: shelter
 Section: devel
 Priority: extra
 Maintainer: zhiming hu <zhiming.hu@intel.com>
-Build-Depends: debhelper (>=9), openssl
+Build-Depends: debhelper (>=9), openssl, libssl-dev, enclave-tls
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/shelter/dist/deb/debian/rules
+++ b/shelter/dist/deb/debian/rules
@@ -8,6 +8,8 @@ export GO111MODULE := on
 %:
 	dh $@
 
+override_dh_auto_clean:
+
 override_dh_auto_build:
 	make -C $(NAME)
 override_dh_auto_install:


### PR DESCRIPTION
1. shelter/dist: add the build depends of the deb packages.
2. shelter/dist: fix unrecognized option '-Wl,-Bsymbolic-functions' error
3. shelter/dist: add override_dh_auto_clean in the deb package rules

Fixes: #976
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>