### PR TITLE
inclavared/dist: minor fixes in the inclavared deb packages

### DIFF
--- a/inclavared/dist/deb/build.sh
+++ b/inclavared/dist/deb/build.sh
@@ -22,8 +22,13 @@ cd $DEBBUILD_DIR && tar zcfP $TARBALL_NAME $PACKAGE-$VERSION
 
 # check the Rust
 if ! [ -x "$(command -v rustc)" ]; then
-  echo 'Error: Rust is not installed. Please install Rust firstly'
+  echo 'Error: Rust is not installed. Please type the "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; source $HOME/.cargo/env" command to install Rust firstly'
   exit 1
+fi
+
+if ! [ -x "$(command -v cargo)" ]; then
+   echo 'Error: Cargo is not installed. Please type the "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; source $HOME/.cargo/env" command to install Cargo firstly'
+   exit 1
 fi
 
 # build_deb_package

--- a/inclavared/dist/deb/debian/control
+++ b/inclavared/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: inclavared
 Section: devel
 Priority: extra
 Maintainer: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>
-Build-Depends: debhelper (>=9), make, rust
+Build-Depends: debhelper (>=9), make
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 

--- a/inclavared/dist/deb/debian/control
+++ b/inclavared/dist/deb/debian/control
@@ -2,7 +2,7 @@ Source: inclavared
 Section: devel
 Priority: extra
 Maintainer: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>
-Build-Depends: debhelper (>=9), make
+Build-Depends: debhelper (>=9), make, enclave-tls
 Standards-Version: 3.9.8
 Homepage: https://github.com/alibaba/inclavare-containers
 


### PR DESCRIPTION
1. inclavared/dist: add enclave-tls build-depends in the deb package
2. inclavared/dist: add the rustc anc cargo check in the build.sh rather than in the build-depends section for the deb package

Fixes: #977
Fixes: #978
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>