### PR TITLE
enclave-tls: enable capability flags in the register of enclave quote instance

### DIFF
--- a/enclave-tls/src/Makefile
+++ b/enclave-tls/src/Makefile
@@ -45,6 +45,7 @@ libenclave_tls_files := \
     $(this_dir)/crypto_wrappers/internal/*.c $(this_dir)/crypto_wrappers/api/*.c \
     $(this_dir)/tls_wrappers/internal/*.c $(this_dir)/tls_wrappers/api/*.c \
     $(this_dir)/enclave_quotes/internal/*.c $(this_dir)/enclave_quotes/api/*.c \
+    $(this_dir)/util/*.c \
   )
 
 ocall_files := \

--- a/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
+++ b/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
@@ -8,6 +8,7 @@
 #include <enclave-tls/err.h>
 #include <enclave-tls/log.h>
 #include "internal/crypto_wrapper.h"
+#include "internal/sgxutils.h"
 
 crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 {
@@ -15,6 +16,13 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 		return -CRYPTO_WRAPPER_ERR_INVALID;
 
 	ETLS_DEBUG("registering the crypto wrapper '%s' ...\n", opts->type);
+
+	if (opts->flags & CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
+		if (!is_sgx_supported_and_configured()) {
+			ETLS_DEBUG("failed to register the crypto wrapper '%s' due to lack of SGX capability\n", opts->type);
+			return -CRYPTO_WRAPPER_ERR_INVALID;
+		}
+	}
 
 	crypto_wrapper_opts_t *new_opts =
 		(crypto_wrapper_opts_t *)malloc(sizeof(*new_opts));

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
@@ -31,6 +31,7 @@ static crypto_wrapper_opts_t wolfcrypt_sgx_opts = {
 	.gen_pubkey_hash = wolfcrypt_sgx_gen_pubkey_hash,
 	.gen_cert = wolfcrypt_sgx_gen_cert,
 	.cleanup = wolfcrypt_sgx_cleanup,
+	.flags = CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE,
 };
 
 void __attribute__((constructor))libcrypto_wrapper_wolfcrypt_sgx_init(void)

--- a/enclave-tls/src/enclave_quotes/api/enclave_quote_register.c
+++ b/enclave-tls/src/enclave_quotes/api/enclave_quote_register.c
@@ -8,6 +8,7 @@
 #include <enclave-tls/err.h>
 #include <enclave-tls/log.h>
 #include "internal/enclave_quote.h"
+#include "internal/sgxutils.h"
 
 enclave_quote_err_t enclave_quote_register(const enclave_quote_opts_t *opts)
 {
@@ -15,6 +16,13 @@ enclave_quote_err_t enclave_quote_register(const enclave_quote_opts_t *opts)
 		return -ENCLAVE_QUOTE_ERR_INVALID;
 
 	ETLS_DEBUG("registering the enclave quote '%s' ...\n", opts->type);
+
+	if (opts->flags & ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE) {
+		if (!is_sgx_supported_and_configured()) {
+			ETLS_DEBUG("failed to register the enclave quote '%s' due to lack of SGX capability\n", opts->type);
+			return -ENCLAVE_QUOTE_ERR_INVALID;
+		}
+	}
 
 	enclave_quote_opts_t *new_opts =
 		(enclave_quote_opts_t *)malloc(sizeof(*new_opts));

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
@@ -34,7 +34,7 @@ enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
 	for (unsigned int i = 0; i < registerd_enclave_quote_nums; ++i) {
 		if (type && strcmp(type, enclave_quotes_ctx[i]->opts->type))
 			continue;
-	
+
 		quote_ctx = malloc(sizeof(*quote_ctx));
 		if (!quote_ctx)
 			 return -ENCLAVE_TLS_ERR_NO_MEM;

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
@@ -22,7 +22,7 @@ extern enclave_quote_err_t sgx_ecdsa_cleanup(enclave_quote_ctx_t *ctx);
 
 static enclave_quote_opts_t sgx_ecdsa_qve_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
-	.flags = ENCLAVE_QUOTE_FLAGS_DEFAULT,
+	.flags = ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE,
 	.type = "sgx_ecdsa_qve",
 	.priority = 53,
 	.pre_init = sgx_ecdsa_pre_init,

--- a/enclave-tls/src/enclave_quotes/sgx-la/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/main.c
@@ -23,7 +23,7 @@ extern enclave_quote_err_t sgx_la_cleanup(enclave_quote_ctx_t *);
 
 static enclave_quote_opts_t sgx_la_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
-	.flags = ENCLAVE_QUOTE_FLAGS_DEFAULT,
+	.flags = ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE,
 	.type = "sgx_la",
 	.priority = 15,
 	.pre_init = sgx_la_pre_init,

--- a/enclave-tls/src/include/internal/sgxutils.h
+++ b/enclave-tls/src/include/internal/sgxutils.h
@@ -1,0 +1,10 @@
+/* Copyright (c) 2020-2021 Alibaba Cloud and Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+
+#define SGX_CPUID				0x12
+
+extern bool is_sgx_supported_and_configured(void);

--- a/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
+++ b/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
@@ -8,6 +8,7 @@
 #include <enclave-tls/err.h>
 #include <enclave-tls/log.h>
 #include "internal/tls_wrapper.h"
+#include "internal/sgxutils.h"
 
 tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 {
@@ -15,6 +16,13 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 		return -CRYPTO_WRAPPER_ERR_INVALID;
 
 	ETLS_DEBUG("registering the tls wrapper '%s' ...\n", opts->type);
+
+	if (opts->flags & TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
+		if (!is_sgx_supported_and_configured()) {
+			ETLS_DEBUG("failed to register the tls wrapper '%s' due to lack of SGX capability\n", opts->type);
+			return -TLS_WRAPPER_ERR_INVALID;
+		}
+	}
 
 	tls_wrapper_opts_t *new_opts =
 		(tls_wrapper_opts_t *)malloc(sizeof(*new_opts));

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
@@ -30,6 +30,7 @@ static tls_wrapper_opts_t wolfssl_sgx_opts = {
 	.transmit = wolfssl_sgx_transmit,
 	.receive = wolfssl_sgx_receive,
 	.cleanup = wolfssl_sgx_cleanup,
+	.flags = TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE,
 };
 
 void __attribute__((constructor))

--- a/enclave-tls/src/util/sgxutils.c
+++ b/enclave-tls/src/util/sgxutils.c
@@ -1,0 +1,92 @@
+/* Copyright (c) 2020-2021 Alibaba Cloud and Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include "internal/sgxutils.h"
+
+static inline void cpuid(int *eax, int *ebx, int *ecx, int *edx)
+{
+#if defined(__x86_64__)
+	asm volatile ("cpuid"
+		      : "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx)
+		      : "0" (*eax), "2" (*ecx)
+		      : "memory");
+#else
+	/* on 32bit, ebx can NOT be used as PIC code */
+	asm volatile ("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
+		      : "=a" (*eax), "=r" (*ebx), "=c" (*ecx), "=d" (*edx)
+		      : "0" (*eax), "2" (*ecx)
+		      : "memory");
+#endif
+}
+
+static inline void __cpuidex(int a[4], int b, int c)
+{
+	a[0] = b;
+	a[2] = c;
+	cpuid(&a[0], &a[1], &a[2], &a[3]);
+}
+
+static bool is_sgx1_supported(void)
+{
+	int cpu_info[4] = { 0, 0, 0, 0 };
+
+	__cpuidex(cpu_info, SGX_CPUID, 0);
+
+	return !!(cpu_info[0] & 1);
+}
+
+static bool is_sgx2_supported(void)
+{
+	int cpu_info[4] = { 0, 0, 0, 0 };
+
+	__cpuidex(cpu_info, SGX_CPUID, 0);
+
+	return !!(cpu_info[0] & 0x2);
+}
+
+static bool is_sgx_device(const char *dev)
+{
+	struct stat st;
+
+	if (!stat(dev, &st)) {
+		if ((st.st_mode & S_IFCHR) && (major(st.st_rdev) == 10))
+			return true;
+	}
+
+	return false;
+}
+
+static bool is_legacy_oot_kernel_driver(void)
+{
+	return is_sgx_device("/dev/isgx");
+}
+
+static bool is_dcap_oot_kernel_driver(void)
+{
+	return is_sgx_device("/dev/sgx/enclave");
+}
+
+static bool is_in_tree_kernel_driver(void)
+{
+	return is_sgx_device("/dev/sgx_enclave");
+}
+
+bool is_sgx_supported_and_configured(void)
+{
+	if (!is_sgx2_supported() && !is_sgx1_supported())
+		return false;
+
+	if (!is_dcap_oot_kernel_driver() &&
+	    !is_legacy_oot_kernel_driver() && !is_in_tree_kernel_driver())
+		return false;
+                        
+	return true;
+}


### PR DESCRIPTION

Fixes: #844

* Set flags for wolfssl_sgx, wolfcrypto_sgx, sgx_la, sgx_ecdsa_qve to 1 as
platform requirement

* Detect platform capabilities while selecting instances

Signed-off-by: Ruoyu.Ying <ruoyu.ying@intel.com>