### PR TITLE
enclave-tls/dist: both avoid building the enclave-tls debuginfo rpm and dbgsym deb package

### DIFF
--- a/enclave-tls/dist/deb/debian/rules
+++ b/enclave-tls/dist/deb/debian/rules
@@ -6,6 +6,9 @@ BUILD_ROOT := $(CURDIR)/debian/enclave-tls
 
 override_dh_auto_clean:
 
+# avoid building dbgsym packages
+override_dh_strip:
+
 override_dh_auto_build:
 	make -C enclave-tls SGX=1
 

--- a/enclave-tls/dist/rpm/enclave_tls.spec
+++ b/enclave-tls/dist/rpm/enclave_tls.spec
@@ -1,9 +1,8 @@
 %define centos_base_release 1
+%define _debugsource_template %{nil}
+%define debug_package %{nil}
 
-%global _find_debuginfo_dwz_opts %{nil}
-%global _dwz_low_mem_die_limit 0
-%undefine _missing_build_ids_terminate_build
-
+%global _missing_build_ids_terminate_build 0
 %global PROJECT inclavare-containers
 
 Name: enclave-tls
@@ -19,7 +18,7 @@ Source10: enclave_tls.filelist
 
 BuildRequires: git
 BuildRequires: make
-BuildRequires: autoconf 
+BuildRequires: autoconf
 BuildRequires: libtool
 BuildRequires: gcc
 BuildRequires: gcc-c++


### PR DESCRIPTION
enclave-tls debuginfo rpm and dbgsym deb package will rebuild sgx_stub_enclave.signed.so in the
incorrect pattern, it will casue enclave-tls-sever load enclave failed. So we
avoid building the enclave-tls debuginfo rpm and dbgsym deb package to workaround this problem.

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>