### PR TITLE
CI/CD: minor fixes about building deb packages error in the nightly SGX1 ubuntu test

### DIFF
--- a/.github/workflows/nightly-ubuntu-sgx1.yml
+++ b/.github/workflows/nightly-ubuntu-sgx1.yml
@@ -155,6 +155,8 @@ jobs:
           echo "$RUNE_VERSION" > VERSION
           find ./ -path "*deb/build.sh" | xargs -I files sed -i '17 d' files;
           find ./ -path "*deb/build.sh" | xargs -I files sed -i "17icp $WORK_DIR/v*.tar.gz \$DEBBUILD_DIR" files;
+          sed -i 's/shelter//g' Makefile
+          sed -i 's/inclavared//g' Makefile
           make package -j${CPU_NUM};
           dpkg -i rune_$RUNE_VERSION-1_amd64.deb;
           dpkg -i shim-rune_$RUNE_VERSION-1_amd64.deb

--- a/epm/dist/deb/debian/rules
+++ b/epm/dist/deb/debian/rules
@@ -6,6 +6,8 @@ LICENSE := /usr/share/licenses/epm
 %:
 	dh $@
 
+override_dh_auto_clean:
+
 override_dh_auto_build:
 	GOOS=linux make binaries -C epm
 override_dh_auto_install:

--- a/sgx-tools/dist/deb/debian/rules
+++ b/sgx-tools/dist/deb/debian/rules
@@ -8,6 +8,8 @@ export GO111MODULE := on
 %:
 	dh $@
 
+override_dh_auto_clean:
+
 override_dh_auto_build:
 	make -C $(NAME)
 override_dh_auto_install:

--- a/shim/dist/deb/debian/rules
+++ b/shim/dist/deb/debian/rules
@@ -6,6 +6,8 @@ LICENSE := /usr/share/licenses/shim-rune
 %:
 	dh $@
 
+override_dh_auto_clean:
+
 override_dh_auto_build:
 	GOOS=linux make binaries -C shim
 override_dh_auto_install:


### PR DESCRIPTION
1. CI/CD: avoid building shelter and inclavared packages in the nightly ubuntu SGX1 test
2. {epm, shim, sgx-tools}: add override_dh_auto_clean in the deb package rules

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>