### PR TITLE
shelter/dist: update rpm and deb version to 0.6.1

### DIFF
--- a/shelter/dist/deb/debian/changelog
+++ b/shelter/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+shelter (0.6.1-1) unstable; urgency=low
+
+  * Update to version 0.6.1.
+
+ -- Yilin Li <YiLin.Li@linux.alibaba.com>  Sat, May 22 2021 15:40:00 +0000
+
 shelter (0.6.0-1) unstable; urgency=low
 
   * Initial release.

--- a/shelter/dist/rpm/shelter.spec
+++ b/shelter/dist/rpm/shelter.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: shelter
-Version: 0.6.0
+Version: 0.6.1
 Release: %{centos_base_release}%{?dist}
 Summary: shelter is designed as a remote attestation tool for customer to verify if their workloads are loaded in a specified intel authorized sgx enclaved.
 
@@ -53,5 +53,8 @@ install -p -m 755 %{name}/%{name} %{buildroot}%{BIN_DIR}
 %{BIN_DIR}/%{name}
 
 %changelog
-* Thu Apr 15 2021 Zhiming Hu <zhiming.hu@intel.com> - 0.6.1
+* Sat May 22 2021 Yilin Li <YiLin.Li@linux.alibaba.com> - 0.6.1
+- Update to version 0.6.1.
+
+* Thu Apr 15 2021 Zhiming Hu <zhiming.hu@intel.com> - 0.6.0
 - Package init.


### PR DESCRIPTION
The shelter centos 8.2 rpm and ubuntu 18.04 deb package is needed by ACK-TEE,
So we need to update the shelter rpm and deb version to 0.6.1

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>