### PR TITLE
enclave-tls/dist: add dh_strip --exclude rules in the deb and dbgsym packages

### DIFF
--- a/enclave-tls/dist/deb/debian/rules
+++ b/enclave-tls/dist/deb/debian/rules
@@ -6,8 +6,8 @@ BUILD_ROOT := $(CURDIR)/debian/enclave-tls
 
 override_dh_auto_clean:
 
-# avoid building dbgsym packages
 override_dh_strip:
+	dh_strip --exclude=sgx_stub_enclave.signed.so --exclude=enclave-tls-server --exclude=enclave-tls-client --exclude=libenclave_tls.so* --exclude=libwolfssl* --exclude=libtls_wrapper*.so* --exclude=libcrypto_wrapper*.so* --exclude=libenclave_quote*.so*
 
 override_dh_auto_build:
 	make -C enclave-tls SGX=1


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man1/dh_strip.1.html, we can use
dh_strip --exclude to exclude the files from being stripped. If the sgx_stub_enclave.signed.so
file is stripped, it will be an error, so we should use dh_strip --exclude rules to avoid
stripping them.

Fixes: #1006
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>