### PR TITLE
shelter/dist: fix the badly formatted trailer line warning

### DIFF
--- a/shelter/dist/deb/debian/changelog
+++ b/shelter/dist/deb/debian/changelog
@@ -2,7 +2,7 @@ shelter (0.6.1-1) unstable; urgency=low
 
   * Update to version 0.6.1.
 
- -- Yilin Li <YiLin.Li@linux.alibaba.com>  Sat, May 22 2021 15:40:00 +0000
+ -- Yilin Li <YiLin.Li@linux.alibaba.com>  Sat, 22 May 2021 15:40:00 +0000
 
 shelter (0.6.0-1) unstable; urgency=low
 


### PR DESCRIPTION
This patch fixes the dpkg-buildpackage warning:
dpkg-gencontrol: warning:     debian/changelog(l5): badly formatted trailer line
LINE:  -- Yilin Li <YiLin.Li@linux.alibaba.com>  Sat, May 22 2021 15:40:00 +0000
dpkg-gencontrol: warning:     debian/changelog(l7): found start of entry where expected more change data or trailer
LINE: shelter (0.6.0-1) unstable; urgency=low
dpkg-gencontrol: warning:     debian/changelog(l7): found end of file where expected more change data or trailer
dpkg-gencontrol: warning:     debian/changelog(l5): badly formatted trailer line
LINE:  -- Yilin Li <YiLin.Li@linux.alibaba.com>  Sat, May 22 2021 15:40:00 +0000
dpkg-gencontrol: warning:     debian/changelog(l7): found start of entry where expected more change data or trailer
LINE: shelter (0.6.0-1) unstable; urgency=low
dpkg-gencontrol: warning:     debian/changelog(l7): found end of file where expected more change data or trailer

Signed-off-by: Yilin Li <YiLin.Li@linux.alibaba.com>