### PR TITLE
enclave-tls: allow sgx_ecdsa instance to support the evidence generatd by sgx_ecdsa_qve

### DIFF
--- a/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
+++ b/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
@@ -15,11 +15,11 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 	if (!opts)
 		return -CRYPTO_WRAPPER_ERR_INVALID;
 
-	ETLS_DEBUG("registering the crypto wrapper '%s' ...\n", opts->type);
+	ETLS_DEBUG("registering the crypto wrapper '%s' ...\n", opts->name);
 
 	if (opts->flags & CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
 		if (!is_sgx_supported_and_configured()) {
-			ETLS_DEBUG("failed to register the crypto wrapper '%s' due to lack of SGX capability\n", opts->type);
+			ETLS_DEBUG("failed to register the crypto wrapper '%s' due to lack of SGX capability\n", opts->name);
 			return -CRYPTO_WRAPPER_ERR_INVALID;
 		}
 	}
@@ -31,8 +31,8 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 
 	memcpy(new_opts, opts, sizeof(*new_opts));
 
-	if (new_opts->type[0] == '\0') {
-		ETLS_ERR("invalid crypto wrapper type\n");
+	if (new_opts->name[0] == '\0') {
+		ETLS_ERR("invalid crypto wrapper name\n");
 		goto err;
 	}
 
@@ -44,7 +44,7 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 
 	crypto_wrappers_opts[registerd_crypto_wrapper_nums++] = new_opts;
 
-	ETLS_INFO("the crypto wrapper '%s' registered\n", opts->type);
+	ETLS_INFO("the crypto wrapper '%s' registered\n", opts->name);
 
 	return CRYPTO_WRAPPER_ERR_NONE;
 

--- a/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
+++ b/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
@@ -23,13 +23,13 @@ static enclave_tls_err_t init_crypto_wrapper(crypto_wrapper_ctx_t *crypto_ctx)
 }
 
 enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx,
-					     const char *type)
+					     const char *name)
 {
-	ETLS_DEBUG("selecting the crypto wrapper '%s' ...\n", type);
+	ETLS_DEBUG("selecting the crypto wrapper '%s' ...\n", name);
 
 	crypto_wrapper_ctx_t *crypto_ctx = NULL;
 	for (unsigned int i = 0; i < registerd_crypto_wrapper_nums; ++i) {
-		if (type && strcmp(type, crypto_wrappers_ctx[i]->opts->type))
+		if (name && strcmp(name, crypto_wrappers_ctx[i]->opts->name))
 			continue;
 
 		crypto_ctx = malloc(sizeof(*crypto_ctx));
@@ -54,10 +54,10 @@ enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx,
 	}
 
 	if (!crypto_ctx) {
-		if (!type)
+		if (!name)
 			ETLS_ERR("failed to select a crypto wrapper\n");
 		else
-			ETLS_ERR("failed to select the crypto wrapper '%s'\n", type);
+			ETLS_ERR("failed to select the crypto wrapper '%s'\n", name);
 
 		return -ENCLAVE_TLS_ERR_INIT;
 	}
@@ -65,7 +65,7 @@ enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx,
 	ctx->crypto_wrapper = crypto_ctx;
 	ctx->flags |= ENCLAVE_TLS_CTX_FLAGS_CRYPTO_INITIALIZED;
 
-	ETLS_INFO("the crypto wrapper '%s' selected\n", crypto_ctx->opts->type);
+	ETLS_INFO("the crypto wrapper '%s' selected\n", crypto_ctx->opts->name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/crypto_wrappers/nullcrypto/main.c
+++ b/enclave-tls/src/crypto_wrappers/nullcrypto/main.c
@@ -21,7 +21,7 @@ extern crypto_wrapper_err_t nullcrypto_cleanup(crypto_wrapper_ctx_t *);
 
 static crypto_wrapper_opts_t nullcrypto_opts = {
 	.api_version = CRYPTO_WRAPPER_API_VERSION_DEFAULT,
-	.type = "nullcrypto",
+	.name = "nullcrypto",
 	.priority = 0,
 	.pre_init = nullcrypto_pre_init,
 	.init = nullcrypto_init,

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
@@ -23,7 +23,7 @@ extern crypto_wrapper_err_t wolfcrypt_sgx_cleanup(crypto_wrapper_ctx_t *);
 
 static crypto_wrapper_opts_t wolfcrypt_sgx_opts = {
 	.api_version = CRYPTO_WRAPPER_API_VERSION_DEFAULT,
-	.type = "wolfcrypt_sgx",
+	.name = "wolfcrypt_sgx",
 	.priority = 50,
 	.pre_init = wolfcrypt_sgx_pre_init,
 	.init = wolfcrypt_sgx_init,

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_cert.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_cert.c
@@ -58,11 +58,6 @@ wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
 
 		memcpy(crt.quote, ecdsa->quote, ecdsa->quote_len);
 		crt.quoteSz = ecdsa->quote_len;
-	} else if (!strcmp(cert_info->evidence.type, "sgx_ecdsa_qve")) {
-		ecdsa_attestation_evidence_t *ecdsa = &cert_info->evidence.ecdsa;
-
-		memcpy(crt.quote, ecdsa->quote, ecdsa->quote_len);
-		crt.qvequoteSz = ecdsa->quote_len;
 	} else if (!strcmp(cert_info->evidence.type, "sgx_la")) {
 		la_attestation_evidence_t *la = &cert_info->evidence.la;
 

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/main.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/main.c
@@ -22,7 +22,7 @@ extern crypto_wrapper_err_t wolfcrypt_cleanup(crypto_wrapper_ctx_t *);
 
 static crypto_wrapper_opts_t wolfcrypt_opts = {
 	.api_version = CRYPTO_WRAPPER_API_VERSION_DEFAULT,
-	.type = "wolfcrypt",
+	.name = "wolfcrypt",
 	.priority = 20,
 	.pre_init = wolfcrypt_pre_init,
 	.init = wolfcrypt_init,

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_single.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_single.c
@@ -14,21 +14,21 @@
 #define PATTERN_PREFIX          "libenclave_quote_"
 #define PATTERN_SUFFIX          ".so"
 
-enclave_tls_err_t etls_enclave_quote_load_single(const char *name)
+enclave_tls_err_t etls_enclave_quote_load_single(const char *fname)
 {
-	ETLS_DEBUG("loading the enclave quote instance '%s' ...\n", name);
+	ETLS_DEBUG("loading the enclave quote instance '%s' ...\n", fname);
 
-	/* Check whether the filename pattern matches up libenclave_quote_<type>.so */
-	if (strlen(name) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
-	    strncmp(name, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
-	    strncmp(name + strlen(name) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
-		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<type>" PATTERN_SUFFIX "\n",
-			 name);
+	/* Check whether the filename pattern matches up libenclave_quote_<name>.so */
+	if (strlen(fname) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
+	    strncmp(fname, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
+	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
+		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<name>" PATTERN_SUFFIX "\n",
+			 fname);
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}
 
-	char realpath[strlen(ENCLAVE_QUOTES_DIR) + strlen(name) + 1];
-	sprintf(realpath, "%s%s", ENCLAVE_QUOTES_DIR, name);
+	char realpath[strlen(ENCLAVE_QUOTES_DIR) + strlen(fname) + 1];
+	sprintf(realpath, "%s%s", ENCLAVE_QUOTES_DIR, fname);
 
 	void *handle = dlopen(realpath, RTLD_LAZY);
 	if (!handle) {
@@ -36,22 +36,22 @@ enclave_tls_err_t etls_enclave_quote_load_single(const char *name)
 		return -ENCLAVE_TLS_ERR_DLOPEN;
 	}
 
-	size_t type_len = strlen(name) - strlen(PATTERN_PREFIX) - strlen(PATTERN_SUFFIX);
-	char type[type_len + 1];
-	strncpy(type, name + strlen(PATTERN_PREFIX), type_len);
-	type[type_len] = '\0';
+	size_t name_len = strlen(fname) - strlen(PATTERN_PREFIX) - strlen(PATTERN_SUFFIX);
+	char name[name_len + 1];
+	strncpy(name, fname + strlen(PATTERN_PREFIX), name_len);
+	name[name_len] = '\0';
 
 	unsigned int i = 0;
 	enclave_quote_opts_t *opts = NULL;
 	for (i = 0; i < registerd_enclave_quote_nums; ++i) {
 		opts = enclave_quotes_opts[i];
 
-		if (!strcmp(type, opts->type))
+		if (!strcmp(name, opts->name))
 			break;
 	}
 
 	if (i == registerd_enclave_quote_nums) {
-		ETLS_ERR("the enclave quote '%s' is not registered yet\n", type);
+		ETLS_ERR("the enclave quote '%s' is not registered yet\n", name);
 		return -ENCLAVE_TLS_ERR_NOT_REGISTERED;
 	}
 
@@ -59,7 +59,7 @@ enclave_tls_err_t etls_enclave_quote_load_single(const char *name)
 		enclave_tls_err_t err = opts->pre_init();
 
 		if (err != ENCLAVE_QUOTE_ERR_NONE) {
-			ETLS_ERR("failed on pre_init() of enclave quote '%s' %#x\n", type, err);
+			ETLS_ERR("failed on pre_init() of enclave quote '%s' %#x\n", name, err);
 			return err;
 		}
 	}
@@ -74,7 +74,7 @@ enclave_tls_err_t etls_enclave_quote_load_single(const char *name)
 
 	enclave_quotes_ctx[enclave_quote_nums++] = quote_ctx;
 
-	ETLS_DEBUG("the enclave quote '%s' loaded\n", type);
+	ETLS_DEBUG("the enclave quote '%s' loaded\n", name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
@@ -25,14 +25,14 @@ static enclave_tls_err_t init_enclave_quote(etls_core_context_t *ctx,
 }
 
 enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
-					    const char *type,
+					    const char *name,
 					    enclave_tls_cert_algo_t algo)
 {
-	ETLS_DEBUG("selecting the attester '%s' ...\n", type);
+	ETLS_DEBUG("selecting the attester '%s' ...\n", name);
 
 	enclave_quote_ctx_t *quote_ctx = NULL;
 	for (unsigned int i = 0; i < registerd_enclave_quote_nums; ++i) {
-		if (type && strcmp(type, enclave_quotes_ctx[i]->opts->type))
+		if (name && strcmp(name, enclave_quotes_ctx[i]->opts->name))
 			continue;
 
 		quote_ctx = malloc(sizeof(*quote_ctx));
@@ -55,10 +55,10 @@ enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
 	}
 
 	if (!quote_ctx) {
-		if (!type)
+		if (!name)
 			ETLS_ERR("failed to select an attester\n");
 		else
-			ETLS_ERR("failed to select the attester '%s'\n", type);
+			ETLS_ERR("failed to select the attester '%s'\n", name);
 
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}
@@ -66,20 +66,20 @@ enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
 	ctx->attester = quote_ctx;
 	ctx->flags |= ENCLAVE_TLS_CTX_FLAGS_QUOTING_INITIALIZED;
 
-	ETLS_INFO("the attester '%s' selected\n", ctx->attester->opts->type);
+	ETLS_INFO("the attester '%s' selected\n", ctx->attester->opts->name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }
 
 enclave_tls_err_t etls_verifier_select(etls_core_context_t *ctx,
-					    const char *type,
+					    const char *name,
 					    enclave_tls_cert_algo_t algo)
 {
-	ETLS_DEBUG("selecting the verifier '%s' ...\n", type);
+	ETLS_DEBUG("selecting the verifier '%s' ...\n", name);
 
 	enclave_quote_ctx_t *quote_ctx = NULL;
 	for (unsigned int i = 0; i < registerd_enclave_quote_nums; ++i) {
-		if (type && strcmp(type, enclave_quotes_ctx[i]->opts->type))
+		if (name && strcmp(name, enclave_quotes_ctx[i]->opts->name))
 			continue;
 
 		quote_ctx = malloc(sizeof(*quote_ctx));
@@ -102,17 +102,17 @@ enclave_tls_err_t etls_verifier_select(etls_core_context_t *ctx,
 	}
 
 	if (!quote_ctx) {
-		if (!type)
+		if (!name)
 			ETLS_ERR("failed to select a verifier\n");
 		else
-			ETLS_ERR("failed to select the verifier '%s'\n", type);
+			ETLS_ERR("failed to select the verifier '%s'\n", name);
 
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}
 
 	ctx->verifier = quote_ctx;
 
-	ETLS_INFO("the verifier '%s' selected\n", ctx->verifier->opts->type);
+	ETLS_INFO("the verifier '%s' selected\n", ctx->verifier->opts->name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/enclave_quotes/nullquote/main.c
+++ b/enclave-tls/src/enclave_quotes/nullquote/main.c
@@ -25,7 +25,7 @@ extern enclave_quote_err_t nullquote_cleanup(enclave_quote_ctx_t *);
 static enclave_quote_opts_t nullquote_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
 	.flags = ENCLAVE_QUOTE_FLAGS_DEFAULT,
-	.type = "nullquote",
+	.name = "nullquote",
 	.priority = 0,
 	.pre_init = nullquote_pre_init,
 	.init = nullquote_init,

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
@@ -23,7 +23,8 @@ extern enclave_quote_err_t sgx_ecdsa_cleanup(enclave_quote_ctx_t *ctx);
 static enclave_quote_opts_t sgx_ecdsa_qve_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
 	.flags = ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE,
-	.type = "sgx_ecdsa_qve",
+	.name = "sgx_ecdsa_qve",
+	.type = "sgx_ecdsa",
 	.priority = 53,
 	.pre_init = sgx_ecdsa_pre_init,
 	.init = sgx_ecdsa_qve_init,

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/collect_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/collect_evidence.c
@@ -101,7 +101,10 @@ enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 
 	ETLS_DEBUG("Succeed to generate the quote!\n");
 
-	strcpy(evidence->type, ctx->opts->type);
+	/* Essentially speaking, sgx_ecdsa_qve verifier generates the same
+	 * format of quote as sgx_ecdsa.
+	 */
+	strcpy(evidence->type, "sgx_ecdsa");
 	evidence->ecdsa.quote_len = quote_size;
 
 	return ENCLAVE_QUOTE_ERR_NONE;

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/main.c
@@ -26,7 +26,7 @@ extern enclave_quote_err_t sgx_ecdsa_cleanup(enclave_quote_ctx_t *ctx);
 static enclave_quote_opts_t sgx_ecdsa_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
 	.flags = ENCLAVE_QUOTE_FLAGS_DEFAULT,
-	.type = "sgx_ecdsa",
+	.name = "sgx_ecdsa",
 	.priority = 52,
 	.pre_init = sgx_ecdsa_pre_init,
 	.init = sgx_ecdsa_init,

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/verify_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/verify_evidence.c
@@ -106,7 +106,10 @@ enclave_quote_err_t sgx_ecdsa_verify_evidence(enclave_quote_ctx_t *ctx,
                 goto errout;
         }
 
-        if (!strcmp(ctx->opts->type, "sgx_ecdsa_qve")) {
+	/* sgx_ecdsa_qve instance re-uses this code and thus we need to distinguish
+	 * it from sgx_ecdsa instance.
+	 */
+        if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
                 qve_report_info = malloc(sizeof(sgx_ql_qe_report_info_t));
                 if (!qve_report_info) {
                         ETLS_ERR("failed to malloc qve report info.\n");
@@ -168,7 +171,7 @@ enclave_quote_err_t sgx_ecdsa_verify_evidence(enclave_quote_ctx_t *ctx,
                 goto errret;
         }
 
-        if (!strcmp(ctx->opts->type, "sgx_ecdsa_qve")) {
+        if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
                 sgx_ret = sgx_tvl_verify_qve_report_and_identity((sgx_enclave_id_t)ecdsa_ctx->eid,
                                 &verify_qveid_ret,
                                 evidence->ecdsa.

--- a/enclave-tls/src/enclave_quotes/sgx-la/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/main.c
@@ -24,7 +24,7 @@ extern enclave_quote_err_t sgx_la_cleanup(enclave_quote_ctx_t *);
 static enclave_quote_opts_t sgx_la_opts = {
 	.api_version = ENCLAVE_QUOTE_API_VERSION_DEFAULT,
 	.flags = ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE,
-	.type = "sgx_la",
+	.name = "sgx_la",
 	.priority = 15,
 	.pre_init = sgx_la_pre_init,
 	.init = sgx_la_init,

--- a/enclave-tls/src/external/wolfssl/patch/wolfssl.patch
+++ b/enclave-tls/src/external/wolfssl/patch/wolfssl.patch
@@ -1,21 +1,22 @@
-From 0e878efc5addf4349eaadf92a05da6701658d011 Mon Sep 17 00:00:00 2001
-From: Liang Yang <liang3.yang@intel.com>
-Date: Tue, 11 May 2021 12:18:54 +0800
+From eb58f550ab09879e5d90697d5ce480a95a30f83a Mon Sep 17 00:00:00 2001
+From: Jia Zhang <zhang.jia@linux.alibaba.com>
+Date: Sat, 22 May 2021 03:10:12 +0000
 Subject: [PATCH] wolfssl-sgx patch
 
 Signed-off-by: Liang Yang <liang3.yang@intel.com>
+Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>
 ---
  IDE/LINUX-SGX/sgx_t_static.mk  |   3 +-
  configure.ac                   |   2 +-
  m4/ax_vcs_checkout.m4          |   1 -
  pre-commit.sh                  |   6 +-
- wolfcrypt/src/asn.c            | 241 ++++++++++++++++++++++++++++++++-
+ wolfcrypt/src/asn.c            | 222 ++++++++++++++++++++++++++++++++-
  wolfssl/internal.h             |   2 +-
- wolfssl/wolfcrypt/asn_public.h |  19 +++
+ wolfssl/wolfcrypt/asn_public.h |  18 +++
  wolfssl/wolfcrypt/settings.h   |   2 +
  wolfssl/wolfcrypt/types.h      |   1 +
  wolfssl/wolfcrypt/wc_port.h    |   2 +-
- 10 files changed, 269 insertions(+), 10 deletions(-)
+ 10 files changed, 249 insertions(+), 10 deletions(-)
 
 diff --git a/IDE/LINUX-SGX/sgx_t_static.mk b/IDE/LINUX-SGX/sgx_t_static.mk
 index 41ff666f2..1767078e2 100644
@@ -91,7 +92,7 @@ index 9c76f4b30..992ecfe2a 100755
  make -j 8 >/dev/null 2>&1
  
 diff --git a/wolfcrypt/src/asn.c b/wolfcrypt/src/asn.c
-index 12ada17af..e65e91d02 100644
+index 12ada17af..7ee415ccb 100644
 --- a/wolfcrypt/src/asn.c
 +++ b/wolfcrypt/src/asn.c
 @@ -18,7 +18,7 @@
@@ -166,7 +167,7 @@ index 12ada17af..e65e91d02 100644
  #ifdef WOLFSSL_CERT_REQ
      byte attrib[MAX_ATTRIB_SZ];        /* Cert req attributes encoded */
  #endif
-@@ -11873,6 +11899,15 @@ typedef struct DerCert {
+@@ -11873,6 +11899,14 @@ typedef struct DerCert {
      int  extKeyUsageSz;                /* encoded ExtendedKeyUsage extension length */
      int  certPoliciesSz;               /* encoded CertPolicies extension length*/
  #endif
@@ -176,13 +177,12 @@ index 12ada17af..e65e91d02 100644
 +    unsigned int iasSigSz;
 +    unsigned int iasAttestationReportSz;
 +    unsigned int quoteSz;
-+    unsigned int qvequoteSz;
 +    unsigned int lareportSz;
 +#endif
  #ifdef WOLFSSL_ALT_NAMES
      int  altNamesSz;                   /* encoded AltNames extension length */
  #endif
-@@ -12736,7 +12771,16 @@ static int SetKeyUsage(byte* output, word32 outSz, word16 input)
+@@ -12736,7 +12770,16 @@ static int SetKeyUsage(byte* output, word32 outSz, word16 input)
                         ku, idx);
  }
  
@@ -200,7 +200,7 @@ index 12ada17af..e65e91d02 100644
      const byte* oid, word32 oidSz)
  {
      /* verify room */
-@@ -12750,6 +12794,53 @@ static int SetOjectIdValue(byte* output, word32 outSz, int* idx,
+@@ -12750,6 +12793,53 @@ static int SetOjectIdValue(byte* output, word32 outSz, int* idx,
      return 0;
  }
  
@@ -254,7 +254,7 @@ index 12ada17af..e65e91d02 100644
  /* encode Extended Key Usage (RFC 5280 4.2.1.12), return total bytes written */
  static int SetExtKeyUsage(Cert* cert, byte* output, word32 outSz, byte input)
  {
-@@ -13431,6 +13522,17 @@ static int SetValidity(byte* output, int daysValid)
+@@ -13431,6 +13521,17 @@ static int SetValidity(byte* output, int daysValid)
      localTime.tm_year += 1900;
      localTime.tm_mon +=    1;
  
@@ -272,7 +272,7 @@ index 12ada17af..e65e91d02 100644
      SetTime(&localTime, before + beforeSz);
      beforeSz += ASN_GEN_TIME_SZ;
  
-@@ -13450,6 +13552,15 @@ static int SetValidity(byte* output, int daysValid)
+@@ -13450,6 +13551,15 @@ static int SetValidity(byte* output, int daysValid)
      localTime.tm_year += 1900;
      localTime.tm_mon  +=    1;
  
@@ -288,7 +288,7 @@ index 12ada17af..e65e91d02 100644
      SetTime(&localTime, after + afterSz);
      afterSz += ASN_GEN_TIME_SZ;
  
-@@ -13751,6 +13862,75 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
+@@ -13751,6 +13861,65 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
      else
          der->certPoliciesSz = 0;
  #endif /* WOLFSSL_CERT_EXT */
@@ -341,16 +341,6 @@ index 12ada17af..e65e91d02 100644
 +        der->extensionsSz += der->quoteSz;
 +    }
 +
-+    if (cert->qvequoteSz > 0) {
-+	    const unsigned char qvequoteOid[] = OID(0x0f);
-+	    der->qvequoteSz = SetSGXExt(der->quote, sizeof(der->quote),
-+			    qvequoteOid, sizeof(qvequoteOid),
-+			    cert->quote, cert->qvequoteSz);
-+	    assert(der->qvequoteSz > 0);
-+
-+	    der->extensionsSz += der->qvequoteSz;
-+    }
-+
 +    if (cert->lareportSz > 0) {
 +	const unsigned char lareportOid[] = OID(0x0e);
 +	der->lareportSz = SetSGXExt(der->lareport, sizeof(der->lareport),
@@ -364,7 +354,7 @@ index 12ada17af..e65e91d02 100644
  
      /* put extensions */
      if (der->extensionsSz > 0) {
-@@ -13828,6 +14008,61 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
+@@ -13828,6 +13997,53 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
                  return EXTENSIONS_E;
          }
  #endif /* WOLFSSL_CERT_EXT */
@@ -407,14 +397,6 @@ index 12ada17af..e65e91d02 100644
 +
 +	}
 +
-+	if (der->qvequoteSz > 0) {
-+		ret = SetExtensions(der->extensions, sizeof(der->extensions),
-+				&der->extensionsSz,
-+				der->quote, der->qvequoteSz);
-+		if (ret <= 0)
-+			return EXTENSIONS_E;
-+	}
-+
 +	if (der->lareportSz > 0) {
 +		ret = SetExtensions(der->extensions, sizeof(der->extensions),
 +				&der->extensionsSz,
@@ -440,10 +422,10 @@ index 73581fe90..03c7aaae1 100644
  
  #ifndef SESSION_TICKET_LEN
 diff --git a/wolfssl/wolfcrypt/asn_public.h b/wolfssl/wolfcrypt/asn_public.h
-index 480b64f64..a5583ddfe 100644
+index 480b64f64..882969ee9 100644
 --- a/wolfssl/wolfcrypt/asn_public.h
 +++ b/wolfssl/wolfcrypt/asn_public.h
-@@ -332,6 +332,21 @@ typedef struct Cert {
+@@ -332,6 +332,20 @@ typedef struct Cert {
      char    certPolicies[CTC_MAX_CERTPOL_NB][CTC_MAX_CERTPOL_SZ];
      word16  certPoliciesNb;              /* Number of Cert Policy */
  #endif
@@ -458,14 +440,13 @@ index 480b64f64..a5583ddfe 100644
 +    unsigned int	iasAttestationReportSz;
 +    byte    		quote[8192];
 +    unsigned int	quoteSz;
-+    unsigned int	qvequoteSz;
 +    byte    		lareport[8192];
 +    unsigned int	lareportSz;
 +#endif
  #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA)
      byte     issRaw[sizeof(CertName)];   /* raw issuer info */
      byte     sbjRaw[sizeof(CertName)];   /* raw subject info */
-@@ -583,6 +598,10 @@ WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
+@@ -583,6 +597,10 @@ WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
  WOLFSSL_API int wc_GetTime(void* timePtr, word32 timeSize);
  #endif
  
@@ -516,5 +497,5 @@ index da89676bf..baf165f1b 100644
  #endif
  #if !defined(XGMTIME) && !defined(TIME_OVERRIDES)
 -- 
-2.27.0
+2.17.1
 

--- a/enclave-tls/src/include/enclave-tls/crypto_wrapper.h
+++ b/enclave-tls/src/include/enclave-tls/crypto_wrapper.h
@@ -26,7 +26,7 @@ typedef struct crypto_wrapper_ctx             crypto_wrapper_ctx_t;
 typedef struct {
 	uint8_t api_version;
 	unsigned long flags;
-	const char type[CRYPTO_TYPE_NAME_SIZE];
+	const char name[CRYPTO_TYPE_NAME_SIZE];
 	uint8_t priority;
 
 	/* Optional */

--- a/enclave-tls/src/include/enclave-tls/enclave_quote.h
+++ b/enclave-tls/src/include/enclave-tls/enclave_quote.h
@@ -27,7 +27,12 @@ typedef struct enclave_quote_ctx             enclave_quote_ctx_t;
 typedef struct {
 	uint8_t api_version;
 	unsigned long flags;
-	const char type[QUOTE_TYPE_NAME_SIZE];
+	const char name[QUOTE_TYPE_NAME_SIZE];
+	/* Different attester instances may generate the same format of quote,
+	 * e.g, sgx_ecdsa and sgx_ecdsa_qve both generate the format "sgx_ecdsa".
+	 * By default, the value of type equals to name.
+	 */
+	char type[QUOTE_TYPE_NAME_SIZE];
 	uint8_t priority;
 
 	/* Optional */

--- a/enclave-tls/src/include/enclave-tls/tls_wrapper.h
+++ b/enclave-tls/src/include/enclave-tls/tls_wrapper.h
@@ -25,7 +25,7 @@ typedef struct tls_wrapper_ctx             tls_wrapper_ctx_t;
 typedef struct {
 	uint8_t api_version;
 	unsigned long flags;
-	const char type[TLS_TYPE_NAME_SIZE];
+	const char name[TLS_TYPE_NAME_SIZE];
 	uint8_t priority;
 
 	/* Optional */

--- a/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
+++ b/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
@@ -15,11 +15,11 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 	if (!opts)
 		return -CRYPTO_WRAPPER_ERR_INVALID;
 
-	ETLS_DEBUG("registering the tls wrapper '%s' ...\n", opts->type);
+	ETLS_DEBUG("registering the tls wrapper '%s' ...\n", opts->name);
 
 	if (opts->flags & TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
 		if (!is_sgx_supported_and_configured()) {
-			ETLS_DEBUG("failed to register the tls wrapper '%s' due to lack of SGX capability\n", opts->type);
+			ETLS_DEBUG("failed to register the tls wrapper '%s' due to lack of SGX capability\n", opts->name);
 			return -TLS_WRAPPER_ERR_INVALID;
 		}
 	}
@@ -31,8 +31,8 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 
 	memcpy(new_opts, opts, sizeof(*new_opts));
 
-	if (new_opts->type[0] == '\0') {
-		ETLS_ERR("invalid tls wrapper type\n");
+	if (new_opts->name[0] == '\0') {
+		ETLS_ERR("invalid tls wrapper name\n");
 		goto err;
 	}
 
@@ -44,7 +44,7 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 
 	tls_wrappers_opts[registerd_tls_wrapper_nums++] = new_opts;
 
-	ETLS_INFO("the tls wrapper '%s' registered\n", opts->type);
+	ETLS_INFO("the tls wrapper '%s' registered\n", opts->name);
 
 	return TLS_WRAPPER_ERR_NONE;
 

--- a/enclave-tls/src/tls_wrappers/api/tls_wrapper_verify_certificate_extension.c
+++ b/enclave-tls/src/tls_wrappers/api/tls_wrapper_verify_certificate_extension.c
@@ -21,7 +21,7 @@ tls_wrapper_err_t tls_wrapper_verify_certificate_extension(tls_wrapper_ctx_t *tl
 		return -TLS_WRAPPER_ERR_INVALID;
 
 	if (strcmp(tls_ctx->etls_handle->verifier->opts->type, evidence->type)) {
-		ETLS_WARN("type doesn't match between verifier '%s' and evidence '%s'\n", tls_ctx->etls_handle->verifier->opts->type, evidence->type);
+		ETLS_WARN("type doesn't match between verifier '%s' and evidence '%s'\n", tls_ctx->etls_handle->verifier->opts->name, evidence->type);
 		enclave_tls_err_t tlserr = etls_verifier_select(tls_ctx->etls_handle, evidence->type, tls_ctx->etls_handle->config.cert_algo);
 		if (tlserr != ENCLAVE_TLS_ERR_NONE) {
 			ETLS_ERR("the verifier selecting err %#x during verifying cert extension\n", tlserr);

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_single.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_single.c
@@ -14,21 +14,21 @@
 #define PATTERN_PREFIX          "libtls_wrapper_"
 #define PATTERN_SUFFIX          ".so"
 
-enclave_tls_err_t etls_tls_wrapper_load_single(const char *name)
+enclave_tls_err_t etls_tls_wrapper_load_single(const char *fname)
 {
-	ETLS_DEBUG("loading the tls wrapper instance '%s' ...\n", name);
+	ETLS_DEBUG("loading the tls wrapper instance '%s' ...\n", fname);
 
-	/* Check whether the filename pattern matches up libtls_wrapper_<type>.so */
-	if (strlen(name) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
-	    strncmp(name, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
-	    strncmp(name + strlen(name) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
-		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<type>" PATTERN_SUFFIX "\n",
-			 name);
+	/* Check whether the filename pattern matches up libtls_wrapper_<name>.so */
+	if (strlen(fname) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
+	    strncmp(fname, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
+	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
+		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<name>" PATTERN_SUFFIX "\n",
+			 fname);
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}
 
-	char realpath[strlen(TLS_WRAPPERS_DIR) + strlen(name) + 1];
-	sprintf(realpath, "%s%s", TLS_WRAPPERS_DIR, name);
+	char realpath[strlen(TLS_WRAPPERS_DIR) + strlen(fname) + 1];
+	sprintf(realpath, "%s%s", TLS_WRAPPERS_DIR, fname);
 
 	void *handle = dlopen(realpath, RTLD_LAZY);
 	if (!handle) {
@@ -36,22 +36,22 @@ enclave_tls_err_t etls_tls_wrapper_load_single(const char *name)
 		return -ENCLAVE_TLS_ERR_DLOPEN;
 	}
 
-	size_t type_len = strlen(name) - strlen(PATTERN_PREFIX) - strlen(PATTERN_SUFFIX);
-	char type[type_len + 1];
-	strncpy(type, name + strlen(PATTERN_PREFIX), type_len);
-	type[type_len] = '\0';
+	size_t name_len = strlen(fname) - strlen(PATTERN_PREFIX) - strlen(PATTERN_SUFFIX);
+	char name[name_len + 1];
+	strncpy(name, fname + strlen(PATTERN_PREFIX), name_len);
+	name[name_len] = '\0';
 
 	unsigned int i = 0;
 	tls_wrapper_opts_t *opts = NULL;
 	for (i = 0; i < registerd_tls_wrapper_nums; ++i) {
 		opts = tls_wrappers_opts[i];
 
-		if (!strcmp(type, opts->type))
+		if (!strcmp(name, opts->name))
 			break;
 	}
 
 	if (i == registerd_tls_wrapper_nums) {
-		ETLS_ERR("the tls wrapper '%s' is not registered yet\n", type);
+		ETLS_ERR("the tls wrapper '%s' is not registered yet\n", name);
 		return -ENCLAVE_TLS_ERR_NOT_REGISTERED;
 	}
 
@@ -59,7 +59,7 @@ enclave_tls_err_t etls_tls_wrapper_load_single(const char *name)
 		enclave_tls_err_t err = opts->pre_init();
 
 		if (err != TLS_WRAPPER_ERR_NONE) {
-			ETLS_ERR("failed on pre_init() of tls wrapper '%s' %#x\n", type, err);
+			ETLS_ERR("failed on pre_init() of tls wrapper '%s' %#x\n", name, err);
 			return err;
 		}
 	}
@@ -76,7 +76,7 @@ enclave_tls_err_t etls_tls_wrapper_load_single(const char *name)
 
 	tls_wrappers_ctx[tls_wrappers_nums++] = tls_ctx;
 
-	ETLS_DEBUG("the tls wrapper '%s' loaded\n", type);
+	ETLS_DEBUG("the tls wrapper '%s' loaded\n", name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
@@ -23,13 +23,13 @@ static enclave_tls_err_t init_tls_wrapper(tls_wrapper_ctx_t *tls_ctx)
 }
 
 enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx,
-					  const char *type)
+					  const char *name)
 {
-	ETLS_DEBUG("selecting the tls wrapper '%s' ...\n", type);
+	ETLS_DEBUG("selecting the tls wrapper '%s' ...\n", name);
 
 	tls_wrapper_ctx_t *tls_ctx = NULL;
 	for (unsigned int i = 0; i < registerd_tls_wrapper_nums; ++i) {
-		if (type && strcmp(type, tls_wrappers_ctx[i]->opts->type))
+		if (name && strcmp(name, tls_wrappers_ctx[i]->opts->name))
 			continue;
 
 		tls_ctx = malloc(sizeof(*tls_ctx));
@@ -53,10 +53,10 @@ enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx,
 	}
 
 	if (!tls_ctx) {
-		if (!type)
+		if (!name)
 			ETLS_ERR("failed to select a tls wrapper\n");
 		else
-			ETLS_ERR("failed to select the tls wrapper '%s'\n", type);
+			ETLS_ERR("failed to select the tls wrapper '%s'\n", name);
 
 		return -ENCLAVE_TLS_ERR_INIT;
 	}
@@ -65,7 +65,7 @@ enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx,
 	ctx->flags |= ENCLAVE_TLS_CTX_FLAGS_TLS_INITIALIZED;
 	tls_ctx->etls_handle = ctx;
 
-	ETLS_INFO("the tls wrapper '%s' selected\n", tls_ctx->opts->type);
+	ETLS_INFO("the tls wrapper '%s' selected\n", tls_ctx->opts->name);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/tls_wrappers/nulltls/main.c
+++ b/enclave-tls/src/tls_wrappers/nulltls/main.c
@@ -21,7 +21,7 @@ extern tls_wrapper_err_t nulltls_cleanup(tls_wrapper_ctx_t *);
 
 static tls_wrapper_opts_t nulltls_opts = {
 	.api_version = TLS_WRAPPER_API_VERSION_DEFAULT,
-	.type = "nulltls",
+	.name = "nulltls",
 	.priority = 0,
 	.pre_init = nulltls_pre_init,
 	.init = nulltls_init,

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
@@ -20,7 +20,7 @@ extern tls_wrapper_err_t wolfssl_sgx_cleanup(tls_wrapper_ctx_t *);
 
 static tls_wrapper_opts_t wolfssl_sgx_opts = {
 	.api_version = TLS_WRAPPER_API_VERSION_DEFAULT,
-	.type = "wolfssl_sgx",
+	.name = "wolfssl_sgx",
 	.priority = 50,
 	.pre_init = wolfssl_sgx_pre_init,
 	.init = wolfssl_sgx_init,

--- a/enclave-tls/src/tls_wrappers/wolfssl/main.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/main.c
@@ -21,7 +21,7 @@ extern tls_wrapper_err_t wolfssl_cleanup(tls_wrapper_ctx_t *);
 
 static tls_wrapper_opts_t wolfssl_opts = {
 	.api_version = TLS_WRAPPER_API_VERSION_DEFAULT,
-	.type = "wolfssl",
+	.name = "wolfssl",
 	.priority = 20,
 	.pre_init = wolfssl_pre_init,
 	.init = wolfssl_init,

--- a/enclave-tls/src/tls_wrappers/wolfssl/oid.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/oid.c
@@ -13,7 +13,7 @@ const uint8_t ias_root_cert_oid[] = OID(0x03);
 const uint8_t ias_leaf_cert_oid[] = OID(0x04);
 const uint8_t ias_report_signature_oid[] = OID(0x05);
 
-const uint8_t quote_oid[] = OID(0x06);
+const uint8_t ecdsa_quote_oid[] = OID(0x06);
 const uint8_t pck_crt_oid[] = OID(0x07);
 const uint8_t pck_sign_chain_oid[] = OID(0x08);
 const uint8_t tcb_info_oid[] = OID(0x09);
@@ -22,6 +22,5 @@ const uint8_t qe_identity_oid[] = OID(0x0b);
 const uint8_t root_ca_crl_oid[] = OID(0x0c);
 const uint8_t pck_crl_oid[] = OID(0x0d);
 const uint8_t la_report_oid[] = OID(0x0e);
-const uint8_t qve_quote_oid[] = OID(0x0f);
 
 const size_t ias_oid_len = sizeof(ias_response_body_oid);

--- a/enclave-tls/src/tls_wrappers/wolfssl/un_negotiate.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/un_negotiate.c
@@ -130,12 +130,7 @@ static int extract_cert_extensions(const uint8_t *ext, int ext_len,
 		return rc;
 	} else if (!strcmp(evidence->type, "sgx_ecdsa")) {
 		return extract_x509_extension(ext, ext_len,
-					      quote_oid, ias_oid_len,
-					      evidence->ecdsa.quote, &evidence->ecdsa.quote_len,
-					      sizeof(evidence->ecdsa.quote));
-	} else if (!strcmp(evidence->type, "sgx_ecdsa_qve")) {
-		return extract_x509_extension(ext, ext_len,
-					      qve_quote_oid, ias_oid_len,
+					      ecdsa_quote_oid, ias_oid_len,
 					      evidence->ecdsa.quote, &evidence->ecdsa.quote_len,
 					      sizeof(evidence->ecdsa.quote));
 	} else if (!strcmp(evidence->type, "sgx_la")) {
@@ -233,13 +228,12 @@ int verify_certificate(int preverify, WOLFSSL_X509_STORE_CTX *store)
 	uint8_t* ext_data;
     	size_t ext_data_len;
 
-	strncpy(evidence.type, "nullquote", sizeof(evidence.type));
-	if (find_oid(der_cert, der_cert_len, qve_quote_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
-		strncpy(evidence.type, "sgx_ecdsa_qve", sizeof(evidence.type));
-	if (find_oid(der_cert, der_cert_len, quote_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
+	if (find_oid(der_cert, der_cert_len, ecdsa_quote_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
 		strncpy(evidence.type, "sgx_ecdsa", sizeof(evidence.type));
-	if (find_oid(der_cert, der_cert_len, la_report_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
+	else if (find_oid(der_cert, der_cert_len, la_report_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
 		strncpy(evidence.type, "sgx_la", sizeof(evidence.type));
+	else
+		strncpy(evidence.type, "nullquote", sizeof(evidence.type));
 
 	int rc = extract_cert_extensions(crt.extensions, crt.extensionsSz,
 					 &evidence);

--- a/enclave-tls/src/tls_wrappers/wolfssl/wolfssl.h
+++ b/enclave-tls/src/tls_wrappers/wolfssl/wolfssl.h
@@ -27,12 +27,11 @@ extern const uint8_t ias_root_cert_oid[];
 extern const uint8_t ias_leaf_cert_oid[];
 extern const uint8_t ias_report_signature_oid[];
 
-extern const uint8_t quote_oid[];
+extern const uint8_t ecdsa_quote_oid[];
 extern const uint8_t pck_crt_oid[];
 extern const uint8_t pck_sign_chain_oid[];
 extern const uint8_t tcb_info_oid[];
 extern const uint8_t tcb_sign_chain_oid[];
-extern const uint8_t qve_quote_oid[];
 
 extern const size_t ias_oid_len;
 extern const uint8_t la_report_oid[];


### PR DESCRIPTION
Tested by enclave-tls-server -m -a sgx_ecdsa|sgx_ecdsa_qve -v sgx_ecdsa|sgx_ecdsa_qve and enclave-tls-client -m -a sgx_ecdsa|sgx_ecdsa_qve -v sgx_ecdsa|sgx_ecdsa_qve


Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>