### PR TITLE
enclave-tls/dist: support debuginfo packages that can run enclave-tls-server/client successfully in centos 8.2

### DIFF
--- a/enclave-tls/dist/rpm/enclave_tls.spec
+++ b/enclave-tls/dist/rpm/enclave_tls.spec
@@ -1,8 +1,19 @@
 %define centos_base_release 1
-%define _debugsource_template %{nil}
-%define debug_package %{nil}
 
-%global _missing_build_ids_terminate_build 0
+%define __enclave_tls_install_post \
+    cp %{_builddir}/%{PROJECT}-%{version}/%{name}/build/bin/sgx_stub_enclave.signed.so %{?buildroot}%{ENCLAVE_TLS_BINDIR} \
+%{nil}
+
+%define __spec_install_post \
+    %{?__debug_package:%{__debug_install_post}}\
+    %{__arch_install_post}\
+    %{__os_install_post}\
+    %{__enclave_tls_install_post}
+
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%undefine _missing_build_ids_terminate_build
+
 %global PROJECT inclavare-containers
 
 %global ENCLAVE_TLS_ROOTDIR /opt/enclave-tls


### PR DESCRIPTION
Because in centos 8.x, rpmbuild has a higher 4.14 version,
and introduces the debugsource sub-packages. So it is not
easy to disable the strip operation, so we customized the
__enclave_tls_install_post and __spec_install_post macros.

The __enclave_tls_install_post macro is executed after
the stripping and we use the sgx_stub_enclave.signed.so which
generated during compilation to replaces the corresponding stripped
one which generated during the install phase.

As a result, we ensure the correct operation of enclave-tls-server/client,
and successfully generate the debuginfo and debugsource subpackages
of enclave-tls.

Fixes: #1029
Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>