### PR TITLE
workflow: fix CI/CD failure due to the lack of -v nullquote

### DIFF
--- a/.github/workflows/pr_enclave_tls.yml
+++ b/.github/workflows/pr_enclave_tls.yml
@@ -132,8 +132,8 @@ jobs:
     - name: Test enclave tls server for mutual nullquote
       run: |
         echo random-port3 ${{ steps.random-port-generator3.outputs.random-port }}
-        docker exec $inclavare_test bash -c '${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-server -a nullquote -m -p ${{ steps.random-port-generator3.outputs.random-port }}' &
-        docker exec $inclavare_test bash -c 'sleep 10 && ${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-client -l debug -a nullquote -m -p ${{ steps.random-port-generator3.outputs.random-port }}'
+        docker exec $inclavare_test bash -c '${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-server -a nullquote -v nullquote -m -p ${{ steps.random-port-generator3.outputs.random-port }}' &
+        docker exec $inclavare_test bash -c 'sleep 10 && ${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-client -l debug -a nullquote -v nullquote -m -p ${{ steps.random-port-generator3.outputs.random-port }}'
 
     - name: Clean up the github workspace
       if: ${{ always() }}

--- a/.github/workflows/pr_shelter.yml
+++ b/.github/workflows/pr_shelter.yml
@@ -122,10 +122,10 @@ jobs:
       shell: bash
 
     - name: Run enclave tls server for null quote
-      run: docker exec $inclavare_test bash -c '${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-server -a nullquote -i 127.0.0.1 -p ${{ steps.random-port-generator1.outputs.random-port }}' &
+      run: docker exec $inclavare_test bash -c '${{ env.ENCLAVE_TLS_BINDIR }}/enclave-tls-server -a nullquote -v nullquote -i 127.0.0.1 -p ${{ steps.random-port-generator1.outputs.random-port }}' &
 
     - name: Run shelter for null quote
-      run: docker exec $inclavare_test bash -c '/usr/local/bin/shelter remoteattestation  --verifier nullquote --addr=tcp://127.0.0.1:${{ steps.random-port-generator1.outputs.random-port }}'
+      run: docker exec $inclavare_test bash -c '/usr/local/bin/shelter remoteattestation --attester nullquote --verifier nullquote --addr=tcp://127.0.0.1:${{ steps.random-port-generator1.outputs.random-port }}'
         docker restart $inclavare_test;
 
     - id: random-port-generator2


### PR DESCRIPTION
Since the attester and verifier are logically splitted, the workflow
should explicitly specify -v nullquote. Otherwise, the best choice,
e.g, sgx_ecdsa_qve, will be selected and thus failed to verify the
evidence for sure.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>