### PR TITLE
enclave-tls: use clang-format (>=9.x) to re-format the codes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# clang-format configuration file. Intended for clang-format >= 9.
+# Refer to https://github.com/torvalds/linux/blob/master/.clang-format
+#
+# For more information, see:
+#
+#   Documentation/process/clang-format.rst
+#   https://clang.llvm.org/docs/ClangFormat.html
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+#AlignConsecutiveBitFields: None # Unknown to clang-format-9.0
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true # Unknown to clang-format-6.0
+AlignEscapedNewlines: Left # Unknown to clang-format-4.0
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false # Unknown to clang-format-6.0
+AllowAllConstructorInitializersOnNextLine: false # Unknown to clang-format-6.0
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+#AllowShortEnumsOnASingleLine: truetrue  # Unknown to clang-format-9.0
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: None # Unknown to clang-format-6.0
+AllowShortLoopsOnASingleLine: false
+#AlwaysBreakAfterDefinitionReturnType: None # Deprecated
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+#AttributeMacros: ['__trusted', '__untrusted'] # Unused
+BinPackArguments: true
+BinPackParameters: true
+#BitFieldColonSpacing: None # Unknown to clang-format-9.0
+BraceWrapping:
+  AfterCaseLabel: false # Unknown to clang-format-6.0
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false # Unknown to clang-format-5.0
+  BeforeCatch: false
+  #BeforeLambdaBody: false # Unknown to clang-format-9.0
+  #BeforeWhile: false # Unknown to clang-format-9.0
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true # Unknown to clang-format-4.0
+  SplitEmptyRecord: true # Unknown to clang-format-4.0
+  SplitEmptyNamespace: true # Unknown to clang-format-4.0
+BreakAfterJavaFieldAnnotations: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+#BreakBeforeConceptDeclarations: false # Unknown to clang-format-9.0
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
+BreakInheritanceList: BeforeColon # Unknown to clang-format-6.0
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IC pragma:'
+CompactNamespaces: false # Unknown to clang-format-4.0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+#DeriveLineEnding: false # Unknown to clang-format-9.0
+DerivePointerAlignment: false
+DisableFormat: false
+#EmptyLineAfterAccessModifier: Never # Unknown to clang-format-9.0
+#EmptyLineBeforeAccessModifier: LogicalBlock # Unknown to clang-format-9.0
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false # Unknown to clang-format-4.0
+ForEachMacros: ['foreach', 'FOREACH']
+IncludeBlocks: Preserve # Unknown to clang-format-5.0
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+#IncludeIsMainSourceRegex: # Not required 
+#IndentAccessModifiers: true # Unknown to clang-format-9.0
+#IndentCaseBlocks: false # Unknown to clang-format-9.0
+IndentCaseLabels: false
+#IndentExternBlock: Indent # Unknown to clang-format-9.0
+#IndentGotoLabels: false # Unknown to clang-format-9.0
+IndentPPDirectives: BeforeHash # Unknown to clang-format-6.0
+#IndentRequires: false # Unknown to clang-format-9.0
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+#InsertTrailingCommas: Wrapped # Unknown to clang-format-9.0
+JavaImportGroups: ['com.example', 'com', 'org'] # Unknown to clang-format-6.0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+#Language: # Not required
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+#NamespaceMacros: # Not required
+ObjCBinPackProtocolList: Auto # Unknown to clang-format-6.0
+ObjCBlockIndentWidth: 8
+#ObjCBreakBeforeNestedBlockParam: 8 # Unknown to clang-format-9.0
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+# Taken from git's rules
+PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyBreakTemplateDeclaration: 10 # Unknown to clang-format-6.0
+PenaltyExcessCharacter: 100
+#PenaltyIndentedWhitespace: 0 # Unknown to clang-format-9.0
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+#RawStringFormats: # Not required
+ReflowComments: false
+#ShortNamespaceLines: 1 # Unknown to clang-format-9.0
+SortIncludes: false
+#SortJavaStaticImport: Before # Unknown to clang-format-9.0
+SortUsingDeclarations: false # Unknown to clang-format-4.0
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false # Unknown to clang-format-6.0
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCaseColon: false # Unknown to clang-format-9.0
+SpaceBeforeCpp11BracedList: true # Unknown to clang-format-6.0
+SpaceBeforeCtorInitializerColon: true # Unknown to clang-format-6.0
+SpaceBeforeInheritanceColon: true # Unknown to clang-format-6.0
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-6.0
+#SpaceBeforeSquareBrackets: false # Unknown to clang-format-9.0
+SpaceInEmptyParentheses: false
+#SpaceInEmptyBlock: true # Unknown to clang-format-9.0
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+#SpacesInConditionalStatement: false # Unknown to clang-format-9.0
+SpacesInContainerLiterals: false
+#SpacesInLineCommentPrefix: # Unknown to clang-format-9.0
+#  - Minimum: 1
+#  - Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+#StatementAttributeLikeMacros: # Not required
+#StatementMacros: # Not required
+TabWidth: 8
+#TypenameMacros: # Not required
+#UseCRLF: false # Unknown to clang-format-9.0
+UseTab: Always
+#WhitespaceSensitiveMacros: # Not required
+...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,38 +78,38 @@ Right now we assume every contribution via pull request is for the `master` bran
 
 ### Format C Codes
 
-Inclavare Containers project uses `indent` to format C codes.
+Inclavare Containers project uses `clang-format` to format C codes.
 
-1. Install `indent`. Please make sure the version of `indent` must be 2.2.12 or higher to get advanced features.
+1. Install `clang-format`. Please make sure the version of `clang-format` must be 9.x or higher to get advanced features.
 
+For Ubuntu:
 ```shell
-wget -c https://ftp.gnu.org/gnu/indent/indent-2.2.12.tar.gz
-tar xzf indent-2.2.12.tar.gz
-cd indent-2.2.12
-./configure
-make
-sudo make install
+sudo apt-get install -y clang-format-9
+```
+
+For CentOS:
+```shell
+sudo yum install -y clang
 ```
 
 2. Format C code style using the following command:
 
 ```shell
-indent -npro -linux -il-8 -ppi2 -nbbo -ci0 -cs -cp1 -gts foo.c
+clang-format -i foo.c
 ```
 
-However, `indent` might generate unexpected results sometimes due to its limitation. For example, `indent` will completely destroy the indentation of the inline assembly because it does not recognize the syntax of inline assembly codes.
+`clang-format` might generate unexpected results sometimes due to its limitation. To avoid the problem, you need to temporarily disable formatting with [special comments](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code), e.g, forbidding formatting the following codes:
 
-To avoid this problem, you need to temporarily disable formatting with [the pair of control comment](https://www.gnu.org/software/indent/manual/indent.html#SEC13), e.g, forbidding formatting the following inline assembly codes.
-
-```shell
-/* *INDENT-OFF* */
-asm volatile(".byte 0x0f,0x01,0xd0" /* xgetbv */
-	     : "=a" (eax), "=d" (edx)
-	     : "c" (index));
-/* *INDENT-ON* */
+```C
+// clang-format off
+typedef enum {
+        VERIFICATION_TYPE_QVL,
+        VERIFICATION_TYPE_QEL
+} quote_sgx_ecdsa_verification_type_t;
+// clang-format on
 ```
 
-Please refer to [this manual](https://www.gnu.org/software/indent/manual/indent.html) for the details about the options of `indent`.
+Please refer to [this page](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for the details about the options of `clang-format`.
 
 ### Commit Rules
 

--- a/enclave-tls/samples/enclave-tls-client/client.c
+++ b/enclave-tls/samples/enclave-tls-client/client.c
@@ -15,16 +15,17 @@
 #include <enclave-tls/api.h>
 #include <enclave-tls/log.h>
 
-#define DEFAULT_PORT     1234
-#define DEFAULT_IP       "127.0.0.1"
+#define DEFAULT_PORT 1234
+#define DEFAULT_IP   "127.0.0.1"
 
+// clang-format off
 #ifdef OCCLUM
-#include <sgx_report.h>
+  #include <sgx_report.h>
 #elif defined(SGX)
-#include <sgx_urts.h>
-#include <sgx_quote.h>
+  #include <sgx_urts.h>
+  #include <sgx_quote.h>
 
-#define ENCLAVE_FILENAME "sgx_stub_enclave.signed.so"
+  #define ENCLAVE_FILENAME "sgx_stub_enclave.signed.so"
 
 static sgx_enclave_id_t load_enclave(bool debug_enclave)
 {
@@ -45,10 +46,10 @@ static sgx_enclave_id_t load_enclave(bool debug_enclave)
 	return eid;
 }
 #endif
+// clang-format on
 
-int enclave_tls_echo(int fd, enclave_tls_log_level_t log_level,
-		     char *attester_type, char *verifier_type,
-		     char *tls_type, char *crypto_type, bool mutual,
+int enclave_tls_echo(int fd, enclave_tls_log_level_t log_level, char *attester_type,
+		     char *verifier_type, char *tls_type, char *crypto_type, bool mutual,
 		     bool debug_enclave)
 {
 	enclave_tls_conf_t conf;
@@ -115,7 +116,8 @@ int enclave_tls_echo(int fd, enclave_tls_log_level_t log_level,
 			printf("%02x", (uint8_t)buf[i]);
 		printf("\n");
 
-		memcpy(buf, buf + 2 * sizeof(sgx_measurement_t), len - 2 * sizeof(sgx_measurement_t));
+		memcpy(buf, buf + 2 * sizeof(sgx_measurement_t),
+		       len - 2 * sizeof(sgx_measurement_t));
 		buf[len - 2 * sizeof(sgx_measurement_t)] = '\0';
 
 		ETLS_INFO("Server:\n%s\n", buf);
@@ -149,19 +151,21 @@ int main(int argc, char **argv)
 	printf("    - Welcome to Enclave-TLS sample client program\n");
 
 	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	// clang-format off
 	struct option long_options[] = {
-		{"attester", required_argument, NULL, 'a'},
-		{"verifier", required_argument, NULL, 'v'},
-		{"tls", required_argument, NULL, 't'},
-		{"crypto", required_argument, NULL, 'c'},
-		{"mutual", no_argument, NULL, 'm'},
-		{"log-level", required_argument, NULL, 'l'},
-		{"ip", required_argument, NULL, 'i'},
-		{"port", required_argument, NULL, 'p'},
-		{"debug-enclave", no_argument, NULL, 'D'},
-		{"help", no_argument, NULL, 'h'},
-		{0, 0, 0, 0}
+		{ "attester", required_argument, NULL, 'a' },
+		{ "verifier", required_argument, NULL, 'v' },
+		{ "tls", required_argument, NULL, 't' },
+		{ "crypto", required_argument, NULL, 'c' },
+		{ "mutual", no_argument, NULL, 'm' },
+		{ "log-level", required_argument, NULL, 'l' },
+		{ "ip", required_argument, NULL, 'i' },
+		{ "port", required_argument, NULL, 'p' },
+		{ "debug-enclave", no_argument, NULL, 'D' },
+		{ "help", no_argument, NULL, 'h' },
+		{ 0, 0, 0, 0 }
 	};
+	// clang-format on
 
 	char *attester_type = "";
 	char *verifier_type = "";
@@ -175,8 +179,7 @@ int main(int argc, char **argv)
 	int opt;
 
 	do {
-		opt = getopt_long(argc, argv, short_options, long_options,
-				  NULL);
+		opt = getopt_long(argc, argv, short_options, long_options, NULL);
 		switch (opt) {
 		case 'a':
 			attester_type = optarg;
@@ -219,19 +222,19 @@ int main(int argc, char **argv)
 		case -1:
 			break;
 		case 'h':
-                        puts("    Usage:\n\n"
-                        "        enclave-tls-client <options> [arguments]\n\n"
-                        "    Options:\n\n"
-                        "        --attester/-a value   set the type of quote attester\n"
-                        "        --verifier/-v value   set the type of quote verifier\n"
-                        "        --tls/-t value        set the type of tls wrapper\n"
-                        "        --crypto/-c value     set the type of crypto wrapper\n"
-                        "        --mutual/-m           set to enable mutual attestation\n"
-                        "        --log-level/-l        set the log level\n"
-                        "        --ip/-i               set the listening ip address\n"
-                        "        --port/-p             set the listening tcp port\n"
-                        "        --debug-enclave/-D    set to enable enclave debugging\n"
-                        "        --help/-h             show the usage\n");
+			puts("    Usage:\n\n"
+			     "        enclave-tls-client <options> [arguments]\n\n"
+			     "    Options:\n\n"
+			     "        --attester/-a value   set the type of quote attester\n"
+			     "        --verifier/-v value   set the type of quote verifier\n"
+			     "        --tls/-t value        set the type of tls wrapper\n"
+			     "        --crypto/-c value     set the type of crypto wrapper\n"
+			     "        --mutual/-m           set to enable mutual attestation\n"
+			     "        --log-level/-l        set the log level\n"
+			     "        --ip/-i               set the listening ip address\n"
+			     "        --port/-p             set the listening tcp port\n"
+			     "        --debug-enclave/-D    set to enable enclave debugging\n"
+			     "        --help/-h             show the usage\n");
 		default:
 			exit(1);
 		}
@@ -260,12 +263,11 @@ int main(int argc, char **argv)
 	}
 
 	/* Connect to the server */
-	if (connect(sockfd, (struct sockaddr *) &s_addr, sizeof(s_addr)) == -1) {
+	if (connect(sockfd, (struct sockaddr *)&s_addr, sizeof(s_addr)) == -1) {
 		perror("failed to call connect()\n");
 		return -1;
 	}
 
-	return enclave_tls_echo(sockfd, log_level,
-				attester_type, verifier_type, tls_type,
+	return enclave_tls_echo(sockfd, log_level, attester_type, verifier_type, tls_type,
 				crypto_type, mutual, debug_enclave);
 }

--- a/enclave-tls/samples/enclave-tls-server/server.c
+++ b/enclave-tls/samples/enclave-tls-server/server.c
@@ -16,18 +16,19 @@
 #include <enclave-tls/api.h>
 #include <enclave-tls/log.h>
 
-#define DEFAULT_PORT         1234
-#define DEFAULT_IP           "127.0.0.1"
+#define DEFAULT_PORT 1234
+#define DEFAULT_IP   "127.0.0.1"
 
+// clang-format off
 #ifdef OCCLUM
-#include <sgx_report.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
+  #include <sgx_report.h>
+  #include <fcntl.h>
+  #include <sys/ioctl.h>
 #elif defined(SGX)
-#include <sgx_urts.h>
-#include <sgx_quote.h>
+  #include <sgx_urts.h>
+  #include <sgx_quote.h>
 
-#define ENCLAVE_FILENAME     "sgx_stub_enclave.signed.so"
+  #define ENCLAVE_FILENAME "sgx_stub_enclave.signed.so"
 
 static sgx_enclave_id_t load_enclave(bool debug_enclave)
 {
@@ -53,12 +54,12 @@ static sgx_enclave_id_t load_enclave(bool debug_enclave)
 typedef struct {
 	const sgx_target_info_t *target_info;
 	const sgx_report_data_t *report_data;
-	sgx_report_t            *report;
+	sgx_report_t *report;
 } sgxioc_create_report_arg_t;
 
-#define SGXIOC_SELF_TARGET	_IOR('s', 3, sgx_target_info_t)
-#define SGXIOC_CREATE_REPORT	_IOWR('s', 4, sgxioc_create_report_arg_t)
-#define ENCLAVE_TLS_HELLO	"Hello and welcome to Enclave TLS!\n"
+  #define SGXIOC_SELF_TARGET   _IOR('s', 3, sgx_target_info_t)
+  #define SGXIOC_CREATE_REPORT _IOWR('s', 4, sgxioc_create_report_arg_t)
+  #define ENCLAVE_TLS_HELLO    "Hello and welcome to Enclave TLS!\n"
 
 static int sgx_create_report(sgx_report_t *report)
 {
@@ -91,10 +92,10 @@ static int sgx_create_report(sgx_report_t *report)
 	return 0;
 }
 #endif
+// clang-format on
 
-int enclave_tls_server_startup(int sockfd, enclave_tls_log_level_t log_level,
-			       char *attester_type, char *verifier_type,
-			       char *tls_type, char *crypto_type, bool mutual,
+int enclave_tls_server_startup(int sockfd, enclave_tls_log_level_t log_level, char *attester_type,
+			       char *verifier_type, char *tls_type, char *crypto_type, bool mutual,
 			       bool debug_enclave)
 {
 	enclave_tls_conf_t conf;
@@ -167,8 +168,10 @@ int enclave_tls_server_startup(int sockfd, enclave_tls_log_level_t log_level,
 		/* Write mrencalve, mesigner and hello into buff */
 		memset(buf, 0, sizeof(buf));
 		memcpy(buf, &app_report.body.mr_enclave, sizeof(sgx_measurement_t));
-		memcpy(buf + sizeof(sgx_measurement_t), &app_report.body.mr_signer, sizeof(sgx_measurement_t));
-		memcpy(buf + 2 * sizeof(sgx_measurement_t), ENCLAVE_TLS_HELLO, sizeof(ENCLAVE_TLS_HELLO));
+		memcpy(buf + sizeof(sgx_measurement_t), &app_report.body.mr_signer,
+		       sizeof(sgx_measurement_t));
+		memcpy(buf + 2 * sizeof(sgx_measurement_t), ENCLAVE_TLS_HELLO,
+		       sizeof(ENCLAVE_TLS_HELLO));
 
 		len = 2 * sizeof(sgx_measurement_t) + strlen(ENCLAVE_TLS_HELLO);
 #endif
@@ -196,19 +199,21 @@ int main(int argc, char **argv)
 	printf("    - Welcome to Enclave-TLS sample server program\n");
 
 	char *const short_options = "a:v:t:c:ml:i:p:D:h";
+	// clang-format off
 	struct option long_options[] = {
-		{"attester", required_argument, NULL, 'a'},
-		{"verifier", required_argument, NULL, 'v'},
-		{"tls", required_argument, NULL, 't'},
-		{"crypto", required_argument, NULL, 'c'},
-		{"mutual", no_argument, NULL, 'm'},
-		{"log-level", required_argument, NULL, 'l'},
-		{"ip", required_argument, NULL, 'i'},
-		{"port", required_argument, NULL, 'p'},
-		{"debug-enclave", no_argument, NULL, 'D'},
-		{"help", no_argument, NULL, 'h'},
-		{0, 0, 0, 0}
+		{ "attester", required_argument, NULL, 'a' },
+		{ "verifier", required_argument, NULL, 'v' },
+		{ "tls", required_argument, NULL, 't' },
+		{ "crypto", required_argument, NULL, 'c' },
+		{ "mutual", no_argument, NULL, 'm' },
+		{ "log-level", required_argument, NULL, 'l' },
+		{ "ip", required_argument, NULL, 'i' },
+		{ "port", required_argument, NULL, 'p' },
+		{ "debug-enclave", no_argument, NULL, 'D' },
+		{ "help", no_argument, NULL, 'h' },
+		{ 0, 0, 0, 0 }
 	};
+	// clang-format on
 
 	char *attester_type = "";
 	char *verifier_type = "";
@@ -222,8 +227,7 @@ int main(int argc, char **argv)
 	int opt;
 
 	do {
-		opt = getopt_long(argc, argv, short_options, long_options,
-				  NULL);
+		opt = getopt_long(argc, argv, short_options, long_options, NULL);
 		switch (opt) {
 		case 'a':
 			attester_type = optarg;
@@ -267,18 +271,18 @@ int main(int argc, char **argv)
 			break;
 		case 'h':
 			puts("    Usage:\n\n"
-			"        enclave-tls-server <options> [arguments]\n\n"
-			"    Options:\n\n"
-			"        --attester/-a value   set the type of quote attester\n"
-			"        --verifier/-v value   set the type of quote verifier\n"
-			"        --tls/-t value        set the type of tls wrapper\n"
-			"        --crypto/-c value     set the type of crypto wrapper\n"
-			"        --mutual/-m           set to enable mutual attestation\n"
-			"        --log-level/-l        set the log level\n"
-			"        --ip/-i               set the listening ip address\n"
-			"        --port/-p             set the listening tcp port\n"
-			"        --debug-enclave/-D    set to enable enclave debugging\n"
-			"        --help/-h             show the usage\n");
+			     "        enclave-tls-server <options> [arguments]\n\n"
+			     "    Options:\n\n"
+			     "        --attester/-a value   set the type of quote attester\n"
+			     "        --verifier/-v value   set the type of quote verifier\n"
+			     "        --tls/-t value        set the type of tls wrapper\n"
+			     "        --crypto/-c value     set the type of crypto wrapper\n"
+			     "        --mutual/-m           set to enable mutual attestation\n"
+			     "        --log-level/-l        set the log level\n"
+			     "        --ip/-i               set the listening ip address\n"
+			     "        --port/-p             set the listening tcp port\n"
+			     "        --debug-enclave/-D    set to enable enclave debugging\n"
+			     "        --help/-h             show the usage\n");
 		default:
 			exit(1);
 		}
@@ -291,8 +295,7 @@ int main(int argc, char **argv)
 	}
 
 	int reuse = 1;
-	int ret = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR,
-			     (const void *)&reuse, sizeof(int));
+	int ret = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (const void *)&reuse, sizeof(int));
 	if (ret < 0) {
 		perror("Failed to call setsockopt()");
 		return -1;
@@ -316,7 +319,6 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	return enclave_tls_server_startup(sockfd, log_level,
-					  attester_type, verifier_type,
-					  tls_type, crypto_type, mutual, debug_enclave);
+	return enclave_tls_server_startup(sockfd, log_level, attester_type, verifier_type, tls_type,
+					  crypto_type, mutual, debug_enclave);
 }

--- a/enclave-tls/src/api/enclave_tls_cleanup.c
+++ b/enclave-tls/src/api/enclave_tls_cleanup.c
@@ -19,9 +19,8 @@ enclave_tls_err_t enclave_tls_cleanup(enclave_tls_handle handle)
 	ETLS_DEBUG("handle %p\n", ctx);
 
 	if (!handle || !handle->tls_wrapper || !handle->tls_wrapper->opts ||
-	    !handle->tls_wrapper->opts->cleanup || !handle->attester ||
-	    !handle->attester->opts || !handle->attester->opts->cleanup ||
-	    !handle->verifier || !handle->verifier->opts ||
+	    !handle->tls_wrapper->opts->cleanup || !handle->attester || !handle->attester->opts ||
+	    !handle->attester->opts->cleanup || !handle->verifier || !handle->verifier->opts ||
 	    !handle->verifier->opts->cleanup)
 		return -ENCLAVE_TLS_ERR_INVALID;
 

--- a/enclave-tls/src/api/enclave_tls_init.c
+++ b/enclave-tls/src/api/enclave_tls_init.c
@@ -12,8 +12,7 @@
 #include "internal/tls_wrapper.h"
 #include "internal/enclave_quote.h"
 
-enclave_tls_err_t enclave_tls_init(const enclave_tls_conf_t *conf,
-				   enclave_tls_handle *handle)
+enclave_tls_err_t enclave_tls_init(const enclave_tls_conf_t *conf, enclave_tls_handle *handle)
 {
 	if (!conf || !handle)
 		return -ENCLAVE_TLS_ERR_INVALID;
@@ -29,14 +28,15 @@ enclave_tls_err_t enclave_tls_init(const enclave_tls_conf_t *conf,
 	enclave_tls_err_t err = -ENCLAVE_TLS_ERR_INVALID;
 
 	if (ctx->config.api_version > ENCLAVE_TLS_API_VERSION_MAX) {
-		ETLS_ERR("unsupported enclave-tls api version %d > %d\n",
-			 ctx->config.api_version, ENCLAVE_TLS_API_VERSION_MAX);
+		ETLS_ERR("unsupported enclave-tls api version %d > %d\n", ctx->config.api_version,
+			 ENCLAVE_TLS_API_VERSION_MAX);
 		goto err_ctx;
 	}
 
 	if (ctx->config.log_level < 0 || ctx->config.log_level >= ENCLAVE_TLS_LOG_LEVEL_MAX) {
 		ctx->config.log_level = global_core_context.config.log_level;
-		ETLS_WARN("log level reset to global value %d\n", global_core_context.config.log_level);
+		ETLS_WARN("log level reset to global value %d\n",
+			  global_core_context.config.log_level);
 	}
 
 	if (ctx->config.cert_algo < 0 || ctx->config.cert_algo >= ENCLAVE_TLS_CERT_ALGO_MAX) {

--- a/enclave-tls/src/api/enclave_tls_negotiate.c
+++ b/enclave-tls/src/api/enclave_tls_negotiate.c
@@ -13,8 +13,7 @@ enclave_tls_err_t enclave_tls_negotiate(enclave_tls_handle handle, int fd)
 
 	ETLS_DEBUG("handle %p, fd %d\n", ctx, fd);
 
-	if (!ctx || !ctx->tls_wrapper ||
-	    !ctx->tls_wrapper->opts ||
+	if (!ctx || !ctx->tls_wrapper || !ctx->tls_wrapper->opts ||
 	    !ctx->tls_wrapper->opts->negotiate || fd < 0)
 		return -ENCLAVE_TLS_ERR_INVALID;
 

--- a/enclave-tls/src/api/enclave_tls_receive.c
+++ b/enclave-tls/src/api/enclave_tls_receive.c
@@ -8,8 +8,7 @@
 
 #include "internal/core.h"
 
-enclave_tls_err_t enclave_tls_receive(enclave_tls_handle handle, void *buf,
-				      size_t *buf_size)
+enclave_tls_err_t enclave_tls_receive(enclave_tls_handle handle, void *buf, size_t *buf_size)
 {
 	etls_core_context_t *ctx = (etls_core_context_t *)handle;
 
@@ -20,8 +19,7 @@ enclave_tls_err_t enclave_tls_receive(enclave_tls_handle handle, void *buf,
 		return -ENCLAVE_TLS_ERR_INVALID;
 
 	enclave_tls_err_t err;
-	err = handle->tls_wrapper->opts->receive(handle->tls_wrapper, buf,
-						 buf_size);
+	err = handle->tls_wrapper->opts->receive(handle->tls_wrapper, buf, buf_size);
 	if (err != TLS_WRAPPER_ERR_NONE)
 		return err;
 

--- a/enclave-tls/src/api/enclave_tls_transmit.c
+++ b/enclave-tls/src/api/enclave_tls_transmit.c
@@ -8,8 +8,7 @@
 
 #include "internal/core.h"
 
-enclave_tls_err_t enclave_tls_transmit(enclave_tls_handle handle, void *buf,
-				       size_t *buf_size)
+enclave_tls_err_t enclave_tls_transmit(enclave_tls_handle handle, void *buf, size_t *buf_size)
 {
 	etls_core_context_t *ctx = (etls_core_context_t *)handle;
 
@@ -20,8 +19,7 @@ enclave_tls_err_t enclave_tls_transmit(enclave_tls_handle handle, void *buf,
 		return -ENCLAVE_TLS_ERR_INVALID;
 
 	enclave_tls_err_t err;
-	err = handle->tls_wrapper->opts->transmit(handle->tls_wrapper, buf,
-						  buf_size);
+	err = handle->tls_wrapper->opts->transmit(handle->tls_wrapper, buf, buf_size);
 	if (err != TLS_WRAPPER_ERR_NONE)
 		return err;
 

--- a/enclave-tls/src/core/etls_core_generate_certificate.c
+++ b/enclave-tls/src/core/etls_core_generate_certificate.c
@@ -12,9 +12,8 @@ enclave_tls_err_t etls_core_generate_certificate(etls_core_context_t *ctx)
 {
 	ETLS_DEBUG("ctx %p\n", ctx);
 
-	if (!ctx || !ctx->tls_wrapper || !ctx->tls_wrapper->opts ||
-	    !ctx->crypto_wrapper || !ctx->crypto_wrapper->opts ||
-	    !ctx->crypto_wrapper->opts->gen_pubkey_hash ||
+	if (!ctx || !ctx->tls_wrapper || !ctx->tls_wrapper->opts || !ctx->crypto_wrapper ||
+	    !ctx->crypto_wrapper->opts || !ctx->crypto_wrapper->opts->gen_pubkey_hash ||
 	    !ctx->crypto_wrapper->opts->gen_cert)
 		return -ENCLAVE_TLS_ERR_INVALID;
 
@@ -40,8 +39,7 @@ enclave_tls_err_t etls_core_generate_certificate(etls_core_context_t *ctx)
 	crypto_wrapper_err_t c_err;
 	uint8_t privkey_buf[2048];
 	unsigned int privkey_len = sizeof(privkey_buf);
-	c_err = ctx->crypto_wrapper->opts->gen_privkey(ctx->crypto_wrapper,
-						       ctx->config.cert_algo,
+	c_err = ctx->crypto_wrapper->opts->gen_privkey(ctx->crypto_wrapper, ctx->config.cert_algo,
 						       privkey_buf, &privkey_len);
 	if (c_err != CRYPTO_WRAPPER_ERR_NONE)
 		return c_err;
@@ -49,8 +47,7 @@ enclave_tls_err_t etls_core_generate_certificate(etls_core_context_t *ctx)
 	/* Generate the hash of public key */
 	uint8_t hash[hash_size];
 	c_err = ctx->crypto_wrapper->opts->gen_pubkey_hash(ctx->crypto_wrapper,
-							   ctx->config.cert_algo,
-							   hash);
+							   ctx->config.cert_algo, hash);
 	if (c_err != CRYPTO_WRAPPER_ERR_NONE)
 		return c_err;
 
@@ -77,8 +74,7 @@ enclave_tls_err_t etls_core_generate_certificate(etls_core_context_t *ctx)
 	if (privkey_len) {
 		tls_wrapper_err_t t_err;
 
-		t_err = ctx->tls_wrapper->opts->use_privkey(ctx->tls_wrapper,
-							    privkey_buf,
+		t_err = ctx->tls_wrapper->opts->use_privkey(ctx->tls_wrapper, privkey_buf,
 							    privkey_len);
 		if (t_err != TLS_WRAPPER_ERR_NONE)
 			return t_err;

--- a/enclave-tls/src/core/main.c
+++ b/enclave-tls/src/core/main.c
@@ -40,7 +40,9 @@ void __attribute__((constructor)) libenclave_tls_init(void)
 	 * attester_type, verifier_type and crypto_type empty to take the
 	 * best guess.
 	 */
+	// clang-format off
 	global_core_context.config.api_version = ENCLAVE_TLS_API_VERSION_DEFAULT;
+	// clang-format on
 	global_core_context.config.log_level = global_log_level;
 	global_core_context.config.cert_algo = ENCLAVE_TLS_CERT_ALGO_DEFAULT;
 

--- a/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
+++ b/enclave-tls/src/crypto_wrappers/api/crypto_wrapper_register.c
@@ -19,13 +19,14 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 
 	if (opts->flags & CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
 		if (!is_sgx_supported_and_configured()) {
+			// clang-format off
 			ETLS_DEBUG("failed to register the crypto wrapper '%s' due to lack of SGX capability\n", opts->name);
+			// clang-format on
 			return -CRYPTO_WRAPPER_ERR_INVALID;
 		}
 	}
 
-	crypto_wrapper_opts_t *new_opts =
-		(crypto_wrapper_opts_t *)malloc(sizeof(*new_opts));
+	crypto_wrapper_opts_t *new_opts = (crypto_wrapper_opts_t *)malloc(sizeof(*new_opts));
 	if (!new_opts)
 		return -CRYPTO_WRAPPER_ERR_NO_MEM;
 
@@ -37,8 +38,8 @@ crypto_wrapper_err_t crypto_wrapper_register(const crypto_wrapper_opts_t *opts)
 	}
 
 	if (new_opts->api_version > CRYPTO_WRAPPER_API_VERSION_MAX) {
-		ETLS_ERR("unsupported crypto wrapper api version %d > %d\n",
-			 new_opts->api_version, CRYPTO_WRAPPER_API_VERSION_MAX);
+		ETLS_ERR("unsupported crypto wrapper api version %d > %d\n", new_opts->api_version,
+			 CRYPTO_WRAPPER_API_VERSION_MAX);
 		goto err;
 	}
 

--- a/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_all.c
+++ b/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_all.c
@@ -10,14 +10,16 @@
 #include <enclave-tls/log.h>
 #include "internal/crypto_wrapper.h"
 
+// clang-format off
 #ifdef OCCLUM
-  #define PATTERN_SUFFIX          ".so"
+  #define PATTERN_SUFFIX ".so"
 #endif
+// clang-format on
 
 static int crypto_wrapper_cmp(const void *a, const void *b)
 {
 	return (*(crypto_wrapper_ctx_t **)b)->opts->priority -
-		(*(crypto_wrapper_ctx_t **)a)->opts->priority;
+	       (*(crypto_wrapper_ctx_t **)a)->opts->priority;
 }
 
 enclave_tls_err_t etls_crypto_wrapper_load_all(void)
@@ -33,15 +35,15 @@ enclave_tls_err_t etls_crypto_wrapper_load_all(void)
 	unsigned int total_loaded = 0;
 	struct dirent *ptr;
 	while ((ptr = readdir(dir))) {
-		if (!strcmp(ptr->d_name, ".") ||
-		    !strcmp(ptr->d_name, ".."))
+		if (!strcmp(ptr->d_name, ".") || !strcmp(ptr->d_name, ".."))
 			continue;
 #ifdef OCCLUM
 		/* Occlum can't identify the d_type of the file, always return DT_UNKNOWN */
-		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
+		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX),
+			    PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
 #else
 		if (ptr->d_type == DT_REG) {
-#endif	
+#endif
 			if (etls_crypto_wrapper_load_single(ptr->d_name) == ENCLAVE_TLS_ERR_NONE)
 				++total_loaded;
 		}
@@ -50,8 +52,7 @@ enclave_tls_err_t etls_crypto_wrapper_load_all(void)
 	closedir(dir);
 
 	if (!total_loaded) {
-		ETLS_ERR("unavailable crypto wrapper instance under %s\n",
-			 CRYPTO_WRAPPERS_DIR);
+		ETLS_ERR("unavailable crypto wrapper instance under %s\n", CRYPTO_WRAPPERS_DIR);
 		return -ENCLAVE_TLS_ERR_LOAD_CRYPTO_WRAPPERS;
 	}
 

--- a/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_single.c
+++ b/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_single.c
@@ -11,8 +11,8 @@
 #include "internal/core.h"
 #include "internal/crypto_wrapper.h"
 
-#define PATTERN_PREFIX          "libcrypto_wrapper_"
-#define PATTERN_SUFFIX          ".so"
+#define PATTERN_PREFIX "libcrypto_wrapper_"
+#define PATTERN_SUFFIX ".so"
 
 enclave_tls_err_t etls_crypto_wrapper_load_single(const char *fname)
 {
@@ -21,8 +21,10 @@ enclave_tls_err_t etls_crypto_wrapper_load_single(const char *fname)
 	/* Check whether the filename pattern matches up libcrypto_wrapper_<name>.so */
 	if (strlen(fname) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
 	    strncmp(fname, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
-	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
-		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<name>" PATTERN_SUFFIX "\n",
+	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX,
+		    strlen(PATTERN_SUFFIX))) {
+		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX
+			 "<name>" PATTERN_SUFFIX "\n",
 			 fname);
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}

--- a/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
+++ b/enclave-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_select.c
@@ -22,8 +22,7 @@ static enclave_tls_err_t init_crypto_wrapper(crypto_wrapper_ctx_t *crypto_ctx)
 	return ENCLAVE_TLS_ERR_NONE;
 }
 
-enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx,
-					     const char *name)
+enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *ctx, const char *name)
 {
 	ETLS_DEBUG("selecting the crypto wrapper '%s' ...\n", name);
 

--- a/enclave-tls/src/crypto_wrappers/nullcrypto/gen_privkey.c
+++ b/enclave-tls/src/crypto_wrappers/nullcrypto/gen_privkey.c
@@ -7,12 +7,11 @@
 #include <enclave-tls/err.h>
 #include <enclave-tls/crypto_wrapper.h>
 
-crypto_wrapper_err_t
-nullcrypto_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
-		       uint8_t *privkey_buf, unsigned int *privkey_len)
+crypto_wrapper_err_t nullcrypto_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
+					    uint8_t *privkey_buf, unsigned int *privkey_len)
 {
-	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n",
-		   ctx, algo, privkey_buf, privkey_len);
+	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n", ctx, algo, privkey_buf,
+		   privkey_len);
 
 	/* Indicate no private key generated */
 	*privkey_len = 0;

--- a/enclave-tls/src/crypto_wrappers/nullcrypto/gen_pubkey_hash.c
+++ b/enclave-tls/src/crypto_wrappers/nullcrypto/gen_pubkey_hash.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/crypto_wrapper.h>
 
 crypto_wrapper_err_t nullcrypto_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
-						enclave_tls_cert_algo_t algo,
-						uint8_t *hash)
+						enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
 	ETLS_DEBUG("ctx %p, algo %d, hash %p\n", ctx, algo, hash);
 

--- a/enclave-tls/src/crypto_wrappers/nullcrypto/main.c
+++ b/enclave-tls/src/crypto_wrappers/nullcrypto/main.c
@@ -10,13 +10,10 @@ extern crypto_wrapper_err_t nullcrypto_pre_init(void);
 extern crypto_wrapper_err_t nullcrypto_init(crypto_wrapper_ctx_t *);
 extern crypto_wrapper_err_t nullcrypto_gen_privkey(crypto_wrapper_ctx_t *ctx,
 						   enclave_tls_cert_algo_t algo,
-						   uint8_t *privkey_buf,
-						   unsigned int *privkey_len);
+						   uint8_t *privkey_buf, unsigned int *privkey_len);
 extern crypto_wrapper_err_t nullcrypto_gen_pubkey_hash(crypto_wrapper_ctx_t *,
-						       enclave_tls_cert_algo_t,
-						       uint8_t *);
-extern crypto_wrapper_err_t nullcrypto_gen_cert(crypto_wrapper_ctx_t *,
-						enclave_tls_cert_info_t *);
+						       enclave_tls_cert_algo_t, uint8_t *);
+extern crypto_wrapper_err_t nullcrypto_gen_cert(crypto_wrapper_ctx_t *, enclave_tls_cert_info_t *);
 extern crypto_wrapper_err_t nullcrypto_cleanup(crypto_wrapper_ctx_t *);
 
 static crypto_wrapper_opts_t nullcrypto_opts = {
@@ -31,8 +28,7 @@ static crypto_wrapper_opts_t nullcrypto_opts = {
 	.cleanup = nullcrypto_cleanup,
 };
 
-void __attribute__((constructor))
-libcrypto_wrapper_nullcrypto_init(void)
+void __attribute__((constructor)) libcrypto_wrapper_nullcrypto_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/ecalls.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/ecalls.c
@@ -30,16 +30,14 @@ crypto_wrapper_err_t ecall_wolfcrypt_init(crypto_wrapper_ctx_t *ctx)
 }
 
 crypto_wrapper_err_t ecall_wolfcrypt_gen_privkey(crypto_wrapper_ctx_t *ctx,
-						 enclave_tls_cert_algo_t algo,
-						 uint8_t *privkey_buf,
+						 enclave_tls_cert_algo_t algo, uint8_t *privkey_buf,
 						 unsigned int *privkey_len)
 {
 	return wolfcrypt_gen_privkey(ctx, algo, privkey_buf, privkey_len);
 }
 
 crypto_wrapper_err_t ecall_wolfcrypt_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
-						     enclave_tls_cert_algo_t algo,
-						     uint8_t *hash)
+						     enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
 	return wolfcrypt_gen_pubkey_hash(ctx, algo, hash);
 }

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_cert.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_cert.c
@@ -8,9 +8,8 @@
 #include <enclave-tls/cert.h>
 #include "wolfcrypt_sgx.h"
 
-crypto_wrapper_err_t
-wolfcrypt_sgx_gen_cert(crypto_wrapper_ctx_t *ctx,
-		       enclave_tls_cert_info_t *cert_info)
+crypto_wrapper_err_t wolfcrypt_sgx_gen_cert(crypto_wrapper_ctx_t *ctx,
+					    enclave_tls_cert_info_t *cert_info)
 {
 	ETLS_DEBUG("ctx %p, cert_info %p\n", ctx, cert_info);
 

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_privkey.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_privkey.c
@@ -8,12 +8,12 @@
 #include <enclave-tls/crypto_wrapper.h>
 #include "wolfcrypt_sgx.h"
 
-crypto_wrapper_err_t
-wolfcrypt_sgx_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
-			  uint8_t *privkey_buf, unsigned int *privkey_len)
+crypto_wrapper_err_t wolfcrypt_sgx_gen_privkey(crypto_wrapper_ctx_t *ctx,
+					       enclave_tls_cert_algo_t algo, uint8_t *privkey_buf,
+					       unsigned int *privkey_len)
 {
-	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n",
-		   ctx, algo, privkey_buf, privkey_len);
+	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n", ctx, algo, privkey_buf,
+		   privkey_len);
 
 	if (!ctx || !privkey_len)
 		return -CRYPTO_WRAPPER_ERR_INVALID;
@@ -21,7 +21,8 @@ wolfcrypt_sgx_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t alg
 	ETLS_DEBUG("calling init() with enclave id %lld ...\n", ctx->enclave_id);
 
 	crypto_wrapper_err_t err;
-	ecall_wolfcrypt_gen_privkey((sgx_enclave_id_t)ctx->enclave_id, &err, ctx, algo, privkey_buf, privkey_len);
+	ecall_wolfcrypt_gen_privkey((sgx_enclave_id_t)ctx->enclave_id, &err, ctx, algo, privkey_buf,
+				    privkey_len);
 
 	return err;
 }

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_pubkey_hash.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/gen_pubkey_hash.c
@@ -9,8 +9,7 @@
 #include "wolfcrypt_sgx.h"
 
 crypto_wrapper_err_t wolfcrypt_sgx_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
-						   enclave_tls_cert_algo_t algo,
-						   uint8_t *hash)
+						   enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
 	ETLS_DEBUG("ctx %p, algo %d, hash %p\n", ctx, algo, hash);
 
@@ -18,7 +17,7 @@ crypto_wrapper_err_t wolfcrypt_sgx_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
 		return -CRYPTO_WRAPPER_ERR_INVALID;
 
 	ETLS_DEBUG("calling init() with enclave id %lld ...\n", ctx->enclave_id);
-	
+
 	crypto_wrapper_err_t err;
 	ecall_wolfcrypt_gen_pubkey_hash((sgx_enclave_id_t)ctx->enclave_id, &err, ctx, algo, hash);
 

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt-sgx/main.c
@@ -16,7 +16,7 @@ extern crypto_wrapper_err_t wolfcrypt_sgx_gen_privkey(crypto_wrapper_ctx_t *ctx,
 						      unsigned int *privkey_len);
 extern crypto_wrapper_err_t wolfcrypt_sgx_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
 							  enclave_tls_cert_algo_t algo,
-							  uint8_t * hash);
+							  uint8_t *hash);
 extern crypto_wrapper_err_t wolfcrypt_sgx_gen_cert(crypto_wrapper_ctx_t *ctx,
 						   enclave_tls_cert_info_t *cert_info);
 extern crypto_wrapper_err_t wolfcrypt_sgx_cleanup(crypto_wrapper_ctx_t *);
@@ -34,7 +34,7 @@ static crypto_wrapper_opts_t wolfcrypt_sgx_opts = {
 	.flags = CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE,
 };
 
-void __attribute__((constructor))libcrypto_wrapper_wolfcrypt_sgx_init(void)
+void __attribute__((constructor)) libcrypto_wrapper_wolfcrypt_sgx_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_cert.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_cert.c
@@ -9,9 +9,8 @@
 #include <enclave-tls/cert.h>
 #include "wolfcrypt.h"
 
-crypto_wrapper_err_t
-wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
-		   enclave_tls_cert_info_t *cert_info)
+crypto_wrapper_err_t wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
+					enclave_tls_cert_info_t *cert_info)
 {
 	ETLS_DEBUG("ctx %p, cert_info %p\n", ctx, cert_info);
 
@@ -22,14 +21,11 @@ wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
 	wc_InitCert(&crt);
 
 	cert_subject_t *subject = &cert_info->subject;
-	strncpy(crt.subject.org, subject->organization,
-		sizeof(crt.subject.org) - 1);
+	strncpy(crt.subject.org, subject->organization, sizeof(crt.subject.org) - 1);
 	crt.subject.org[sizeof(crt.subject.org) - 1] = '\0';
-	strncpy(crt.subject.unit, subject->organization_unit,
-		sizeof(crt.subject.unit) - 1);
+	strncpy(crt.subject.unit, subject->organization_unit, sizeof(crt.subject.unit) - 1);
 	crt.subject.unit[sizeof(crt.subject.unit) - 1] = '\0';
-	strncpy(crt.subject.commonName, subject->common_name,
-		sizeof(crt.subject.commonName) - 1);
+	strncpy(crt.subject.commonName, subject->common_name, sizeof(crt.subject.commonName) - 1);
 	crt.subject.commonName[sizeof(crt.subject.commonName) - 1] = '\0';
 
 	ETLS_DEBUG("evidence type '%s' requested\n", cert_info->evidence.type);
@@ -68,8 +64,7 @@ wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
 	RNG rng;
 	wc_InitRng(&rng);
 	wolfcrypt_ctx_t *wc_ctx = (wolfcrypt_ctx_t *)ctx->crypto_private;
-	int cert_len = wc_MakeSelfCert(&crt, cert_info->cert_buf,
-				       sizeof(cert_info->cert_buf),
+	int cert_len = wc_MakeSelfCert(&crt, cert_info->cert_buf, sizeof(cert_info->cert_buf),
 				       &wc_ctx->key, &rng);
 	if (cert_len <= 0) {
 		ETLS_DEBUG("failed to create self-signing certificate %d\n", cert_info->cert_len);

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_privkey.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_privkey.c
@@ -9,12 +9,11 @@
 #include <enclave-tls/crypto_wrapper.h>
 #include "wolfcrypt.h"
 
-crypto_wrapper_err_t
-wolfcrypt_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
-		      uint8_t *privkey_buf, unsigned int *privkey_len)
+crypto_wrapper_err_t wolfcrypt_gen_privkey(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
+					   uint8_t *privkey_buf, unsigned int *privkey_len)
 {
-	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n",
-		   ctx, algo, privkey_buf, privkey_len);
+	ETLS_DEBUG("ctx %p, algo %d, privkey_buf %p, privkey_len %p\n", ctx, algo, privkey_buf,
+		   privkey_len);
 
 	if (!ctx || !privkey_len)
 		return -CRYPTO_WRAPPER_ERR_INVALID;

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_pubkey_hash.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/gen_pubkey_hash.c
@@ -9,10 +9,11 @@
 #include <enclave-tls/crypto_wrapper.h>
 #include "wolfcrypt.h"
 
-static const int rsa_pub_3072_raw_der_len = 398;	/* rsa_pub_3072_pcks_der_len - pcks_nr_1_header_len */
+/* rsa_pub_3072_pcks_der_len - pcks_nr_1_header_len */
+static const int rsa_pub_3072_raw_der_len = 398;
 
-static int
-gen_rsa3072_pubkey(wolfcrypt_ctx_t *wc_ctx, uint8_t *pub_key_buf, unsigned int *pub_key_len)
+static int gen_rsa3072_pubkey(wolfcrypt_ctx_t *wc_ctx, uint8_t *pub_key_buf,
+			      unsigned int *pub_key_len)
 {
 	/* SetRsaPublicKey() only exports n and e without wrapping them in
 	   additional ASN.1 (PKCS#1). */
@@ -31,8 +32,7 @@ gen_rsa3072_pubkey(wolfcrypt_ctx_t *wc_ctx, uint8_t *pub_key_buf, unsigned int *
 }
 
 crypto_wrapper_err_t wolfcrypt_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
-					       enclave_tls_cert_algo_t algo,
-					       uint8_t *hash)
+					       enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
 	ETLS_DEBUG("ctx %p, algo %d, hash %p\n", ctx, algo, hash);
 
@@ -57,8 +57,8 @@ crypto_wrapper_err_t wolfcrypt_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
 	wc_Sha256Final(&sha256, hash);
 
 	ETLS_DEBUG("the sha256 of public key %02x%02x%02x%02x%02x%02x%02x%02x...%02x%02x%02x%02x\n",
-		hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
-		hash[28], hash[29], hash[30], hash[31]);
+		   hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[28],
+		   hash[29], hash[30], hash[31]);
 
 	return CRYPTO_WRAPPER_ERR_NONE;
 }

--- a/enclave-tls/src/crypto_wrappers/wolfcrypt/main.c
+++ b/enclave-tls/src/crypto_wrappers/wolfcrypt/main.c
@@ -11,11 +11,10 @@ extern crypto_wrapper_err_t wolfcrypt_pre_init(void);
 extern crypto_wrapper_err_t wolfcrypt_init(crypto_wrapper_ctx_t *);
 extern crypto_wrapper_err_t __secured wolfcrypt_gen_privkey(crypto_wrapper_ctx_t *ctx,
 							    enclave_tls_cert_algo_t algo,
-						  	    uint8_t *privkey_buf,
+							    uint8_t *privkey_buf,
 							    unsigned int *privkey_len);
 extern crypto_wrapper_err_t wolfcrypt_gen_pubkey_hash(crypto_wrapper_ctx_t *ctx,
-						      enclave_tls_cert_algo_t algo,
-						      uint8_t *hash);
+						      enclave_tls_cert_algo_t algo, uint8_t *hash);
 extern crypto_wrapper_err_t wolfcrypt_gen_cert(crypto_wrapper_ctx_t *ctx,
 					       enclave_tls_cert_info_t *cert_info);
 extern crypto_wrapper_err_t wolfcrypt_cleanup(crypto_wrapper_ctx_t *);
@@ -32,8 +31,7 @@ static crypto_wrapper_opts_t wolfcrypt_opts = {
 	.cleanup = wolfcrypt_cleanup,
 };
 
-void __attribute__((constructor))
-libcrypto_wrapper_wolfcrypt_init(void)
+void __attribute__((constructor)) libcrypto_wrapper_wolfcrypt_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/enclave_quotes/api/enclave_quote_register.c
+++ b/enclave-tls/src/enclave_quotes/api/enclave_quote_register.c
@@ -19,20 +19,20 @@ enclave_quote_err_t enclave_quote_register(const enclave_quote_opts_t *opts)
 
 	if (opts->flags & ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE) {
 		if (!is_sgx_supported_and_configured()) {
+			// clang-format off
 			ETLS_DEBUG("failed to register the enclave quote '%s' due to lack of SGX capability\n", opts->type);
+			// clang-format on
 			return -ENCLAVE_QUOTE_ERR_INVALID;
 		}
 	}
 
-	enclave_quote_opts_t *new_opts =
-		(enclave_quote_opts_t *)malloc(sizeof(*new_opts));
+	enclave_quote_opts_t *new_opts = (enclave_quote_opts_t *)malloc(sizeof(*new_opts));
 	if (!new_opts)
 		return -ENCLAVE_QUOTE_ERR_NO_MEM;
 
 	memcpy(new_opts, opts, sizeof(*new_opts));
 
-	if ((new_opts->name[0] == '\0') ||
-	    (strlen(new_opts->name) >= sizeof(new_opts->name))) {
+	if ((new_opts->name[0] == '\0') || (strlen(new_opts->name) >= sizeof(new_opts->name))) {
 		ETLS_ERR("invalid enclave quote name\n");
 		goto err;
 	}
@@ -43,8 +43,8 @@ enclave_quote_err_t enclave_quote_register(const enclave_quote_opts_t *opts)
 	}
 
 	if (new_opts->api_version > ENCLAVE_QUOTE_API_VERSION_MAX) {
-		ETLS_ERR("unsupported enclave quote api version %d > %d\n",
-			 new_opts->api_version, ENCLAVE_QUOTE_API_VERSION_MAX);
+		ETLS_ERR("unsupported enclave quote api version %d > %d\n", new_opts->api_version,
+			 ENCLAVE_QUOTE_API_VERSION_MAX);
 		goto err;
 	}
 
@@ -54,8 +54,8 @@ enclave_quote_err_t enclave_quote_register(const enclave_quote_opts_t *opts)
 
 	enclave_quotes_opts[registerd_enclave_quote_nums++] = new_opts;
 
-	ETLS_INFO("the enclave quote '%s' registered with type '%s'\n",
-		  new_opts->name, new_opts->type);
+	ETLS_INFO("the enclave quote '%s' registered with type '%s'\n", new_opts->name,
+		  new_opts->type);
 
 	return ENCLAVE_QUOTE_ERR_NONE;
 

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_all.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_all.c
@@ -10,14 +10,16 @@
 #include <enclave-tls/log.h>
 #include "internal/enclave_quote.h"
 
+// clang-format off
 #ifdef OCCLUM
-  #define PATTERN_SUFFIX          ".so"
+  #define PATTERN_SUFFIX ".so"
 #endif
+// clang-format on
 
 static int enclave_quote_cmp(const void *a, const void *b)
 {
 	return (*(enclave_quote_ctx_t **)b)->opts->priority -
-		(*(enclave_quote_ctx_t **)a)->opts->priority;
+	       (*(enclave_quote_ctx_t **)a)->opts->priority;
 }
 
 enclave_tls_err_t etls_enclave_quote_load_all(void)
@@ -33,13 +35,13 @@ enclave_tls_err_t etls_enclave_quote_load_all(void)
 	unsigned int total_loaded = 0;
 	struct dirent *ptr;
 	while ((ptr = readdir(dir)) != NULL) {
-		if (!strcmp(ptr->d_name, ".") ||
-		    !strcmp(ptr->d_name, ".."))
+		if (!strcmp(ptr->d_name, ".") || !strcmp(ptr->d_name, ".."))
 			continue;
 
 #ifdef OCCLUM
 		/* Occlum can't identify the d_type of the file, always return DT_UNKNOWN */
-		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
+		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX),
+			    PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
 #else
 		if (ptr->d_type == DT_REG) {
 #endif
@@ -51,8 +53,7 @@ enclave_tls_err_t etls_enclave_quote_load_all(void)
 	closedir(dir);
 
 	if (!total_loaded) {
-		ETLS_ERR("unavailable enclave quote instance under %s\n",
-			 ENCLAVE_QUOTES_DIR);
+		ETLS_ERR("unavailable enclave quote instance under %s\n", ENCLAVE_QUOTES_DIR);
 		return -ENCLAVE_TLS_ERR_LOAD_ENCLAVE_QUOTES;
 	}
 

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_single.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_load_single.c
@@ -11,8 +11,8 @@
 #include "internal/core.h"
 #include "internal/enclave_quote.h"
 
-#define PATTERN_PREFIX          "libenclave_quote_"
-#define PATTERN_SUFFIX          ".so"
+#define PATTERN_PREFIX "libenclave_quote_"
+#define PATTERN_SUFFIX ".so"
 
 enclave_tls_err_t etls_enclave_quote_load_single(const char *fname)
 {
@@ -21,8 +21,10 @@ enclave_tls_err_t etls_enclave_quote_load_single(const char *fname)
 	/* Check whether the filename pattern matches up libenclave_quote_<name>.so */
 	if (strlen(fname) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
 	    strncmp(fname, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
-	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
-		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<name>" PATTERN_SUFFIX "\n",
+	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX,
+		    strlen(PATTERN_SUFFIX))) {
+		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX
+			 "<name>" PATTERN_SUFFIX "\n",
 			 fname);
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}

--- a/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
+++ b/enclave-tls/src/enclave_quotes/internal/etls_enclave_quote_select.c
@@ -24,15 +24,14 @@ static enclave_tls_err_t init_enclave_quote(etls_core_context_t *ctx,
 	return ENCLAVE_TLS_ERR_NONE;
 }
 
-enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
-					    const char *name,
-					    enclave_tls_cert_algo_t algo)
+enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx, const char *name,
+				       enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("selecting the attester '%s' ...\n", name);
 
-	// Explicitly specifying verifier which will never be changed
+	/* Explicitly specifying verifier which will never be changed */
 	if (name)
-		 ctx->flags |= ENCLAVE_TLS_CONF_VERIFIER_ENFORCED;
+		ctx->flags |= ENCLAVE_TLS_CONF_VERIFIER_ENFORCED;
 
 	enclave_quote_ctx_t *quote_ctx = NULL;
 	for (unsigned int i = 0; i < registerd_enclave_quote_nums; ++i) {
@@ -41,7 +40,7 @@ enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
 
 		quote_ctx = malloc(sizeof(*quote_ctx));
 		if (!quote_ctx)
-			 return -ENCLAVE_TLS_ERR_NO_MEM;
+			return -ENCLAVE_TLS_ERR_NO_MEM;
 
 		memcpy(quote_ctx, enclave_quotes_ctx[i], sizeof(*quote_ctx));
 
@@ -75,9 +74,8 @@ enclave_tls_err_t etls_attester_select(etls_core_context_t *ctx,
 	return ENCLAVE_TLS_ERR_NONE;
 }
 
-enclave_tls_err_t etls_verifier_select(etls_core_context_t *ctx,
-					    const char *name,
-					    enclave_tls_cert_algo_t algo)
+enclave_tls_err_t etls_verifier_select(etls_core_context_t *ctx, const char *name,
+				       enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("selecting the verifier '%s' ...\n", name);
 
@@ -88,7 +86,7 @@ enclave_tls_err_t etls_verifier_select(etls_core_context_t *ctx,
 
 		quote_ctx = malloc(sizeof(*quote_ctx));
 		if (!quote_ctx)
-			 return -ENCLAVE_TLS_ERR_NO_MEM;
+			return -ENCLAVE_TLS_ERR_NO_MEM;
 
 		memcpy(quote_ctx, enclave_quotes_ctx[i], sizeof(*quote_ctx));
 

--- a/enclave-tls/src/enclave_quotes/nullquote/collect_evidence.c
+++ b/enclave-tls/src/enclave_quotes/nullquote/collect_evidence.c
@@ -8,11 +8,9 @@
 
 enclave_quote_err_t nullquote_collect_evidence(enclave_quote_ctx_t *ctx,
 					       attestation_evidence_t *evidence,
-					       enclave_tls_cert_algo_t algo,
-					       uint8_t *hash)
+					       enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
-	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n",
-		   ctx, evidence, algo, hash);
+	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence, algo, hash);
 
 	return ENCLAVE_QUOTE_ERR_NONE;
 }

--- a/enclave-tls/src/enclave_quotes/nullquote/init.c
+++ b/enclave-tls/src/enclave_quotes/nullquote/init.c
@@ -8,8 +8,7 @@
 
 static unsigned int dummy_private;
 
-enclave_quote_err_t nullquote_init(enclave_quote_ctx_t *ctx,
-				   enclave_tls_cert_algo_t algo)
+enclave_quote_err_t nullquote_init(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("ctx %p, algo %d\n", ctx, algo);
 

--- a/enclave-tls/src/enclave_quotes/nullquote/main.c
+++ b/enclave-tls/src/enclave_quotes/nullquote/main.c
@@ -9,14 +9,12 @@
 
 extern enclave_quote_err_t enclave_quote_register(enclave_quote_opts_t *);
 extern enclave_quote_err_t nullquote_pre_init(void);
-extern enclave_quote_err_t nullquote_init(enclave_quote_ctx_t *,
-					  enclave_tls_cert_algo_t algo);
+extern enclave_quote_err_t nullquote_init(enclave_quote_ctx_t *, enclave_tls_cert_algo_t algo);
 //extern enclave_quote_err_t nullquote_extend_cert(enclave_quote_ctx_t *ctx,
 //					    const enclave_tls_cert_info_t *cert_info);
 extern enclave_quote_err_t nullquote_collect_evidence(enclave_quote_ctx_t *,
 						      attestation_evidence_t *,
-						      enclave_tls_cert_algo_t algo,
-						      uint8_t *);
+						      enclave_tls_cert_algo_t algo, uint8_t *);
 extern enclave_quote_err_t nullquote_verify_evidence(enclave_quote_ctx_t *,
 						     attestation_evidence_t *, uint8_t *,
 						     unsigned int hash_len);
@@ -35,8 +33,7 @@ static enclave_quote_opts_t nullquote_opts = {
 	.cleanup = nullquote_cleanup,
 };
 
-void __attribute__((constructor))
-libenclave_quote_nullquote_init(void)
+void __attribute__((constructor)) libenclave_quote_nullquote_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/enclave_quotes/nullquote/verify_evidence.c
+++ b/enclave-tls/src/enclave_quotes/nullquote/verify_evidence.c
@@ -7,8 +7,8 @@
 #include <enclave-tls/enclave_quote.h>
 
 enclave_quote_err_t nullquote_verify_evidence(enclave_quote_ctx_t *ctx,
-					      attestation_evidence_t *evidence,
-					      uint8_t *hash, unsigned int hash_len)
+					      attestation_evidence_t *evidence, uint8_t *hash,
+					      unsigned int hash_len)
 {
 	ETLS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/init.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/init.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/enclave_quote.h>
 #include "sgx_ecdsa.h"
 
-enclave_quote_err_t sgx_ecdsa_qve_init(enclave_quote_ctx_t *ctx,
-				   enclave_tls_cert_algo_t algo)
+enclave_quote_err_t sgx_ecdsa_qve_init(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("ctx %p, algo %d\n", ctx, algo);
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa-qve/main.c
@@ -10,11 +10,10 @@
 extern enclave_quote_err_t enclave_quote_register(enclave_quote_opts_t *opts);
 extern enclave_quote_err_t sgx_ecdsa_pre_init(void);
 extern enclave_quote_err_t sgx_ecdsa_qve_init(enclave_quote_ctx_t *ctx,
-					  enclave_tls_cert_algo_t algo);
+					      enclave_tls_cert_algo_t algo);
 extern enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 						      attestation_evidence_t *evidence,
-						      enclave_tls_cert_algo_t algo,
-						      uint8_t *hash);
+						      enclave_tls_cert_algo_t algo, uint8_t *hash);
 extern enclave_quote_err_t sgx_ecdsa_verify_evidence(enclave_quote_ctx_t *ctx,
 						     attestation_evidence_t *evidence,
 						     uint8_t *hash, uint32_t hash_len);
@@ -33,8 +32,7 @@ static enclave_quote_opts_t sgx_ecdsa_qve_opts = {
 	.cleanup = sgx_ecdsa_cleanup,
 };
 
-void __attribute__((constructor))
-libenclave_quote_sgx_ecdsa_qve_init(void)
+void __attribute__((constructor)) libenclave_quote_sgx_ecdsa_qve_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/cleanup.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/cleanup.c
@@ -10,7 +10,7 @@
 enclave_quote_err_t sgx_ecdsa_cleanup(enclave_quote_ctx_t *ctx)
 {
 	ETLS_DEBUG("called\n");
-	
+
 	sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->quote_private;
 
 	free(ecdsa_ctx);

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/collect_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/collect_evidence.c
@@ -16,10 +16,11 @@
 #include <sgx_error.h>
 #include "sgx_ecdsa.h"
 #include "sgx_stub_u.h"
+// clang-format off
 #ifdef OCCLUM
-#include "sgx_edger8r.h"
-#include "sgx_report.h"
-#include "quote_generation.h"
+  #include "sgx_edger8r.h"
+  #include "sgx_report.h"
+  #include "quote_generation.h"
 
 int generate_quote(int sgx_fd, sgxioc_gen_dcap_quote_arg_t *gen_quote_arg)
 {
@@ -36,14 +37,13 @@ int generate_quote(int sgx_fd, sgxioc_gen_dcap_quote_arg_t *gen_quote_arg)
 	return 0;
 }
 #endif
+// clang-format on
 
 enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 					       attestation_evidence_t *evidence,
-					       enclave_tls_cert_algo_t algo,
-					       uint8_t *hash)
+					       enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
-	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence,
-		   algo, hash);
+	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence, algo, hash);
 
 #ifdef OCCLUM
 	int sgx_fd;
@@ -52,7 +52,9 @@ enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 		return -ENCLAVE_QUOTE_ERR_INVALID;
 	}
 
-	sgx_report_data_t report_data = { 0, };
+	sgx_report_data_t report_data = {
+		0,
+	};
 	assert(sizeof(report_data.d) > SHA256_HASH_SIZE);
 	memcpy(report_data.d, hash, SHA256_HASH_SIZE);
 
@@ -62,11 +64,9 @@ enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 		return -ENCLAVE_QUOTE_ERR_INVALID;
 	}
 
-	sgxioc_gen_dcap_quote_arg_t gen_quote_arg = {
-		.report_data = &report_data,
-		.quote_len = &quote_size,
-		.quote_buf = evidence->ecdsa.quote
-	};
+	sgxioc_gen_dcap_quote_arg_t gen_quote_arg = { .report_data = &report_data,
+						      .quote_len = &quote_size,
+						      .quote_buf = evidence->ecdsa.quote };
 
 	if (generate_quote(sgx_fd, &gen_quote_arg) != 0) {
 		ETLS_ERR("failed to generate quote\n");
@@ -78,8 +78,8 @@ enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 
 	sgx_report_t app_report;
 	sgx_status_t generate_evidence_ret;
-	sgx_status_t status = ecall_generate_evidence(ecdsa_ctx->eid, &generate_evidence_ret,
-						      hash, &app_report);
+	sgx_status_t status =
+		ecall_generate_evidence(ecdsa_ctx->eid, &generate_evidence_ret, hash, &app_report);
 	if (status != SGX_SUCCESS || generate_evidence_ret != SGX_SUCCESS) {
 		ETLS_ERR("failed to generate evidence %#x, %#x\n", status, generate_evidence_ret);
 		return SGX_ECDSA_ERR_CODE((int)generate_evidence_ret);

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/init.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/init.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/enclave_quote.h>
 #include "sgx_ecdsa.h"
 
-enclave_quote_err_t sgx_ecdsa_init(enclave_quote_ctx_t *ctx,
-				   enclave_tls_cert_algo_t algo)
+enclave_quote_err_t sgx_ecdsa_init(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("ctx %p, algo %d\n", ctx, algo);
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/main.c
@@ -9,18 +9,15 @@
 
 extern enclave_quote_err_t enclave_quote_register(enclave_quote_opts_t *opts);
 extern enclave_quote_err_t sgx_ecdsa_pre_init(void);
-extern enclave_quote_err_t sgx_ecdsa_init(enclave_quote_ctx_t *ctx,
-					  enclave_tls_cert_algo_t algo);
+extern enclave_quote_err_t sgx_ecdsa_init(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo);
 //extern enclave_quote_err_t null_extend_cert(enclave_quote_ctx_t *ctx,
 //					      const enclave_tls_cert_info_t *cert_info);
 extern enclave_quote_err_t sgx_ecdsa_collect_evidence(enclave_quote_ctx_t *ctx,
 						      attestation_evidence_t *evidence,
-						      enclave_tls_cert_algo_t algo,
-						      uint8_t *hash);
+						      enclave_tls_cert_algo_t algo, uint8_t *hash);
 extern enclave_quote_err_t sgx_ecdsa_verify_evidence(enclave_quote_ctx_t *ctx,
 						     attestation_evidence_t *evidence,
-						     uint8_t *hash,
-						     unsigned int hash_len);
+						     uint8_t *hash, unsigned int hash_len);
 extern enclave_quote_err_t sgx_ecdsa_cleanup(enclave_quote_ctx_t *ctx);
 
 static enclave_quote_opts_t sgx_ecdsa_opts = {
@@ -36,8 +33,7 @@ static enclave_quote_opts_t sgx_ecdsa_opts = {
 	.cleanup = sgx_ecdsa_cleanup,
 };
 
-void __attribute__((constructor))
-libenclave_quote_sgx_ecdsa_init(void)
+void __attribute__((constructor)) libenclave_quote_sgx_ecdsa_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/quote_generation.h
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/quote_generation.h
@@ -28,14 +28,14 @@ typedef struct {
 } sgxioc_gen_dcap_quote_arg_t;
 
 typedef struct {
-	const sgx_target_info_t *target_info;	// input (optinal)
-	const sgx_report_data_t *report_data;	// input (optional)
-	sgx_report_t *report;	// output
+	const sgx_target_info_t *target_info; // input (optinal)
+	const sgx_report_data_t *report_data; // input (optional)
+	sgx_report_t *report; // output
 } sgxioc_create_report_arg_t;
 
-#define SGXIOC_GET_DCAP_QUOTE_SIZE	_IOR('s', 7, uint32_t)
-#define SGXIOC_GEN_DCAP_QUOTE		_IOWR('s', 8, sgxioc_gen_dcap_quote_arg_t)
-#define SGXIOC_CREATE_REPORT		_IOWR('s', 4, sgxioc_create_report_arg_t)
+#define SGXIOC_GET_DCAP_QUOTE_SIZE _IOR('s', 7, uint32_t)
+#define SGXIOC_GEN_DCAP_QUOTE	   _IOWR('s', 8, sgxioc_gen_dcap_quote_arg_t)
+#define SGXIOC_CREATE_REPORT	   _IOWR('s', 4, sgxioc_create_report_arg_t)
 
 int generate_quote(int sgx_fd, sgxioc_gen_dcap_quote_arg_t *gen_quote_arg);
 

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/quote_verification.h
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/quote_verification.h
@@ -34,7 +34,7 @@ typedef struct {
 	uint8_t *supplemental_data;
 } sgxioc_ver_dcap_quote_arg_t;
 
-#define SGXIOC_GET_DCAP_SUPPLEMENTAL_SIZE    _IOR('s', 9, uint32_t)
-#define SGXIOC_VER_DCAP_QUOTE                _IOWR('s', 10, sgxioc_ver_dcap_quote_arg_t)
+#define SGXIOC_GET_DCAP_SUPPLEMENTAL_SIZE _IOR('s', 9, uint32_t)
+#define SGXIOC_VER_DCAP_QUOTE		  _IOWR('s', 10, sgxioc_ver_dcap_quote_arg_t)
 
 #endif /* QUOTE_VERIFICATION_H_ */

--- a/enclave-tls/src/enclave_quotes/sgx-ecdsa/verify_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-ecdsa/verify_evidence.c
@@ -13,6 +13,7 @@
 #include <sgx_dcap_quoteverify.h>
 #include "sgx_ecdsa.h"
 #include "sgx_stub_u.h"
+// clang-format off
 #ifdef OCCLUM
   #include <sys/stat.h>
   #include <fcntl.h>
@@ -20,217 +21,214 @@
   #include <errno.h>
   #include "quote_verification.h"
 #endif
+// clang-format on
 
 void get_random_nonce(uint8_t *nonce, uint32_t size)
 {
-    for (uint32_t i = 0; i < size; i ++)
-        nonce[i] = (uint8_t)((rand() % 255) + 1);
+	for (uint32_t i = 0; i < size; i++)
+		nonce[i] = (uint8_t)((rand() % 255) + 1);
 }
 
 enclave_quote_err_t sgx_ecdsa_verify_evidence(enclave_quote_ctx_t *ctx,
-					      attestation_evidence_t *evidence,
-					      uint8_t *hash,
-                                              __attribute__((unused)) uint32_t hash_len)
+					      attestation_evidence_t *evidence, uint8_t *hash,
+					      __attribute__((unused)) uint32_t hash_len)
 {
-        ETLS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
+	ETLS_DEBUG("ctx %p, evidence %p, hash %p\n", ctx, evidence, hash);
 
-        enclave_quote_err_t err = -ENCLAVE_QUOTE_ERR_UNKNOWN;
-        uint32_t supplemental_data_size = 0;
-        uint8_t *p_supplemental_data = NULL;
-        sgx_ql_qv_result_t quote_verification_result = SGX_QL_QV_RESULT_UNSPECIFIED;
-        uint32_t collateral_expiration_status = 1;
+	enclave_quote_err_t err = -ENCLAVE_QUOTE_ERR_UNKNOWN;
+	uint32_t supplemental_data_size = 0;
+	uint8_t *p_supplemental_data = NULL;
+	sgx_ql_qv_result_t quote_verification_result = SGX_QL_QV_RESULT_UNSPECIFIED;
+	uint32_t collateral_expiration_status = 1;
 #if !defined(OCCLUM)
-        time_t current_time = 0;
-        sgx_isv_svn_t qve_isvsvn_threshold = 3;
-        sgx_status_t sgx_ret = SGX_SUCCESS;
-        quote3_error_t verify_qveid_ret = SGX_QL_ERROR_UNEXPECTED;
-        quote3_error_t dcap_ret = SGX_QL_ERROR_UNEXPECTED;
-        sgx_ql_qe_report_info_t *qve_report_info = NULL;
-        uint8_t rand_nonce[16];
+	time_t current_time = 0;
+	sgx_isv_svn_t qve_isvsvn_threshold = 3;
+	sgx_status_t sgx_ret = SGX_SUCCESS;
+	quote3_error_t verify_qveid_ret = SGX_QL_ERROR_UNEXPECTED;
+	quote3_error_t dcap_ret = SGX_QL_ERROR_UNEXPECTED;
+	sgx_ql_qe_report_info_t *qve_report_info = NULL;
+	uint8_t rand_nonce[16];
 #endif
 
 #ifdef OCCLUM
-        int sgx_fd = open("/dev/sgx", O_RDONLY);
-        if (sgx_fd < 0) {
-                ETLS_ERR("failed to open /dev/sgx\n");
-                return -ENCLAVE_QUOTE_ERR_INVALID;
-        }
+	int sgx_fd = open("/dev/sgx", O_RDONLY);
+	if (sgx_fd < 0) {
+		ETLS_ERR("failed to open /dev/sgx\n");
+		return -ENCLAVE_QUOTE_ERR_INVALID;
+	}
 
-        if (ioctl(sgx_fd, SGXIOC_GET_DCAP_SUPPLEMENTAL_SIZE, &supplemental_data_size) < 0) {
-                ETLS_ERR("failed to ioctl get supplemental data size: %s\n", strerror(errno));
-                close(sgx_fd);
-                return -ENCLAVE_QUOTE_ERR_INVALID;
-        }
+	if (ioctl(sgx_fd, SGXIOC_GET_DCAP_SUPPLEMENTAL_SIZE, &supplemental_data_size) < 0) {
+		ETLS_ERR("failed to ioctl get supplemental data size: %s\n", strerror(errno));
+		close(sgx_fd);
+		return -ENCLAVE_QUOTE_ERR_INVALID;
+	}
 
-        p_supplemental_data = (uint8_t *)malloc(supplemental_data_size);
-        if (!p_supplemental_data) {
-                close(sgx_fd);
-                return -ENCLAVE_QUOTE_ERR_NO_MEM;
-        }
+	p_supplemental_data = (uint8_t *)malloc(supplemental_data_size);
+	if (!p_supplemental_data) {
+		close(sgx_fd);
+		return -ENCLAVE_QUOTE_ERR_NO_MEM;
+	}
 
-        memset(p_supplemental_data, 0, supplemental_data_size);
+	memset(p_supplemental_data, 0, supplemental_data_size);
 
-        sgxioc_ver_dcap_quote_arg_t ver_quote_arg = {
-                .quote_buf = evidence->ecdsa.quote,
-                .quote_size = evidence->ecdsa.quote_len,
-                .collateral_expiration_status = &collateral_expiration_status,
-                .quote_verification_result = &quote_verification_result,
-                .supplemental_data_size = supplemental_data_size,
-                .supplemental_data = p_supplemental_data
-        };
+	sgxioc_ver_dcap_quote_arg_t ver_quote_arg = {
+		.quote_buf = evidence->ecdsa.quote,
+		.quote_size = evidence->ecdsa.quote_len,
+		.collateral_expiration_status = &collateral_expiration_status,
+		.quote_verification_result = &quote_verification_result,
+		.supplemental_data_size = supplemental_data_size,
+		.supplemental_data = p_supplemental_data
+	};
 
-        if (ioctl(sgx_fd, SGXIOC_VER_DCAP_QUOTE, &ver_quote_arg) < 0) {
-                ETLS_ERR("failed to ioctl verify quote: %s\n", strerror(errno));
-                close(sgx_fd);
-                return -ENCLAVE_QUOTE_ERR_INVALID;
-        }
+	if (ioctl(sgx_fd, SGXIOC_VER_DCAP_QUOTE, &ver_quote_arg) < 0) {
+		ETLS_ERR("failed to ioctl verify quote: %s\n", strerror(errno));
+		close(sgx_fd);
+		return -ENCLAVE_QUOTE_ERR_INVALID;
+	}
 
-        close(sgx_fd);
+	close(sgx_fd);
 #else
-        sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->quote_private;
-        sgx_quote3_t *pquote = (sgx_quote3_t *)malloc(8192);
-        if (!pquote) {
-                ETLS_ERR("failed to malloc sgx quote3 data space.\n");
-                return -ENCLAVE_QUOTE_ERR_NO_MEM;
-        }
+	sgx_ecdsa_ctx_t *ecdsa_ctx = (sgx_ecdsa_ctx_t *)ctx->quote_private;
+	sgx_quote3_t *pquote = (sgx_quote3_t *)malloc(8192);
+	if (!pquote) {
+		ETLS_ERR("failed to malloc sgx quote3 data space.\n");
+		return -ENCLAVE_QUOTE_ERR_NO_MEM;
+	}
 
-        memcpy(pquote, evidence->ecdsa.quote, evidence->ecdsa.quote_len);
+	memcpy(pquote, evidence->ecdsa.quote, evidence->ecdsa.quote_len);
 
-        uint32_t quote_size = (uint32_t)sizeof(sgx_quote3_t) + pquote->signature_data_len;
-        ETLS_DEBUG("quote size is %d, quote signature_data_len is %d\n", quote_size, pquote->signature_data_len);
+	uint32_t quote_size = (uint32_t)sizeof(sgx_quote3_t) + pquote->signature_data_len;
+	ETLS_DEBUG("quote size is %d, quote signature_data_len is %d\n", quote_size,
+		   pquote->signature_data_len);
 
-        // First verify the hash value
-        if (memcmp(hash, pquote->report_body.report_data.d, hash_len) != 0) {
-                ETLS_ERR("unmatched hash value in evidence.\n");
-                err = -ENCLAVE_QUOTE_ERR_INVALID;
-                goto errout;
-        }
+	/* First verify the hash value */
+	if (memcmp(hash, pquote->report_body.report_data.d, hash_len) != 0) {
+		ETLS_ERR("unmatched hash value in evidence.\n");
+		err = -ENCLAVE_QUOTE_ERR_INVALID;
+		goto errout;
+	}
 
 	/* sgx_ecdsa_qve instance re-uses this code and thus we need to distinguish
 	 * it from sgx_ecdsa instance.
 	 */
-        if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
-                qve_report_info = malloc(sizeof(sgx_ql_qe_report_info_t));
-                if (!qve_report_info) {
-                        ETLS_ERR("failed to malloc qve report info.\n");
-                        goto errout;
-                }
-                get_random_nonce(rand_nonce, sizeof(rand_nonce));
-                memcpy(qve_report_info->nonce.rand, rand_nonce, sizeof(rand_nonce));
+	if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
+		qve_report_info = malloc(sizeof(sgx_ql_qe_report_info_t));
+		if (!qve_report_info) {
+			ETLS_ERR("failed to malloc qve report info.\n");
+			goto errout;
+		}
+		get_random_nonce(rand_nonce, sizeof(rand_nonce));
+		memcpy(qve_report_info->nonce.rand, rand_nonce, sizeof(rand_nonce));
 
-                sgx_status_t get_target_info_ret;
-                sgx_ret = ecall_get_target_info((sgx_enclave_id_t)ecdsa_ctx->eid, &get_target_info_ret,
-                                &qve_report_info->app_enclave_target_info);
-                if (sgx_ret != SGX_SUCCESS || get_target_info_ret != SGX_SUCCESS) {
-                        ETLS_ERR("failed to get target info sgx_ret and get_target_info_ret. %04x, %04x\n", sgx_ret, get_target_info_ret);
-                        err = SGX_ECDSA_ERR_CODE((int)get_target_info_ret);
-                        goto errout;
-                } else
-                        ETLS_INFO("get target info successfully.\n");
+		sgx_status_t get_target_info_ret;
+		sgx_ret = ecall_get_target_info((sgx_enclave_id_t)ecdsa_ctx->eid,
+						&get_target_info_ret,
+						&qve_report_info->app_enclave_target_info);
+		if (sgx_ret != SGX_SUCCESS || get_target_info_ret != SGX_SUCCESS) {
+			ETLS_ERR(
+				"failed to get target info sgx_ret and get_target_info_ret. %04x, %04x\n",
+				sgx_ret, get_target_info_ret);
+			err = SGX_ECDSA_ERR_CODE((int)get_target_info_ret);
+			goto errout;
+		} else
+			ETLS_INFO("get target info successfully.\n");
 
-                dcap_ret = sgx_qv_set_enclave_load_policy(SGX_QL_DEFAULT);
-                if (dcap_ret == SGX_QL_SUCCESS)
-                        ETLS_INFO("sgx qv setting for enclave load policy succeeds.\n");
-                else {
-                        ETLS_ERR("failed to set enclave load policy by sgx qv: %04x\n", dcap_ret);
-                        err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
-                        goto errout;
-                }
-        }
+		dcap_ret = sgx_qv_set_enclave_load_policy(SGX_QL_DEFAULT);
+		if (dcap_ret == SGX_QL_SUCCESS)
+			ETLS_INFO("sgx qv setting for enclave load policy succeeds.\n");
+		else {
+			ETLS_ERR("failed to set enclave load policy by sgx qv: %04x\n", dcap_ret);
+			err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
+			goto errout;
+		}
+	}
 
-        dcap_ret = sgx_qv_get_quote_supplemental_data_size(&supplemental_data_size);
-        if (dcap_ret == SGX_QL_SUCCESS) {
-                ETLS_INFO("sgx qv gets quote supplemental data size successfully.\n");
-                p_supplemental_data = (uint8_t *)malloc(supplemental_data_size);
-                if (!p_supplemental_data) {
-                        ETLS_ERR("failed to malloc supplemental data space.\n");
-                        err = -ENCLAVE_QUOTE_ERR_NO_MEM;
-                        goto errout;
-                }
-        } else {
-                ETLS_ERR("failed to get quote supplemental data size by sgx qv: %04x\n", dcap_ret);
-                err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
-                goto errout;
-        }
+	dcap_ret = sgx_qv_get_quote_supplemental_data_size(&supplemental_data_size);
+	if (dcap_ret == SGX_QL_SUCCESS) {
+		ETLS_INFO("sgx qv gets quote supplemental data size successfully.\n");
+		p_supplemental_data = (uint8_t *)malloc(supplemental_data_size);
+		if (!p_supplemental_data) {
+			ETLS_ERR("failed to malloc supplemental data space.\n");
+			err = -ENCLAVE_QUOTE_ERR_NO_MEM;
+			goto errout;
+		}
+	} else {
+		ETLS_ERR("failed to get quote supplemental data size by sgx qv: %04x\n", dcap_ret);
+		err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
+		goto errout;
+	}
 
-        current_time = time(NULL);
+	current_time = time(NULL);
 
-        dcap_ret = sgx_qv_verify_quote(evidence->ecdsa.quote,
-                        (uint32_t)quote_size, NULL,
-                        current_time,
-                        &collateral_expiration_status,
-                        &quote_verification_result,
-                        qve_report_info,
-                        supplemental_data_size,
-                        p_supplemental_data);
-        if (dcap_ret == SGX_QL_SUCCESS)
-                ETLS_INFO("sgx qv verifies quote successfully.\n");
-        else {
-                ETLS_ERR("failed to verify quote by sgx qv: %04x\n", dcap_ret);
-                err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
-                goto errret;
-        }
+	dcap_ret = sgx_qv_verify_quote(evidence->ecdsa.quote, (uint32_t)quote_size, NULL,
+				       current_time, &collateral_expiration_status,
+				       &quote_verification_result, qve_report_info,
+				       supplemental_data_size, p_supplemental_data);
+	if (dcap_ret == SGX_QL_SUCCESS)
+		ETLS_INFO("sgx qv verifies quote successfully.\n");
+	else {
+		ETLS_ERR("failed to verify quote by sgx qv: %04x\n", dcap_ret);
+		err = SGX_ECDSA_ERR_CODE((int)dcap_ret);
+		goto errret;
+	}
 
-        if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
-                sgx_ret = sgx_tvl_verify_qve_report_and_identity((sgx_enclave_id_t)ecdsa_ctx->eid,
-                                &verify_qveid_ret,
-                                evidence->ecdsa.
-                                quote,
-                                (uint32_t)quote_size,
-                                qve_report_info,
-                                current_time,
-                                collateral_expiration_status,
-                                quote_verification_result,
-                                p_supplemental_data,
-                                supplemental_data_size,
-                                qve_isvsvn_threshold);
-                if (sgx_ret != SGX_SUCCESS || verify_qveid_ret != SGX_QL_SUCCESS) {
-                        ETLS_ERR("verify QvE report and identity failed. %04x\n", verify_qveid_ret);
-                        err = SGX_ECDSA_ERR_CODE((int)verify_qveid_ret);
-                        goto errret;
-                } else
-                        ETLS_INFO("verify QvE report and identity successfully.\n");
+	if (!strcmp(ctx->opts->name, "sgx_ecdsa_qve")) {
+		sgx_ret = sgx_tvl_verify_qve_report_and_identity(
+			(sgx_enclave_id_t)ecdsa_ctx->eid, &verify_qveid_ret, evidence->ecdsa.quote,
+			(uint32_t)quote_size, qve_report_info, current_time,
+			collateral_expiration_status, quote_verification_result,
+			p_supplemental_data, supplemental_data_size, qve_isvsvn_threshold);
+		if (sgx_ret != SGX_SUCCESS || verify_qveid_ret != SGX_QL_SUCCESS) {
+			ETLS_ERR("verify QvE report and identity failed. %04x\n", verify_qveid_ret);
+			err = SGX_ECDSA_ERR_CODE((int)verify_qveid_ret);
+			goto errret;
+		} else
+			ETLS_INFO("verify QvE report and identity successfully.\n");
 
-                if (qve_report_info) {
-                        if (memcmp(qve_report_info->nonce.rand, rand_nonce, sizeof(rand_nonce)) != 0) {
-                                ETLS_ERR("nonce during SGX quote verification has been tampered with.\n");
-                                err = -ENCLAVE_QUOTE_ERR_INVALID;
-                                goto errret;
-                        }
-                }
-        }
+		if (qve_report_info) {
+			if (memcmp(qve_report_info->nonce.rand, rand_nonce, sizeof(rand_nonce)) !=
+			    0) {
+				ETLS_ERR(
+					"nonce during SGX quote verification has been tampered with.\n");
+				err = -ENCLAVE_QUOTE_ERR_INVALID;
+				goto errret;
+			}
+		}
+	}
 #endif
 
-        /* Check verification result */
-        switch (quote_verification_result) {
-                case SGX_QL_QV_RESULT_OK:
-                        ETLS_INFO("verification completed successfully.\n");
-                        err = ENCLAVE_QUOTE_ERR_NONE;
-                        break;
-                case SGX_QL_QV_RESULT_CONFIG_NEEDED:
-                case SGX_QL_QV_RESULT_OUT_OF_DATE:
-                case SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED:
-                case SGX_QL_QV_RESULT_SW_HARDENING_NEEDED:
-                case SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED:
-                        ETLS_WARN("verification completed with Non-terminal result: %x\n", quote_verification_result);
-                        err = SGX_ECDSA_ERR_CODE((int)quote_verification_result);
-                        break;
-                case SGX_QL_QV_RESULT_INVALID_SIGNATURE:
-                case SGX_QL_QV_RESULT_REVOKED:
-                case SGX_QL_QV_RESULT_UNSPECIFIED:
-                default:
-                        ETLS_ERR("verification completed with Terminal result: %x\n", quote_verification_result);
-                        err = SGX_ECDSA_ERR_CODE((int)quote_verification_result);
-                        break;
-        }
+	/* Check verification result */
+	switch (quote_verification_result) {
+	case SGX_QL_QV_RESULT_OK:
+		ETLS_INFO("verification completed successfully.\n");
+		err = ENCLAVE_QUOTE_ERR_NONE;
+		break;
+	case SGX_QL_QV_RESULT_CONFIG_NEEDED:
+	case SGX_QL_QV_RESULT_OUT_OF_DATE:
+	case SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED:
+	case SGX_QL_QV_RESULT_SW_HARDENING_NEEDED:
+	case SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED:
+		ETLS_WARN("verification completed with Non-terminal result: %x\n",
+			  quote_verification_result);
+		err = SGX_ECDSA_ERR_CODE((int)quote_verification_result);
+		break;
+	case SGX_QL_QV_RESULT_INVALID_SIGNATURE:
+	case SGX_QL_QV_RESULT_REVOKED:
+	case SGX_QL_QV_RESULT_UNSPECIFIED:
+	default:
+		ETLS_ERR("verification completed with Terminal result: %x\n",
+			 quote_verification_result);
+		err = SGX_ECDSA_ERR_CODE((int)quote_verification_result);
+		break;
+	}
 
 #if !defined(OCCLUM)
 errret:
-        free(p_supplemental_data);
+	free(p_supplemental_data);
 errout:
-        free(qve_report_info);
-        free(pquote);
+	free(qve_report_info);
+	free(pquote);
 #endif
 
-        return err;
+	return err;
 }

--- a/enclave-tls/src/enclave_quotes/sgx-la/cleanup.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/cleanup.c
@@ -11,7 +11,7 @@ enclave_quote_err_t sgx_la_cleanup(enclave_quote_ctx_t *ctx)
 {
 	ETLS_DEBUG("called\n");
 
-	sgx_la_ctx_t *la_ctx = (sgx_la_ctx_t *) ctx->quote_private;
+	sgx_la_ctx_t *la_ctx = (sgx_la_ctx_t *)ctx->quote_private;
 
 	free(la_ctx);
 

--- a/enclave-tls/src/enclave_quotes/sgx-la/collect_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/collect_evidence.c
@@ -21,22 +21,18 @@
  */
 enclave_quote_err_t sgx_la_collect_evidence(enclave_quote_ctx_t *ctx,
 					    attestation_evidence_t *evidence,
-					    enclave_tls_cert_algo_t algo,
-					    uint8_t *hash)
+					    enclave_tls_cert_algo_t algo, uint8_t *hash)
 {
-	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence,
-		   algo, hash);
+	ETLS_DEBUG("ctx %p, evidence %p, algo %d, hash %p\n", ctx, evidence, algo, hash);
 
-	sgx_la_ctx_t *la_ctx = (sgx_la_ctx_t *) ctx->quote_private;
+	sgx_la_ctx_t *la_ctx = (sgx_la_ctx_t *)ctx->quote_private;
 
 	sgx_report_t isv_report;
 	sgx_status_t generate_evidence_ret;
 	sgx_status_t status =
-		ecall_generate_evidence(la_ctx->eid, &generate_evidence_ret,
-					hash, &isv_report);
+		ecall_generate_evidence(la_ctx->eid, &generate_evidence_ret, hash, &isv_report);
 	if (status != SGX_SUCCESS || generate_evidence_ret != SGX_SUCCESS) {
-		ETLS_ERR("failed to generate evidence %#x\n",
-			 generate_evidence_ret);
+		ETLS_ERR("failed to generate evidence %#x\n", generate_evidence_ret);
 		return SGX_LA_ERR_CODE((int)generate_evidence_ret);
 	}
 

--- a/enclave-tls/src/enclave_quotes/sgx-la/ecalls.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/ecalls.c
@@ -5,6 +5,6 @@
 
 /* This function only exists to make edger8r happy. There must be at
    least one trusted (ECALL) function. */
-void dummy(void) {
+void dummy(void)
+{
 }
-

--- a/enclave-tls/src/enclave_quotes/sgx-la/init.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/init.c
@@ -8,8 +8,7 @@
 
 #include "sgx_la.h"
 
-enclave_quote_err_t sgx_la_init(enclave_quote_ctx_t *ctx,
-				enclave_tls_cert_algo_t algo)
+enclave_quote_err_t sgx_la_init(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo)
 {
 	ETLS_DEBUG("ctx %p, algo %d\n", ctx, algo);
 

--- a/enclave-tls/src/enclave_quotes/sgx-la/main.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/main.c
@@ -9,16 +9,11 @@
 
 extern enclave_quote_err_t enclave_quote_register(enclave_quote_opts_t *);
 extern enclave_quote_err_t sgx_la_pre_init(void);
-extern enclave_quote_err_t sgx_la_init(enclave_quote_ctx_t *,
-				       enclave_tls_cert_algo_t algo);
-extern enclave_quote_err_t sgx_la_collect_evidence(enclave_quote_ctx_t *,
-						   attestation_evidence_t *,
-						   enclave_tls_cert_algo_t algo,
-						   uint8_t *);
-extern enclave_quote_err_t sgx_la_verify_evidence(enclave_quote_ctx_t *,
-						  attestation_evidence_t *,
-						  uint8_t *,
-						  unsigned int hash_len);
+extern enclave_quote_err_t sgx_la_init(enclave_quote_ctx_t *, enclave_tls_cert_algo_t algo);
+extern enclave_quote_err_t sgx_la_collect_evidence(enclave_quote_ctx_t *, attestation_evidence_t *,
+						   enclave_tls_cert_algo_t algo, uint8_t *);
+extern enclave_quote_err_t sgx_la_verify_evidence(enclave_quote_ctx_t *, attestation_evidence_t *,
+						  uint8_t *, unsigned int hash_len);
 extern enclave_quote_err_t sgx_la_cleanup(enclave_quote_ctx_t *);
 
 static enclave_quote_opts_t sgx_la_opts = {
@@ -33,13 +28,11 @@ static enclave_quote_opts_t sgx_la_opts = {
 	.cleanup = sgx_la_cleanup,
 };
 
-void __attribute__((constructor))
-libenclave_quote_sgx_la_init(void)
+void __attribute__((constructor)) libenclave_quote_sgx_la_init(void)
 {
 	ETLS_DEBUG("called\n");
 
 	enclave_quote_err_t err = enclave_quote_register(&sgx_la_opts);
 	if (err != ENCLAVE_QUOTE_ERR_NONE)
-		ETLS_ERR("failed to register the enclave quote 'sgx_la' %#x\n",
-			 err);
+		ETLS_ERR("failed to register the enclave quote 'sgx_la' %#x\n", err);
 }

--- a/enclave-tls/src/enclave_quotes/sgx-la/verify_evidence.c
+++ b/enclave-tls/src/enclave_quotes/sgx-la/verify_evidence.c
@@ -13,8 +13,8 @@
 
 /* Refer to explanation in sgx_la_collect_evidence */
 enclave_quote_err_t sgx_la_verify_evidence(enclave_quote_ctx_t *ctx,
-					   attestation_evidence_t *evidence,
-					   uint8_t *hash, unsigned int hash_len)
+					   attestation_evidence_t *evidence, uint8_t *hash,
+					   unsigned int hash_len)
 {
 	uint32_t quote_size = 0;
 	unsigned char quote[8192];

--- a/enclave-tls/src/include/enclave-tls/api.h
+++ b/enclave-tls/src/include/enclave-tls/api.h
@@ -11,11 +11,11 @@
 #include <stddef.h>
 #include <enclave-tls/err.h>
 
-#define TLS_TYPE_NAME_SIZE      32
-#define QUOTE_TYPE_NAME_SIZE    32
-#define CRYPTO_TYPE_NAME_SIZE   32
+#define TLS_TYPE_NAME_SIZE	32
+#define QUOTE_TYPE_NAME_SIZE	32
+#define CRYPTO_TYPE_NAME_SIZE	32
 #define ENCLAVE_SGX_SPID_LENGTH 16
-#define SHA256_HASH_SIZE        32
+#define SHA256_HASH_SIZE	32
 
 typedef enum {
 	ENCLAVE_TLS_LOG_LEVEL_DEBUG,
@@ -37,10 +37,12 @@ typedef enum {
 } enclave_tls_cert_algo_t;
 
 /* FIXME: add the type of ecdsa verification */
+// clang-format off
 typedef enum {
 	VERIFICATION_TYPE_QVL,
 	VERIFICATION_TYPE_QEL
 } quote_sgx_ecdsa_verification_type_t;
+// clang-format on
 
 typedef struct {
 	unsigned int api_version;
@@ -68,29 +70,24 @@ typedef struct {
 	} quote_sgx_ecdsa;
 } enclave_tls_conf_t;
 
-#define ENCLAVE_TLS_API_VERSION_1                   1
-#define ENCLAVE_TLS_API_VERSION_MAX                 ENCLAVE_TLS_API_VERSION_1
-#define ENCLAVE_TLS_API_VERSION_DEFAULT             ENCLAVE_TLS_API_VERSION_1
+#define ENCLAVE_TLS_API_VERSION_1	1
+#define ENCLAVE_TLS_API_VERSION_MAX	ENCLAVE_TLS_API_VERSION_1
+#define ENCLAVE_TLS_API_VERSION_DEFAULT ENCLAVE_TLS_API_VERSION_1
 
-#define ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK_SHIFT    0
-#define ENCLAVE_TLS_CONF_FLAGS_PRIVATE_MASK_SHIFT   32
-#define	ENCLAVE_TLS_CONF_FLAGS_VERENFORCED_MASK_SHIFT	33
+#define ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK_SHIFT      0
+#define ENCLAVE_TLS_CONF_FLAGS_PRIVATE_MASK_SHIFT     32
+#define ENCLAVE_TLS_CONF_FLAGS_VERENFORCED_MASK_SHIFT 33
 
 #define ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK          (ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK << ENCLAVE_TLS_CONF_FLAGS_PRIVATE_MASK_SHIFT
 
-#define ENCLAVE_TLS_CONF_FLAGS_MUTUAL               (1UL << ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK_SHIFT)
+#define ENCLAVE_TLS_CONF_FLAGS_MUTUAL	   (1UL << ENCLAVE_TLS_CONF_FLAGS_GLOBAL_MASK_SHIFT)
+#define ENCLAVE_TLS_CONF_FLAGS_SERVER	   (1UL << ENCLAVE_TLS_CONF_FLAGS_PRIVATE_MASK_SHIFT)
+#define ENCLAVE_TLS_CONF_VERIFIER_ENFORCED (1UL << ENCLAVE_TLS_CONF_FLAGS_VERENFORCED_MASK_SHIFT)
 
-#define ENCLAVE_TLS_CONF_FLAGS_SERVER               (1UL << ENCLAVE_TLS_CONF_FLAGS_PRIVATE_MASK_SHIFT)
-
-#define ENCLAVE_TLS_CONF_VERIFIER_ENFORCED          (1UL << ENCLAVE_TLS_CONF_FLAGS_VERENFORCED_MASK_SHIFT)
-
-enclave_tls_err_t enclave_tls_init(const enclave_tls_conf_t *conf,
-				   enclave_tls_handle *handle);
+enclave_tls_err_t enclave_tls_init(const enclave_tls_conf_t *conf, enclave_tls_handle *handle);
 enclave_tls_err_t enclave_tls_negotiate(enclave_tls_handle handle, int fd);
-enclave_tls_err_t enclave_tls_receive(enclave_tls_handle handle, void *buf,
-				      size_t *buf_size);
-enclave_tls_err_t enclave_tls_transmit(enclave_tls_handle handle, void *buf,
-				       size_t *buf_size);
+enclave_tls_err_t enclave_tls_receive(enclave_tls_handle handle, void *buf, size_t *buf_size);
+enclave_tls_err_t enclave_tls_transmit(enclave_tls_handle handle, void *buf, size_t *buf_size);
 enclave_tls_err_t enclave_tls_cleanup(enclave_tls_handle handle);
 
 #endif

--- a/enclave-tls/src/include/enclave-tls/crypto_wrapper.h
+++ b/enclave-tls/src/include/enclave-tls/crypto_wrapper.h
@@ -13,15 +13,15 @@
 #include <enclave-tls/api.h>
 #include <enclave-tls/cert.h>
 
-#define CRYPTO_WRAPPER_TYPE_MAX               32
+#define CRYPTO_WRAPPER_TYPE_MAX 32
 
-#define CRYPTO_WRAPPER_API_VERSION_1          1
-#define CRYPTO_WRAPPER_API_VERSION_MAX        CRYPTO_WRAPPER_API_VERSION_1
-#define CRYPTO_WRAPPER_API_VERSION_DEFAULT    CRYPTO_WRAPPER_API_VERSION_1
+#define CRYPTO_WRAPPER_API_VERSION_1	   1
+#define CRYPTO_WRAPPER_API_VERSION_MAX	   CRYPTO_WRAPPER_API_VERSION_1
+#define CRYPTO_WRAPPER_API_VERSION_DEFAULT CRYPTO_WRAPPER_API_VERSION_1
 
 #define CRYPTO_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE 1
 
-typedef struct crypto_wrapper_ctx             crypto_wrapper_ctx_t;
+typedef struct crypto_wrapper_ctx crypto_wrapper_ctx_t;
 
 typedef struct {
 	uint8_t api_version;
@@ -32,13 +32,10 @@ typedef struct {
 	/* Optional */
 	crypto_wrapper_err_t (*pre_init)(void);
 	crypto_wrapper_err_t (*init)(crypto_wrapper_ctx_t *ctx);
-	crypto_wrapper_err_t (*gen_privkey)(crypto_wrapper_ctx_t *ctx,
-					    enclave_tls_cert_algo_t algo,
-					    uint8_t *privkey_buf,
-					    unsigned int *privkey_len);
+	crypto_wrapper_err_t (*gen_privkey)(crypto_wrapper_ctx_t *ctx, enclave_tls_cert_algo_t algo,
+					    uint8_t *privkey_buf, unsigned int *privkey_len);
 	crypto_wrapper_err_t (*gen_pubkey_hash)(crypto_wrapper_ctx_t *ctx,
-						enclave_tls_cert_algo_t algo,
-						uint8_t *hash);
+						enclave_tls_cert_algo_t algo, uint8_t *hash);
 	crypto_wrapper_err_t (*gen_cert)(crypto_wrapper_ctx_t *ctx,
 					 enclave_tls_cert_info_t *cert_info);
 	crypto_wrapper_err_t (*cleanup)(crypto_wrapper_ctx_t *ctx);

--- a/enclave-tls/src/include/enclave-tls/enclave_quote.h
+++ b/enclave-tls/src/include/enclave-tls/enclave_quote.h
@@ -12,17 +12,17 @@
 #include <enclave-tls/api.h>
 #include <enclave-tls/cert.h>
 
-#define ENCLAVE_QUOTE_TYPE_MAX               32
+#define ENCLAVE_QUOTE_TYPE_MAX 32
 
-#define ENCLAVE_QUOTE_API_VERSION_1          1
-#define ENCLAVE_QUOTE_API_VERSION_MAX        ENCLAVE_QUOTE_API_VERSION_1
-#define ENCLAVE_QUOTE_API_VERSION_DEFAULT    ENCLAVE_QUOTE_API_VERSION_1
+#define ENCLAVE_QUOTE_API_VERSION_1	  1
+#define ENCLAVE_QUOTE_API_VERSION_MAX	  ENCLAVE_QUOTE_API_VERSION_1
+#define ENCLAVE_QUOTE_API_VERSION_DEFAULT ENCLAVE_QUOTE_API_VERSION_1
 
 #define ENCLAVE_QUOTE_OPTS_FLAGS_SGX_ENCLAVE 1
 
-#define ENCLAVE_QUOTE_FLAGS_DEFAULT          0
+#define ENCLAVE_QUOTE_FLAGS_DEFAULT 0
 
-typedef struct enclave_quote_ctx             enclave_quote_ctx_t;
+typedef struct enclave_quote_ctx enclave_quote_ctx_t;
 
 typedef struct {
 	uint8_t api_version;
@@ -37,17 +37,15 @@ typedef struct {
 
 	/* Optional */
 	enclave_quote_err_t (*pre_init)(void);
-	enclave_quote_err_t (*init)(enclave_quote_ctx_t *ctx,
-				    enclave_tls_cert_algo_t algo);
+	enclave_quote_err_t (*init)(enclave_quote_ctx_t *ctx, enclave_tls_cert_algo_t algo);
 	enclave_quote_err_t (*extend_cert)(enclave_quote_ctx_t *ctx,
 					   const enclave_tls_cert_info_t *cert_info);
 	enclave_quote_err_t (*collect_evidence)(enclave_quote_ctx_t *ctx,
 						attestation_evidence_t *evidence,
-						enclave_tls_cert_algo_t algo,
-						uint8_t *hash);
+						enclave_tls_cert_algo_t algo, uint8_t *hash);
 	enclave_quote_err_t (*verify_evidence)(enclave_quote_ctx_t *ctx,
-					       attestation_evidence_t *evidence,
-					       uint8_t *hash, unsigned int hash_len);
+					       attestation_evidence_t *evidence, uint8_t *hash,
+					       unsigned int hash_len);
 	enclave_quote_err_t (*collect_collateral)(enclave_quote_ctx_t *ctx);
 	enclave_quote_err_t (*cleanup)(enclave_quote_ctx_t *ctx);
 } enclave_quote_opts_t;

--- a/enclave-tls/src/include/enclave-tls/err.h
+++ b/enclave-tls/src/include/enclave-tls/err.h
@@ -20,60 +20,55 @@
  * Bit 22-00: sub-class specific error codes
  */
 
-#define ERR_CODE_CLASS_SHIFT            28
-#define ERR_CODE_SUBCLASS_SHIFT         23
-#define ERR_CODE_CLASS_MASK             0x70000000
-#define ERR_CODE_SUBCLASS_MASK          0x0f800000
-#define ERR_CODE_ERROR_MASK             ((1 << ERR_CODE_SUBCLASS_SHIFT) - 1)
-#define ERR_CODE_NAGATIVE               (1 << 31)
+#define ERR_CODE_CLASS_SHIFT	28
+#define ERR_CODE_SUBCLASS_SHIFT 23
+#define ERR_CODE_CLASS_MASK	0x70000000
+#define ERR_CODE_SUBCLASS_MASK	0x0f800000
+#define ERR_CODE_ERROR_MASK	((1 << ERR_CODE_SUBCLASS_SHIFT) - 1)
+#define ERR_CODE_NAGATIVE	(1 << 31)
 
 /* The error code class */
-#define ENCLAVE_TLS_ERR_BASE            (0 << ERR_CODE_CLASS_SHIFT)
-#define TLS_WRAPPER_ERR_BASE            (1 << ERR_CODE_CLASS_SHIFT)
-#define ENCLAVE_QUOTE_ERR_BASE          (2 << ERR_CODE_CLASS_SHIFT)
-#define CRYPTO_WRAPPER_ERR_BASE         (3 << ERR_CODE_CLASS_SHIFT)
+#define ENCLAVE_TLS_ERR_BASE	(0 << ERR_CODE_CLASS_SHIFT)
+#define TLS_WRAPPER_ERR_BASE	(1 << ERR_CODE_CLASS_SHIFT)
+#define ENCLAVE_QUOTE_ERR_BASE	(2 << ERR_CODE_CLASS_SHIFT)
+#define CRYPTO_WRAPPER_ERR_BASE (3 << ERR_CODE_CLASS_SHIFT)
 
 /* The base of error code used by wolfssl */
-#define WOLFSSL_ERR_BASE                (0 << ERR_CODE_SUBCLASS_SHIFT)
+#define WOLFSSL_ERR_BASE (0 << ERR_CODE_SUBCLASS_SHIFT)
 /* The base of error code used by wolfssl-sgx */
-#define WOLFSSL_SGX_ERR_BASE            (1 << ERR_CODE_SUBCLASS_SHIFT)
+#define WOLFSSL_SGX_ERR_BASE (1 << ERR_CODE_SUBCLASS_SHIFT)
 
 /* The base of error code used by wolfcrypt */
-#define WOLFCRYPT_ERR_BASE              (0 << ERR_CODE_SUBCLASS_SHIFT)
+#define WOLFCRYPT_ERR_BASE (0 << ERR_CODE_SUBCLASS_SHIFT)
 
 /* The base of error code used by sgx-ecdsa */
-#define SGX_ECDSA_ERR_BASE		(0 << ERR_CODE_SUBCLASS_SHIFT)
+#define SGX_ECDSA_ERR_BASE (0 << ERR_CODE_SUBCLASS_SHIFT)
 
 /* The base of error code used by sgx-la */
-#define SGX_LA_ERR_BASE                 (0 << ERR_CODE_SUBCLASS_SHIFT)
+#define SGX_LA_ERR_BASE (0 << ERR_CODE_SUBCLASS_SHIFT)
 
 // Error code used to construct TLS Wrapper instance
-#define __TLS_WRAPPER_ERR_CODE(base, err) \
-	(((TLS_WRAPPER_ERR_BASE + (base)) & ERR_CODE_CLASS_MASK) | \
-	 ((err) & ERR_CODE_ERROR_MASK) | ERR_CODE_NAGATIVE)
+#define __TLS_WRAPPER_ERR_CODE(base, err)                                                        \
+	(((TLS_WRAPPER_ERR_BASE + (base)) & ERR_CODE_CLASS_MASK) | ((err)&ERR_CODE_ERROR_MASK) | \
+	 ERR_CODE_NAGATIVE)
 
-#define WOLFSSL_ERR_CODE(err) \
-	__TLS_WRAPPER_ERR_CODE(WOLFSSL_ERR_BASE, err)
+#define WOLFSSL_ERR_CODE(err) __TLS_WRAPPER_ERR_CODE(WOLFSSL_ERR_BASE, err)
 
-#define WOLFSSL_SGX_ERR_CODE(err) \
-	__TLS_WRAPPER_ERR_CODE(WOLFSSL_SGX_ERR_BASE, err)
+#define WOLFSSL_SGX_ERR_CODE(err) __TLS_WRAPPER_ERR_CODE(WOLFSSL_SGX_ERR_BASE, err)
 
-#define __CRYPTO_WRAPPER_ERR_CODE(base, err) \
+#define __CRYPTO_WRAPPER_ERR_CODE(base, err)                          \
 	(((CRYPTO_WRAPPER_ERR_BASE + (base)) & ERR_CODE_CLASS_MASK) | \
-	 ((err) & ERR_CODE_ERROR_MASK) | ERR_CODE_NAGATIVE)
+	 ((err)&ERR_CODE_ERROR_MASK) | ERR_CODE_NAGATIVE)
 
-#define WOLFCRYPT_ERR_CODE(err) \
-	__CRYPTO_WRAPPER_ERR_CODE(WOLFCRYPT_ERR_BASE, err)
+#define WOLFCRYPT_ERR_CODE(err) __CRYPTO_WRAPPER_ERR_CODE(WOLFCRYPT_ERR_BASE, err)
 
-#define __ENCLAVE_QUOTE_ERR_CODE(base, err) \
-	(((ENCLAVE_QUOTE_ERR_BASE + (base)) & ERR_CODE_CLASS_MASK) | \
-	 ((err) & ERR_CODE_ERROR_MASK) | ERR_CODE_NAGATIVE)
+#define __ENCLAVE_QUOTE_ERR_CODE(base, err)                                                        \
+	(((ENCLAVE_QUOTE_ERR_BASE + (base)) & ERR_CODE_CLASS_MASK) | ((err)&ERR_CODE_ERROR_MASK) | \
+	 ERR_CODE_NAGATIVE)
 
-#define SGX_ECDSA_ERR_CODE(err) \
-	__ENCLAVE_QUOTE_ERR_CODE(SGX_ECDSA_ERR_BASE, err)	
+#define SGX_ECDSA_ERR_CODE(err) __ENCLAVE_QUOTE_ERR_CODE(SGX_ECDSA_ERR_BASE, err)
 
-#define SGX_LA_ERR_CODE(err) \
-	__ENCLAVE_QUOTE_ERR_CODE(SGX_LA_ERR_BASE, err)
+#define SGX_LA_ERR_CODE(err) __ENCLAVE_QUOTE_ERR_CODE(SGX_LA_ERR_BASE, err)
 
 typedef enum {
 	ENCLAVE_TLS_ERR_NONE = ENCLAVE_TLS_ERR_BASE,

--- a/enclave-tls/src/include/enclave-tls/log.h
+++ b/enclave-tls/src/include/enclave-tls/log.h
@@ -6,79 +6,91 @@
 #ifndef _ENCLAVE_LOG_H_
 #define _ENCLAVE_LOG_H_
 
+// clang-format off
 #ifndef WOLFSSL_SGX
   #include <time.h>
 #endif
+// clang-format on
 #include <stdio.h>
 #include <stdlib.h>
 #include <enclave-tls/api.h>
+// clang-format off
 #ifdef WOLFSSL_SGX
   #include <enclave-tls/sgx.h>
 #endif
+// clang-format on
 
+// clang-format off
 #ifdef OCCLUM
-#define FPRINTF(io, fmt, ...)    \
-        do {    \
-                fprintf(io, fmt, ##__VA_ARGS__);    \
-                fflush(io);    \
-        } while (0)
+  #define FPRINTF(io, fmt, ...)                  \
+	do {                                     \
+		fprintf(io, fmt, ##__VA_ARGS__); \
+		fflush(io);                      \
+	} while (0)
 #else
-#define FPRINTF(io, fmt, ...)    \
-        do {    \
-                fprintf(io, fmt, ##__VA_ARGS__);    \
-        } while (0)
+  #define FPRINTF(io, fmt, ...)                  \
+	do {                                     \
+		fprintf(io, fmt, ##__VA_ARGS__); \
+	} while (0)
 #endif
+// clang-format on
 
 extern enclave_tls_log_level_t global_log_level;
 
-#define ETLS_FATAL(fmt, ...)   \
-	do {    \
-		__PR__(FATAL, stderr, fmt, ##__VA_ARGS__);      \
-		exit(EXIT_FAILURE);     \
+#define ETLS_FATAL(fmt, ...)                               \
+	do {                                               \
+		__PR__(FATAL, stderr, fmt, ##__VA_ARGS__); \
+		exit(EXIT_FAILURE);                        \
 	} while (0)
 
-#define ETLS_ERR(fmt, ...)   \
-	do {    \
-		__PR__(ERROR, stderr, fmt, ##__VA_ARGS__);      \
+#define ETLS_ERR(fmt, ...)                                 \
+	do {                                               \
+		__PR__(ERROR, stderr, fmt, ##__VA_ARGS__); \
 	} while (0)
 
-#define ETLS_WARN(fmt, ...)  \
-	do {    \
-		__PR__(WARN, stdout, fmt, ##__VA_ARGS__);    \
+#define ETLS_WARN(fmt, ...)                               \
+	do {                                              \
+		__PR__(WARN, stdout, fmt, ##__VA_ARGS__); \
 	} while (0)
 
-#define ETLS_INFO(fmt, ...)  \
-	do {    \
-		__PR__(INFO, stdout, fmt, ##__VA_ARGS__);       \
+#define ETLS_INFO(fmt, ...)                               \
+	do {                                              \
+		__PR__(INFO, stdout, fmt, ##__VA_ARGS__); \
 	} while (0)
 
-#define ETLS_DEBUG(fmt, ...) \
-	do {    \
-		__PR__(DEBUG, stdout, fmt, ##__VA_ARGS__);      \
+#define ETLS_DEBUG(fmt, ...)                               \
+	do {                                               \
+		__PR__(DEBUG, stdout, fmt, ##__VA_ARGS__); \
 	} while (0)
 
+// clang-format off
 #ifdef WOLFSSL_SGX
-#define __PR__(level, io, fmt, ...)     \
-        do {    \
-		if (global_log_level <= ENCLAVE_TLS_LOG_LEVEL_##level) \
-			printf("[" #level "] %s()@L%d: " fmt, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
+  #define __PR__(level, io, fmt, ...)                                                 \
+	do {                                                                          \
+		if (global_log_level <= ENCLAVE_TLS_LOG_LEVEL_##level)                \
+			printf("[" #level "] %s()@L%d: " fmt, __FUNCTION__, __LINE__, \
+			       ##__VA_ARGS__);                                        \
 	} while (0)
 #else
-#define __PR__(level, io, fmt, ...)     \
-	do {    \
-		if (global_log_level <= ENCLAVE_TLS_LOG_LEVEL_##level) {   \
-			if (ENCLAVE_TLS_LOG_LEVEL_##level != ENCLAVE_TLS_LOG_LEVEL_DEBUG) {	\
-				FPRINTF(io, "[" #level "] " fmt, ##__VA_ARGS__);	\
-			} else {	\
-				time_t __t__ = time(NULL);      \
-				struct tm __loc__;      \
-				localtime_r(&__t__, &__loc__);  \
-				char __buf__[64]; \
-				strftime(__buf__, sizeof(__buf__), "%a %b %e %T %Z %Y", &__loc__);      \
-				FPRINTF(io, "%s: [" #level "] %s()@L%d: " fmt, __buf__, __FUNCTION__, __LINE__, ##__VA_ARGS__);   \
-			}	\
-		} \
+  #define __PR__(level, io, fmt, ...)                                                   \
+	do {                                                                            \
+		if (global_log_level <= ENCLAVE_TLS_LOG_LEVEL_##level) {                \
+			if (ENCLAVE_TLS_LOG_LEVEL_##level !=                            \
+			    ENCLAVE_TLS_LOG_LEVEL_DEBUG) {                              \
+				FPRINTF(io, "[" #level "] " fmt, ##__VA_ARGS__);        \
+			} else {                                                        \
+				time_t __t__ = time(NULL);                              \
+				struct tm __loc__;                                      \
+				localtime_r(&__t__, &__loc__);                          \
+				char __buf__[64];                                       \
+				strftime(__buf__, sizeof(__buf__), "%a %b %e %T %Z %Y", \
+					 &__loc__);                                     \
+				FPRINTF(io, "%s: [" #level "] %s()@L%d: " fmt, __buf__, \
+					__FUNCTION__, __LINE__, ##__VA_ARGS__);         \
+			}                                                               \
+		}                                                                       \
 	} while (0)
 #endif
+// clang-format on
 
 #endif

--- a/enclave-tls/src/include/enclave-tls/sgx.h
+++ b/enclave-tls/src/include/enclave-tls/sgx.h
@@ -6,8 +6,7 @@
 #ifndef _ENCLAVE_SGX_H_
 #define _ENCLAVE_SGX_H_
 
-#define fprintf(stream, fmt, ...) \
-	printf(fmt, ##__VA_ARGS__)
+#define fprintf(stream, fmt, ...) printf(fmt, ##__VA_ARGS__)
 
 extern void printf(const char *fmt, ...);
 #endif

--- a/enclave-tls/src/include/enclave-tls/tls_wrapper.h
+++ b/enclave-tls/src/include/enclave-tls/tls_wrapper.h
@@ -12,15 +12,15 @@
 #include <enclave-tls/api.h>
 #include <enclave-tls/cert.h>
 
-#define TLS_WRAPPER_TYPE_MAX               32
+#define TLS_WRAPPER_TYPE_MAX 32
 
-#define TLS_WRAPPER_API_VERSION_1          1
-#define TLS_WRAPPER_API_VERSION_MAX        TLS_WRAPPER_API_VERSION_1
-#define TLS_WRAPPER_API_VERSION_DEFAULT    TLS_WRAPPER_API_VERSION_1
+#define TLS_WRAPPER_API_VERSION_1	1
+#define TLS_WRAPPER_API_VERSION_MAX	TLS_WRAPPER_API_VERSION_1
+#define TLS_WRAPPER_API_VERSION_DEFAULT TLS_WRAPPER_API_VERSION_1
 
 #define TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE 1
 
-typedef struct tls_wrapper_ctx             tls_wrapper_ctx_t;
+typedef struct tls_wrapper_ctx tls_wrapper_ctx_t;
 
 typedef struct {
 	uint8_t api_version;
@@ -31,16 +31,12 @@ typedef struct {
 	/* Optional */
 	tls_wrapper_err_t (*pre_init)(void);
 	tls_wrapper_err_t (*init)(tls_wrapper_ctx_t *ctx);
-	tls_wrapper_err_t (*use_privkey)(tls_wrapper_ctx_t *ctx,
-					 void *privkey_buf,
+	tls_wrapper_err_t (*use_privkey)(tls_wrapper_ctx_t *ctx, void *privkey_buf,
 					 size_t privkey_len);
-	tls_wrapper_err_t (*use_cert)(tls_wrapper_ctx_t *ctx,
-				      enclave_tls_cert_info_t *cert_info);
+	tls_wrapper_err_t (*use_cert)(tls_wrapper_ctx_t *ctx, enclave_tls_cert_info_t *cert_info);
 	tls_wrapper_err_t (*negotiate)(tls_wrapper_ctx_t *ctx, int fd);
-	tls_wrapper_err_t (*transmit)(tls_wrapper_ctx_t *ctx, void *buf,
-				      size_t *buf_size);
-	tls_wrapper_err_t (*receive)(tls_wrapper_ctx_t *ctx, void *buf,
-				     size_t *buf_size);
+	tls_wrapper_err_t (*transmit)(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size);
+	tls_wrapper_err_t (*receive)(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size);
 	tls_wrapper_err_t (*cleanup)(tls_wrapper_ctx_t *ctx);
 } tls_wrapper_opts_t;
 
@@ -57,9 +53,9 @@ struct tls_wrapper_ctx {
 };
 
 extern tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *);
-extern tls_wrapper_err_t
-tls_wrapper_verify_certificate_extension(tls_wrapper_ctx_t *tls_ctx,
-					 attestation_evidence_t *evidence,
-					 uint8_t *hash, unsigned int hash_len);
+extern tls_wrapper_err_t tls_wrapper_verify_certificate_extension(tls_wrapper_ctx_t *tls_ctx,
+								  attestation_evidence_t *evidence,
+								  uint8_t *hash,
+								  unsigned int hash_len);
 
 #endif

--- a/enclave-tls/src/include/internal/core.h
+++ b/enclave-tls/src/include/internal/core.h
@@ -25,12 +25,12 @@ extern etls_core_context_t global_core_context;
 extern enclave_tls_err_t etls_core_generate_certificate(etls_core_context_t *);
 
 // Whether the quote instance is initialized
-#define ENCLAVE_TLS_CTX_FLAGS_QUOTING_INITIALIZED   (1 << 0)
+#define ENCLAVE_TLS_CTX_FLAGS_QUOTING_INITIALIZED (1 << 0)
 // Whether the tls lib is initialized
-#define ENCLAVE_TLS_CTX_FLAGS_TLS_INITIALIZED       (1 << 16)
+#define ENCLAVE_TLS_CTX_FLAGS_TLS_INITIALIZED (1 << 16)
 // Whether the tls library has completed the creation and initialization of the TLS certificate
-#define ENCLAVE_TLS_CTX_FLAGS_CERT_CREATED          (1 << 17)
+#define ENCLAVE_TLS_CTX_FLAGS_CERT_CREATED (1 << 17)
 // Whether the crypto lib is initialized
-#define ENCLAVE_TLS_CTX_FLAGS_CRYPTO_INITIALIZED    (1 << 18)
+#define ENCLAVE_TLS_CTX_FLAGS_CRYPTO_INITIALIZED (1 << 18)
 
 #endif

--- a/enclave-tls/src/include/internal/crypto_wrapper.h
+++ b/enclave-tls/src/include/internal/crypto_wrapper.h
@@ -9,12 +9,11 @@
 #include <enclave-tls/crypto_wrapper.h>
 #include "internal/core.h"
 
-#define CRYPTO_WRAPPERS_DIR     "/opt/enclave-tls/lib/crypto-wrappers/"
+#define CRYPTO_WRAPPERS_DIR "/opt/enclave-tls/lib/crypto-wrappers/"
 
 extern enclave_tls_err_t etls_crypto_wrapper_load_all(void);
 extern enclave_tls_err_t etls_crypto_wrapper_load_single(const char *);
-extern enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *,
-						    const char *);
+extern enclave_tls_err_t etls_crypto_wrapper_select(etls_core_context_t *, const char *);
 
 extern crypto_wrapper_ctx_t *crypto_wrappers_ctx[CRYPTO_WRAPPER_TYPE_MAX];
 extern crypto_wrapper_opts_t *crypto_wrappers_opts[CRYPTO_WRAPPER_TYPE_MAX];

--- a/enclave-tls/src/include/internal/enclave_quote.h
+++ b/enclave-tls/src/include/internal/enclave_quote.h
@@ -9,16 +9,14 @@
 #include <enclave-tls/enclave_quote.h>
 #include "internal/core.h"
 
-#define ENCLAVE_QUOTES_DIR    "/opt/enclave-tls/lib/enclave-quotes/"
+#define ENCLAVE_QUOTES_DIR "/opt/enclave-tls/lib/enclave-quotes/"
 
 extern enclave_tls_err_t etls_enclave_quote_load_all(void);
 extern enclave_tls_err_t etls_enclave_quote_load_single(const char *);
-extern enclave_tls_err_t etls_attester_select(etls_core_context_t *,
-						   const char *,
-						   enclave_tls_cert_algo_t);
-extern enclave_tls_err_t etls_verifier_select(etls_core_context_t *,
-						   const char *,
-						   enclave_tls_cert_algo_t);
+extern enclave_tls_err_t etls_attester_select(etls_core_context_t *, const char *,
+					      enclave_tls_cert_algo_t);
+extern enclave_tls_err_t etls_verifier_select(etls_core_context_t *, const char *,
+					      enclave_tls_cert_algo_t);
 extern enclave_quote_opts_t *enclave_quotes_opts[ENCLAVE_QUOTE_TYPE_MAX];
 extern enclave_quote_ctx_t *enclave_quotes_ctx[ENCLAVE_QUOTE_TYPE_MAX];
 extern unsigned int enclave_quote_nums;

--- a/enclave-tls/src/include/internal/sgxutils.h
+++ b/enclave-tls/src/include/internal/sgxutils.h
@@ -5,6 +5,6 @@
 
 #include <stdbool.h>
 
-#define SGX_CPUID				0x12
+#define SGX_CPUID 0x12
 
 extern bool is_sgx_supported_and_configured(void);

--- a/enclave-tls/src/include/internal/tls_wrapper.h
+++ b/enclave-tls/src/include/internal/tls_wrapper.h
@@ -9,12 +9,11 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "internal/core.h"
 
-#define TLS_WRAPPERS_DIR    "/opt/enclave-tls/lib/tls-wrappers/"
+#define TLS_WRAPPERS_DIR "/opt/enclave-tls/lib/tls-wrappers/"
 
 extern enclave_tls_err_t etls_tls_wrapper_load_all(void);
 extern enclave_tls_err_t etls_tls_wrapper_load_single(const char *);
-extern enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *,
-						 const char *);
+extern enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *, const char *);
 
 extern tls_wrapper_ctx_t *tls_wrappers_ctx[TLS_WRAPPER_TYPE_MAX];
 extern tls_wrapper_opts_t *tls_wrappers_opts[TLS_WRAPPER_TYPE_MAX];

--- a/enclave-tls/src/sgx/ocalls.c
+++ b/enclave-tls/src/sgx/ocalls.c
@@ -13,7 +13,7 @@ static double current_time()
 
 	gettimeofday(&tv, NULL);
 
-	return (double)(1000000 * tv.tv_sec + tv.tv_usec)/1000000.0;
+	return (double)(1000000 * tv.tv_sec + tv.tv_usec) / 1000000.0;
 }
 
 void ocall_print_string(const char *str)

--- a/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
+++ b/enclave-tls/src/tls_wrappers/api/tls_wrapper_register.c
@@ -19,13 +19,14 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 
 	if (opts->flags & TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE) {
 		if (!is_sgx_supported_and_configured()) {
+			// clang-format off
 			ETLS_DEBUG("failed to register the tls wrapper '%s' due to lack of SGX capability\n", opts->name);
+			// clang-format on
 			return -TLS_WRAPPER_ERR_INVALID;
 		}
 	}
 
-	tls_wrapper_opts_t *new_opts =
-		(tls_wrapper_opts_t *)malloc(sizeof(*new_opts));
+	tls_wrapper_opts_t *new_opts = (tls_wrapper_opts_t *)malloc(sizeof(*new_opts));
 	if (!new_opts)
 		return -TLS_WRAPPER_ERR_NO_MEM;
 
@@ -37,8 +38,8 @@ tls_wrapper_err_t tls_wrapper_register(const tls_wrapper_opts_t *opts)
 	}
 
 	if (new_opts->api_version > TLS_WRAPPER_API_VERSION_MAX) {
-		ETLS_ERR("unsupported tls wrapper api version %d > %d\n",
-			 new_opts->api_version, TLS_WRAPPER_API_VERSION_MAX);
+		ETLS_ERR("unsupported tls wrapper api version %d > %d\n", new_opts->api_version,
+			 TLS_WRAPPER_API_VERSION_MAX);
 		goto err;
 	}
 

--- a/enclave-tls/src/tls_wrappers/api/tls_wrapper_verify_certificate_extension.c
+++ b/enclave-tls/src/tls_wrappers/api/tls_wrapper_verify_certificate_extension.c
@@ -11,25 +11,33 @@
 #include "internal/enclave_quote.h"
 
 tls_wrapper_err_t tls_wrapper_verify_certificate_extension(tls_wrapper_ctx_t *tls_ctx,
-							attestation_evidence_t *evidence,
-							uint8_t *hash, uint32_t hash_len)
+							   attestation_evidence_t *evidence,
+							   uint8_t *hash, uint32_t hash_len)
 {
-	ETLS_DEBUG("tls_wrapper_verify_certificate_extension() called with evidence type: '%s'\n", evidence->type);
+	ETLS_DEBUG("tls_wrapper_verify_certificate_extension() called with evidence type: '%s'\n",
+		   evidence->type);
 
-	if (!tls_ctx || !tls_ctx->etls_handle || !tls_ctx->etls_handle->verifier || !tls_ctx->etls_handle->verifier->opts ||
-			!tls_ctx->etls_handle->verifier->opts->verify_evidence)
+	if (!tls_ctx || !tls_ctx->etls_handle || !tls_ctx->etls_handle->verifier ||
+	    !tls_ctx->etls_handle->verifier->opts ||
+	    !tls_ctx->etls_handle->verifier->opts->verify_evidence)
 		return -TLS_WRAPPER_ERR_INVALID;
 
-	if (strcmp(tls_ctx->etls_handle->verifier->opts->type, evidence->type) && !(tls_ctx->etls_handle->flags & ENCLAVE_TLS_CONF_VERIFIER_ENFORCED)) {
-		ETLS_WARN("type doesn't match between verifier '%s' and evidence '%s'\n", tls_ctx->etls_handle->verifier->opts->name, evidence->type);
-		enclave_tls_err_t tlserr = etls_verifier_select(tls_ctx->etls_handle, evidence->type, tls_ctx->etls_handle->config.cert_algo);
+	if (strcmp(tls_ctx->etls_handle->verifier->opts->type, evidence->type) &&
+	    !(tls_ctx->etls_handle->flags & ENCLAVE_TLS_CONF_VERIFIER_ENFORCED)) {
+		ETLS_WARN("type doesn't match between verifier '%s' and evidence '%s'\n",
+			  tls_ctx->etls_handle->verifier->opts->name, evidence->type);
+		enclave_tls_err_t tlserr =
+			etls_verifier_select(tls_ctx->etls_handle, evidence->type,
+					     tls_ctx->etls_handle->config.cert_algo);
 		if (tlserr != ENCLAVE_TLS_ERR_NONE) {
-			ETLS_ERR("the verifier selecting err %#x during verifying cert extension\n", tlserr);
+			ETLS_ERR("the verifier selecting err %#x during verifying cert extension\n",
+				 tlserr);
 			return -TLS_WRAPPER_ERR_INVALID;
 		}
 	}
 
-	enclave_quote_err_t err = tls_ctx->etls_handle->verifier->opts->verify_evidence(tls_ctx->etls_handle->verifier, evidence, hash, hash_len);
+	enclave_quote_err_t err = tls_ctx->etls_handle->verifier->opts->verify_evidence(
+		tls_ctx->etls_handle->verifier, evidence, hash, hash_len);
 	if (err != ENCLAVE_QUOTE_ERR_NONE) {
 		ETLS_ERR("failed to verify evidence %#x\n", err);
 		return -TLS_WRAPPER_ERR_INVALID;

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_all.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_all.c
@@ -10,14 +10,16 @@
 #include <enclave-tls/log.h>
 #include "internal/tls_wrapper.h"
 
+// clang-format off
 #ifdef OCCLUM
-  #define PATTERN_SUFFIX          ".so"
+  #define PATTERN_SUFFIX ".so"
 #endif
+// clang-format on
 
 static int tls_wrapper_cmp(const void *a, const void *b)
 {
 	return (*(tls_wrapper_ctx_t **)b)->opts->priority -
-		(*(tls_wrapper_ctx_t **)a)->opts->priority;
+	       (*(tls_wrapper_ctx_t **)a)->opts->priority;
 }
 
 enclave_tls_err_t etls_tls_wrapper_load_all(void)
@@ -33,15 +35,15 @@ enclave_tls_err_t etls_tls_wrapper_load_all(void)
 	unsigned int total_loaded = 0;
 	struct dirent *ptr;
 	while ((ptr = readdir(dir)) != NULL) {
-		if (!strcmp(ptr->d_name, ".") ||
-		    !strcmp(ptr->d_name, ".."))
+		if (!strcmp(ptr->d_name, ".") || !strcmp(ptr->d_name, ".."))
 			continue;
 
 #ifdef OCCLUM
 		/* Occlum can't identify the d_type of the file, always return DT_UNKNOWN */
-		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
+		if (strncmp(ptr->d_name + strlen(ptr->d_name) - strlen(PATTERN_SUFFIX),
+			    PATTERN_SUFFIX, strlen(PATTERN_SUFFIX)) == 0) {
 #else
-			if (ptr->d_type == DT_REG) {
+		if (ptr->d_type == DT_REG) {
 #endif
 			if (etls_tls_wrapper_load_single(ptr->d_name) == ENCLAVE_TLS_ERR_NONE)
 				++total_loaded;
@@ -51,16 +53,14 @@ enclave_tls_err_t etls_tls_wrapper_load_all(void)
 	closedir(dir);
 
 	if (!total_loaded) {
-		ETLS_ERR("unavailable tls wrapper instance under %s\n",
-			 TLS_WRAPPERS_DIR);
+		ETLS_ERR("unavailable tls wrapper instance under %s\n", TLS_WRAPPERS_DIR);
 		return -ENCLAVE_TLS_ERR_LOAD_TLS_WRAPPERS;
 	}
 
 	/* Sort all tls_wrappers_ctx_t instances in the tls_wrappers_ctx, and the higher priority
 	 * instance should be sorted in front of the tls_wrappers_ctx array.
 	 */
-	qsort(tls_wrappers_ctx, tls_wrappers_nums, sizeof(tls_wrapper_ctx_t *),
-	      tls_wrapper_cmp);
+	qsort(tls_wrappers_ctx, tls_wrappers_nums, sizeof(tls_wrapper_ctx_t *), tls_wrapper_cmp);
 
 	return ENCLAVE_TLS_ERR_NONE;
 }

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_single.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_single.c
@@ -11,8 +11,8 @@
 #include "internal/core.h"
 #include "internal/tls_wrapper.h"
 
-#define PATTERN_PREFIX          "libtls_wrapper_"
-#define PATTERN_SUFFIX          ".so"
+#define PATTERN_PREFIX "libtls_wrapper_"
+#define PATTERN_SUFFIX ".so"
 
 enclave_tls_err_t etls_tls_wrapper_load_single(const char *fname)
 {
@@ -21,8 +21,10 @@ enclave_tls_err_t etls_tls_wrapper_load_single(const char *fname)
 	/* Check whether the filename pattern matches up libtls_wrapper_<name>.so */
 	if (strlen(fname) <= strlen(PATTERN_PREFIX) + strlen(PATTERN_SUFFIX) ||
 	    strncmp(fname, PATTERN_PREFIX, strlen(PATTERN_PREFIX)) ||
-	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX, strlen(PATTERN_SUFFIX))) {
-		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX "<name>" PATTERN_SUFFIX "\n",
+	    strncmp(fname + strlen(fname) - strlen(PATTERN_SUFFIX), PATTERN_SUFFIX,
+		    strlen(PATTERN_SUFFIX))) {
+		ETLS_ERR("The filename pattern of '%s' NOT match " PATTERN_PREFIX
+			 "<name>" PATTERN_SUFFIX "\n",
 			 fname);
 		return -ENCLAVE_TLS_ERR_INVALID;
 	}

--- a/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
+++ b/enclave-tls/src/tls_wrappers/internal/etls_tls_wrapper_select.c
@@ -22,8 +22,7 @@ static enclave_tls_err_t init_tls_wrapper(tls_wrapper_ctx_t *tls_ctx)
 	return ENCLAVE_TLS_ERR_NONE;
 }
 
-enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx,
-					  const char *name)
+enclave_tls_err_t etls_tls_wrapper_select(etls_core_context_t *ctx, const char *name)
 {
 	ETLS_DEBUG("selecting the tls wrapper '%s' ...\n", name);
 

--- a/enclave-tls/src/tls_wrappers/nulltls/main.c
+++ b/enclave-tls/src/tls_wrappers/nulltls/main.c
@@ -9,8 +9,7 @@
 
 extern tls_wrapper_err_t nulltls_pre_init(void);
 extern tls_wrapper_err_t nulltls_init(tls_wrapper_ctx_t *);
-extern tls_wrapper_err_t nulltls_use_privkey(tls_wrapper_ctx_t *ctx,
-					     void *privkey_buf,
+extern tls_wrapper_err_t nulltls_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf,
 					     size_t privkey_len);
 extern tls_wrapper_err_t nulltls_use_cert(tls_wrapper_ctx_t *ctx,
 					  enclave_tls_cert_info_t *cert_info);
@@ -33,8 +32,7 @@ static tls_wrapper_opts_t nulltls_opts = {
 	.cleanup = nulltls_cleanup,
 };
 
-void __attribute__((constructor))
-libtls_wrapper_nulltls_init(void)
+void __attribute__((constructor)) libtls_wrapper_nulltls_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/tls_wrappers/nulltls/negotiate.c
+++ b/enclave-tls/src/tls_wrappers/nulltls/negotiate.c
@@ -22,8 +22,8 @@ tls_wrapper_err_t nulltls_negotiate(tls_wrapper_ctx_t *ctx, int fd)
 		/* There is no evidence in tls_wrapper_nulltls */
 		strncpy(evidence.type, "nulltls", sizeof(evidence.type));
 
-		err = tls_wrapper_verify_certificate_extension(ctx, &evidence,
-							       hash, SHA256_HASH_SIZE);
+		err = tls_wrapper_verify_certificate_extension(ctx, &evidence, hash,
+							       SHA256_HASH_SIZE);
 		if (err != TLS_WRAPPER_ERR_NONE) {
 			ETLS_ERR("ERROR: failed to verify certificate extension\n");
 			return err;

--- a/enclave-tls/src/tls_wrappers/nulltls/use_cert.c
+++ b/enclave-tls/src/tls_wrappers/nulltls/use_cert.c
@@ -6,8 +6,7 @@
 #include <enclave-tls/log.h>
 #include <enclave-tls/tls_wrapper.h>
 
-tls_wrapper_err_t nulltls_use_cert(tls_wrapper_ctx_t *ctx,
-				   enclave_tls_cert_info_t *cert_info)
+tls_wrapper_err_t nulltls_use_cert(tls_wrapper_ctx_t *ctx, enclave_tls_cert_info_t *cert_info)
 {
 	ETLS_DEBUG("ctx %p, cert_info %p\n", ctx, cert_info);
 

--- a/enclave-tls/src/tls_wrappers/nulltls/use_privkey.c
+++ b/enclave-tls/src/tls_wrappers/nulltls/use_privkey.c
@@ -6,12 +6,9 @@
 #include <enclave-tls/log.h>
 #include <enclave-tls/tls_wrapper.h>
 
-tls_wrapper_err_t
-nulltls_use_privkey(tls_wrapper_ctx_t *ctx,
-		    void *privkey_buf, size_t privkey_len)
+tls_wrapper_err_t nulltls_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf, size_t privkey_len)
 {
-	ETLS_DEBUG("ctx %p, privkey_buf %p, privkey_len %ld\n",
-		   ctx, privkey_buf, privkey_len);
+	ETLS_DEBUG("ctx %p, privkey_buf %p, privkey_len %ld\n", ctx, privkey_buf, privkey_len);
 
 	return TLS_WRAPPER_ERR_NONE;
 }

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/ecalls.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/ecalls.c
@@ -27,15 +27,13 @@ tls_wrapper_err_t ecall_wolfssl_init(tls_wrapper_ctx_t *ctx)
 	return wolfssl_init(ctx);
 }
 
-tls_wrapper_err_t ecall_wolfssl_use_privkey(tls_wrapper_ctx_t *ctx,
-					    void *privkey_buf,
+tls_wrapper_err_t ecall_wolfssl_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf,
 					    size_t privkey_len)
 {
 	return wolfssl_use_privkey(ctx, privkey_buf, privkey_len);
 }
 
-tls_wrapper_err_t ecall_wolfssl_use_cert(tls_wrapper_ctx_t *ctx,
-					 enclave_tls_cert_info_t *cert_info)
+tls_wrapper_err_t ecall_wolfssl_use_cert(tls_wrapper_ctx_t *ctx, enclave_tls_cert_info_t *cert_info)
 {
 	return wolfssl_use_cert(ctx, cert_info);
 }
@@ -45,14 +43,12 @@ tls_wrapper_err_t ecall_wolfssl_negotiate(tls_wrapper_ctx_t *ctx, int fd)
 	return wolfssl_negotiate(ctx, fd);
 }
 
-tls_wrapper_err_t ecall_wolfssl_transmit(tls_wrapper_ctx_t *ctx, void *buf,
-				 size_t *buf_size)
+tls_wrapper_err_t ecall_wolfssl_transmit(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {
 	return wolfssl_transmit(ctx, buf, buf_size);
 }
 
-tls_wrapper_err_t ecall_wolfssl_receive(tls_wrapper_ctx_t *ctx, void *buf,
-				size_t *buf_size)
+tls_wrapper_err_t ecall_wolfssl_receive(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {
 	return wolfssl_receive(ctx, buf, buf_size);
 }

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/main.c
@@ -8,9 +8,8 @@
 
 extern tls_wrapper_err_t wolfssl_sgx_pre_init(void);
 extern tls_wrapper_err_t wolfssl_sgx_init(tls_wrapper_ctx_t *);
-extern tls_wrapper_err_t wolfssl_sgx_use_privkey(tls_wrapper_ctx_t *ctx,
-							   void *privkey_buf,
-							   size_t privkey_len);
+extern tls_wrapper_err_t wolfssl_sgx_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf,
+						 size_t privkey_len);
 extern tls_wrapper_err_t wolfssl_sgx_use_cert(tls_wrapper_ctx_t *ctx,
 					      enclave_tls_cert_info_t *cert_info);
 extern tls_wrapper_err_t wolfssl_sgx_negotiate(tls_wrapper_ctx_t *, int fd);
@@ -33,8 +32,7 @@ static tls_wrapper_opts_t wolfssl_sgx_opts = {
 	.flags = TLS_WRAPPER_OPTS_FLAGS_SGX_ENCLAVE,
 };
 
-void __attribute__((constructor))
-libtls_wrapper_wolfssl_sgx_init(void)
+void __attribute__((constructor)) libtls_wrapper_wolfssl_sgx_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/ocalls.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/ocalls.c
@@ -9,12 +9,12 @@
 
 size_t ocall_recv(int sockfd, void *buf, size_t len, int flags)
 {
-        return recv(sockfd, buf, len, flags);
+	return recv(sockfd, buf, len, flags);
 }
 
 size_t ocall_send(int sockfd, const void *buf, size_t len, int flags)
 {
-        return send(sockfd, buf, len, flags);
+	return send(sockfd, buf, len, flags);
 }
 
 int ocall_verify_certificate(void *ctx, uint8_t *der_crt, uint32_t der_crt_len)

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/transmit.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/transmit.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl_sgx.h"
 
-tls_wrapper_err_t wolfssl_sgx_transmit(tls_wrapper_ctx_t *ctx, void *buf,
-				       size_t *buf_size)
+tls_wrapper_err_t wolfssl_sgx_transmit(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/use_cert.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/use_cert.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl_sgx.h"
 
-tls_wrapper_err_t wolfssl_sgx_use_cert(tls_wrapper_ctx_t *ctx,
-				       enclave_tls_cert_info_t *cert_info)
+tls_wrapper_err_t wolfssl_sgx_use_cert(tls_wrapper_ctx_t *ctx, enclave_tls_cert_info_t *cert_info)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/tls_wrappers/wolfssl-sgx/use_privkey.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl-sgx/use_privkey.c
@@ -7,14 +7,14 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl_sgx.h"
 
-tls_wrapper_err_t wolfssl_sgx_use_privkey(tls_wrapper_ctx_t *ctx,
-					  void *privkey_buf,
+tls_wrapper_err_t wolfssl_sgx_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf,
 					  size_t privkey_len)
 {
 	ETLS_DEBUG("called\n");
 
 	tls_wrapper_err_t err;
-	ecall_wolfssl_use_privkey((sgx_enclave_id_t)ctx->enclave_id, &err, ctx, privkey_buf, privkey_len);
+	ecall_wolfssl_use_privkey((sgx_enclave_id_t)ctx->enclave_id, &err, ctx, privkey_buf,
+				  privkey_len);
 
 	return err;
 }

--- a/enclave-tls/src/tls_wrappers/wolfssl/main.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/main.c
@@ -9,9 +9,8 @@
 
 extern tls_wrapper_err_t wolfssl_pre_init(void);
 extern tls_wrapper_err_t wolfssl_init(tls_wrapper_ctx_t *);
-extern tls_wrapper_err_t wolfssl_use_privkey(tls_wrapper_ctx_t *ctx,
-						       void *privkey_buf,
-						       size_t privkey_len);
+extern tls_wrapper_err_t wolfssl_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf,
+					     size_t privkey_len);
 extern tls_wrapper_err_t wolfssl_use_cert(tls_wrapper_ctx_t *ctx,
 					  enclave_tls_cert_info_t *cert_info);
 extern tls_wrapper_err_t wolfssl_negotiate(tls_wrapper_ctx_t *, int fd);
@@ -33,8 +32,7 @@ static tls_wrapper_opts_t wolfssl_opts = {
 	.cleanup = wolfssl_cleanup,
 };
 
-void __attribute__((constructor))
-libtls_wrapper_wolfssl_init(void)
+void __attribute__((constructor)) libtls_wrapper_wolfssl_init(void)
 {
 	ETLS_DEBUG("called\n");
 

--- a/enclave-tls/src/tls_wrappers/wolfssl/negotiate.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/negotiate.c
@@ -12,15 +12,15 @@
 extern int verify_certificate(int preverify, WOLFSSL_X509_STORE_CTX *store);
 #endif
 
-tls_wrapper_err_t wolfssl_internal_negotiate(tls_wrapper_ctx_t *ctx,
-					     unsigned long conf_flags, int fd,
-					     int (*verify)(int, WOLFSSL_X509_STORE_CTX *))
+tls_wrapper_err_t wolfssl_internal_negotiate(tls_wrapper_ctx_t *ctx, unsigned long conf_flags,
+					     int fd, int (*verify)(int, WOLFSSL_X509_STORE_CTX *))
 {
 	int flags = WOLFSSL_VERIFY_PEER;
 	wolfssl_ctx_t *ws_ctx = ctx->tls_private;
 
-	if ((conf_flags & ENCLAVE_TLS_CONF_FLAGS_MUTUAL) && (conf_flags & ENCLAVE_TLS_CONF_FLAGS_SERVER))
-             flags |= WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+	if ((conf_flags & ENCLAVE_TLS_CONF_FLAGS_MUTUAL) &&
+	    (conf_flags & ENCLAVE_TLS_CONF_FLAGS_SERVER))
+		flags |= WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 
 	if (verify)
 		wolfSSL_CTX_set_verify(ws_ctx->ws, flags, verify);
@@ -66,7 +66,8 @@ static int ssl_ctx_set_verify_callback(int mode, WOLFSSL_X509_STORE_CTX *store)
 {
 	(void)mode;
 	int result;
-	int sgxStatus = ocall_verify_certificate(&result, store->userCtx, store->certs->buffer, store->certs->length);
+	int sgxStatus = ocall_verify_certificate(&result, store->userCtx, store->certs->buffer,
+						 store->certs->length);
 	if (sgxStatus != SGX_SUCCESS)
 		return 0;
 
@@ -84,7 +85,8 @@ tls_wrapper_err_t wolfssl_negotiate(tls_wrapper_ctx_t *ctx, int fd)
 	int (*verify)(int, WOLFSSL_X509_STORE_CTX *) = NULL;
 	unsigned long conf_flags = ctx->conf_flags;
 
-	if (!(conf_flags & ENCLAVE_TLS_CONF_FLAGS_SERVER) || (conf_flags & ENCLAVE_TLS_CONF_FLAGS_MUTUAL)) {
+	if (!(conf_flags & ENCLAVE_TLS_CONF_FLAGS_SERVER) ||
+	    (conf_flags & ENCLAVE_TLS_CONF_FLAGS_MUTUAL)) {
 #ifdef WOLFSSL_SGX_WRAPPER
 		verify = ssl_ctx_set_verify_callback;
 #else

--- a/enclave-tls/src/tls_wrappers/wolfssl/oid.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/oid.c
@@ -6,7 +6,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define OID(N) {0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x8A, 0x39, (N)}
+#define OID(N)                                                                  \
+	{                                                                       \
+		0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF8, 0x4D, 0x8A, 0x39, (N) \
+	}
 
 const uint8_t ias_response_body_oid[] = OID(0x02);
 const uint8_t ias_root_cert_oid[] = OID(0x03);

--- a/enclave-tls/src/tls_wrappers/wolfssl/receive.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/receive.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl.h"
 
-tls_wrapper_err_t wolfssl_receive(tls_wrapper_ctx_t *ctx, void *buf,
-				  size_t *buf_size)
+tls_wrapper_err_t wolfssl_receive(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {
 	ETLS_DEBUG("ctx %p, buf %p, buf_size %p\n", ctx, buf, buf_size);
 

--- a/enclave-tls/src/tls_wrappers/wolfssl/transmit.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/transmit.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl.h"
 
-tls_wrapper_err_t wolfssl_transmit(tls_wrapper_ctx_t *ctx, void *buf,
-				   size_t *buf_size)
+tls_wrapper_err_t wolfssl_transmit(tls_wrapper_ctx_t *ctx, void *buf, size_t *buf_size)
 {
 	ETLS_DEBUG("ctx %p, buf %p, buf_size %p\n", ctx, buf, buf_size);
 

--- a/enclave-tls/src/tls_wrappers/wolfssl/un_negotiate.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/un_negotiate.c
@@ -11,7 +11,8 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl.h"
 
-static const int rsa_pub_3072_raw_der_len = 398;      /* rsa_pub_3072_pcks_der_len - pcks_nr_1_header_len */
+/* rsa_pub_3072_pcks_der_len - pcks_nr_1_header_len */
+static const int rsa_pub_3072_raw_der_len = 398;
 
 #ifdef WOLFSSL_SGX_WRAPPER
 void *memmem(void *start, unsigned int s_len, void *find, unsigned int f_len)
@@ -20,24 +21,23 @@ void *memmem(void *start, unsigned int s_len, void *find, unsigned int f_len)
 	unsigned int len;
 	p = start, q = find;
 	len = 0;
-	while((p - (char *)start + f_len) <= s_len){
-		while(*p++ == *q++){
+	while ((p - (char *)start + f_len) <= s_len) {
+		while (*p++ == *q++) {
 			len++;
-			if(len == f_len)
-				return(p - f_len);
+			if (len == f_len)
+				return (p - f_len);
 		};
 		q = find;
 		len = 0;
 	};
-	return(NULL);
+	return (NULL);
 }
 #endif
 
 /**
  * @return Returns -1 if OID was not found. Otherwise, returns 1;
  */
-int find_oid(const unsigned char *ext, size_t ext_len,
-	     const unsigned char *oid, size_t oid_len,
+int find_oid(const unsigned char *ext, size_t ext_len, const unsigned char *oid, size_t oid_len,
 	     unsigned char **val, size_t *len)
 {
 	uint8_t *p = memmem((void *)ext, ext_len, (void *)oid, oid_len);
@@ -51,14 +51,14 @@ int find_oid(const unsigned char *ext, size_t ext_len,
 
 	// Some TLS libraries generate a BOOLEAN for the criticality of the extension.
 	if (p[i] == 0x01) {
-		assert(p[i++] == 0x01);	// tag, 0x01 is ASN1 Boolean
-		assert(p[i++] == 0x01);	// length
-		assert(p[i++] == 0x00);	// value (0 is non-critical, non-zero is critical)
+		assert(p[i++] == 0x01); // tag, 0x01 is ASN1 Boolean
+		assert(p[i++] == 0x01); // length
+		assert(p[i++] == 0x00); // value (0 is non-critical, non-zero is critical)
 	}
 
 	// Now comes the octet string
-	assert(p[i++] == 0x04);	// tag for octet string
-	assert(p[i++] == 0x82);	// length encoded in two bytes
+	assert(p[i++] == 0x04); // tag for octet string
+	assert(p[i++] == 0x82); // length encoded in two bytes
 	*len = p[i++] << 8;
 	*len += p[i++];
 	*val = &p[i++];
@@ -69,9 +69,8 @@ int find_oid(const unsigned char *ext, size_t ext_len,
 /**
  * @return Returns -1 if OID was not found. Otherwise, returns 1;
  */
-int extract_x509_extension(const uint8_t *ext, int ext_len,
-			   const uint8_t *oid, size_t oid_len, uint8_t *data,
-			   uint32_t *data_len, uint32_t data_max_len)
+int extract_x509_extension(const uint8_t *ext, int ext_len, const uint8_t *oid, size_t oid_len,
+			   uint8_t *data, uint32_t *data_len, uint32_t data_max_len)
 {
 	uint8_t *ext_data;
 	size_t ext_data_len;
@@ -94,57 +93,46 @@ static int extract_cert_extensions(const uint8_t *ext, int ext_len,
 				   attestation_evidence_t *evidence)
 {
 	if (!strcmp(evidence->type, "sgx_epid")) {
-		int rc = extract_x509_extension(ext, ext_len,
-						ias_response_body_oid,
-						ias_oid_len,
+		int rc = extract_x509_extension(ext, ext_len, ias_response_body_oid, ias_oid_len,
 						evidence->epid.ias_report,
 						&evidence->epid.ias_report_len,
 						sizeof(evidence->epid.ias_report));
 		if (rc != 1)
 			return rc;
 
-		rc = extract_x509_extension(ext, ext_len,
-					    ias_root_cert_oid, ias_oid_len,
+		rc = extract_x509_extension(ext, ext_len, ias_root_cert_oid, ias_oid_len,
 					    evidence->epid.ias_sign_ca_cert,
-					    &evidence->epid.
-					    ias_sign_ca_cert_len,
+					    &evidence->epid.ias_sign_ca_cert_len,
 					    sizeof(evidence->epid.ias_sign_ca_cert));
 		if (rc != 1)
 			return rc;
 
-		rc = extract_x509_extension(ext, ext_len,
-					    ias_leaf_cert_oid, ias_oid_len,
+		rc = extract_x509_extension(ext, ext_len, ias_leaf_cert_oid, ias_oid_len,
 					    evidence->epid.ias_sign_cert,
 					    &evidence->epid.ias_sign_cert_len,
 					    sizeof(evidence->epid.ias_sign_cert));
 		if (rc != 1)
 			return rc;
 
-		rc = extract_x509_extension(ext, ext_len,
-					    ias_report_signature_oid,
-					    ias_oid_len,
+		rc = extract_x509_extension(ext, ext_len, ias_report_signature_oid, ias_oid_len,
 					    evidence->epid.ias_report_signature,
-					    &evidence->epid.
-					    ias_report_signature_len,
+					    &evidence->epid.ias_report_signature_len,
 					    sizeof(evidence->epid.ias_report_signature));
 		return rc;
 	} else if (!strcmp(evidence->type, "sgx_ecdsa")) {
-		return extract_x509_extension(ext, ext_len,
-					      ecdsa_quote_oid, ias_oid_len,
+		return extract_x509_extension(ext, ext_len, ecdsa_quote_oid, ias_oid_len,
 					      evidence->ecdsa.quote, &evidence->ecdsa.quote_len,
 					      sizeof(evidence->ecdsa.quote));
 	} else if (!strcmp(evidence->type, "sgx_la")) {
-		return extract_x509_extension(ext, ext_len,
-					la_report_oid, ias_oid_len,
-					evidence->la.report, &evidence->la.report_len,
-					sizeof(evidence->la.report));
+		return extract_x509_extension(ext, ext_len, la_report_oid, ias_oid_len,
+					      evidence->la.report, &evidence->la.report_len,
+					      sizeof(evidence->la.report));
 	}
 
 	return 1;
 }
 
-crypto_wrapper_err_t sha256_rsa_pubkey(unsigned char hash[SHA256_DIGEST_SIZE],
-				       RsaKey *key)
+crypto_wrapper_err_t sha256_rsa_pubkey(unsigned char hash[SHA256_DIGEST_SIZE], RsaKey *key)
 {
 	uint8_t buf[1024];
 
@@ -162,8 +150,7 @@ crypto_wrapper_err_t sha256_rsa_pubkey(unsigned char hash[SHA256_DIGEST_SIZE],
 	return CRYPTO_WRAPPER_ERR_NONE;
 }
 
-static crypto_wrapper_err_t calc_pubkey_hash(DecodedCert *crt,
-					     enclave_tls_cert_algo_t algo,
+static crypto_wrapper_err_t calc_pubkey_hash(DecodedCert *crt, enclave_tls_cert_algo_t algo,
 					     uint8_t *hash)
 {
 	if (algo != ENCLAVE_TLS_CERT_ALGO_RSA_3072_SHA256)
@@ -173,8 +160,7 @@ static crypto_wrapper_err_t calc_pubkey_hash(DecodedCert *crt,
 	wc_InitRsaKey(&rsaKey, NULL);
 
 	unsigned int idx = 0;
-	int ret = wc_RsaPublicKeyDecode(crt->publicKey, &idx, &rsaKey,
-					crt->pubKeySize);
+	int ret = wc_RsaPublicKeyDecode(crt->publicKey, &idx, &rsaKey, crt->pubKeySize);
 	if (ret)
 		return WOLFCRYPT_ERR_CODE(ret);
 
@@ -194,7 +180,7 @@ int verify_certificate(void *ctx, uint8_t *der_cert, uint32_t der_cert_len)
 #else
 int verify_certificate(int preverify, WOLFSSL_X509_STORE_CTX *store)
 {
-	(void) preverify;
+	(void)preverify;
 
 	const uint8_t *der_cert = store->certs->buffer;
 	uint32_t der_cert_len = store->certs->length;
@@ -202,7 +188,7 @@ int verify_certificate(int preverify, WOLFSSL_X509_STORE_CTX *store)
 #endif
 
 	DecodedCert crt;
-	InitDecodedCert(&crt, (byte*)der_cert, der_cert_len, NULL);
+	InitDecodedCert(&crt, (byte *)der_cert, der_cert_len, NULL);
 
 	int ret = ParseCert(&crt, CERT_TYPE, NO_VERIFY, 0);
 	if (ret) {
@@ -225,24 +211,26 @@ int verify_certificate(int preverify, WOLFSSL_X509_STORE_CTX *store)
 	 * extension and parse it into evidence
 	 */
 	attestation_evidence_t evidence;
-	uint8_t* ext_data;
-    	size_t ext_data_len;
+	uint8_t *ext_data;
+	size_t ext_data_len;
 
-	if (find_oid(der_cert, der_cert_len, ecdsa_quote_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
+	if (find_oid(der_cert, der_cert_len, ecdsa_quote_oid, ias_oid_len, &ext_data,
+		     &ext_data_len) == 1)
 		strncpy(evidence.type, "sgx_ecdsa", sizeof(evidence.type));
-	else if (find_oid(der_cert, der_cert_len, la_report_oid, ias_oid_len, &ext_data, &ext_data_len) == 1)
+	else if (find_oid(der_cert, der_cert_len, la_report_oid, ias_oid_len, &ext_data,
+			  &ext_data_len) == 1)
 		strncpy(evidence.type, "sgx_la", sizeof(evidence.type));
 	else
 		strncpy(evidence.type, "nullquote", sizeof(evidence.type));
 
-	int rc = extract_cert_extensions(crt.extensions, crt.extensionsSz,
-					 &evidence);
+	int rc = extract_cert_extensions(crt.extensions, crt.extensionsSz, &evidence);
 	if (rc != 1) {
 		ETLS_ERR("ERROR: extract_cert_extensions %d\n", rc);
 		return 0;
 	}
 
-	tls_wrapper_err_t err = tls_wrapper_verify_certificate_extension(tls_ctx, &evidence, hash, hash_size);
+	tls_wrapper_err_t err =
+		tls_wrapper_verify_certificate_extension(tls_ctx, &evidence, hash, hash_size);
 	if (err != TLS_WRAPPER_ERR_NONE) {
 		ETLS_ERR("failed to verify certificate extension %#x\n", err);
 		return 0;

--- a/enclave-tls/src/tls_wrappers/wolfssl/use_cert.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/use_cert.c
@@ -7,8 +7,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl.h"
 
-tls_wrapper_err_t wolfssl_use_cert(tls_wrapper_ctx_t *ctx,
-				   enclave_tls_cert_info_t *cert_info)
+tls_wrapper_err_t wolfssl_use_cert(tls_wrapper_ctx_t *ctx, enclave_tls_cert_info_t *cert_info)
 {
 	ETLS_DEBUG("ctx %p, cert_info %p\n", ctx, cert_info);
 
@@ -17,10 +16,8 @@ tls_wrapper_err_t wolfssl_use_cert(tls_wrapper_ctx_t *ctx,
 
 	wolfssl_ctx_t *ws_ctx = (wolfssl_ctx_t *)ctx->tls_private;
 
-	int ret = wolfSSL_CTX_use_certificate_buffer(ws_ctx->ws,
-						     cert_info->cert_buf,
-						     cert_info->cert_len,
-						     SSL_FILETYPE_ASN1);
+	int ret = wolfSSL_CTX_use_certificate_buffer(ws_ctx->ws, cert_info->cert_buf,
+						     cert_info->cert_len, SSL_FILETYPE_ASN1);
 	if (ret != SSL_SUCCESS) {
 		ETLS_ERR("failed to use certificate %d\n", ret);
 		return WOLFSSL_ERR_CODE(ret);

--- a/enclave-tls/src/tls_wrappers/wolfssl/use_privkey.c
+++ b/enclave-tls/src/tls_wrappers/wolfssl/use_privkey.c
@@ -7,21 +7,16 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "wolfssl.h"
 
-tls_wrapper_err_t
-wolfssl_use_privkey(tls_wrapper_ctx_t *ctx,
-		    void *privkey_buf, size_t privkey_len)
+tls_wrapper_err_t wolfssl_use_privkey(tls_wrapper_ctx_t *ctx, void *privkey_buf, size_t privkey_len)
 {
-	ETLS_DEBUG("ctx %p, privkey_buf %p, privkey_len %zu\n",
-		   ctx, privkey_buf, privkey_len);
+	ETLS_DEBUG("ctx %p, privkey_buf %p, privkey_len %zu\n", ctx, privkey_buf, privkey_len);
 
 	if (!ctx || !privkey_buf || !privkey_len)
 		return -TLS_WRAPPER_ERR_INVALID;
 
 	wolfssl_ctx_t *ws_ctx = (wolfssl_ctx_t *)ctx->tls_private;
 
-	int ret = wolfSSL_CTX_use_PrivateKey_buffer(ws_ctx->ws,
-						    privkey_buf,
-						    (long)privkey_len,
+	int ret = wolfSSL_CTX_use_PrivateKey_buffer(ws_ctx->ws, privkey_buf, (long)privkey_len,
 						    SSL_FILETYPE_ASN1);
 	if (ret != SSL_SUCCESS) {
 		ETLS_ERR("failed to use private key %d\n", ret);

--- a/enclave-tls/src/util/sgxutils.c
+++ b/enclave-tls/src/util/sgxutils.c
@@ -14,16 +14,16 @@
 static inline void cpuid(int *eax, int *ebx, int *ecx, int *edx)
 {
 #if defined(__x86_64__)
-	asm volatile ("cpuid"
-		      : "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx)
-		      : "0" (*eax), "2" (*ecx)
-		      : "memory");
+	asm volatile("cpuid"
+		     : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+		     : "0"(*eax), "2"(*ecx)
+		     : "memory");
 #else
 	/* on 32bit, ebx can NOT be used as PIC code */
-	asm volatile ("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
-		      : "=a" (*eax), "=r" (*ebx), "=c" (*ecx), "=d" (*edx)
-		      : "0" (*eax), "2" (*ecx)
-		      : "memory");
+	asm volatile("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
+		     : "=a"(*eax), "=r"(*ebx), "=c"(*ecx), "=d"(*edx)
+		     : "0"(*eax), "2"(*ecx)
+		     : "memory");
 #endif
 }
 
@@ -84,9 +84,9 @@ bool is_sgx_supported_and_configured(void)
 	if (!is_sgx2_supported() && !is_sgx1_supported())
 		return false;
 
-	if (!is_dcap_oot_kernel_driver() &&
-	    !is_legacy_oot_kernel_driver() && !is_in_tree_kernel_driver())
+	if (!is_dcap_oot_kernel_driver() && !is_legacy_oot_kernel_driver() &&
+	    !is_in_tree_kernel_driver())
 		return false;
-                        
+
 	return true;
 }


### PR DESCRIPTION
Use clang-format instead of indent to format the C codes.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>