### PR TITLE
rune & sgx-tools: bump the versions of deb and rpm to 0.6.1

### DIFF
--- a/rune/dist/deb/debian/changelog
+++ b/rune/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+rune (0.6.1-1) unstable; urgency=low
+
+  * Update to version 0.6.1.
+
+ -- Shirong Hao <shirong@linux.alibaba.com>  Mon, 24 May 2021 07:25:20 +0000
+
 rune (0.6.0-1) unstable; urgency=low
 
   * Update to version 0.6.0.

--- a/rune/dist/rpm/rune.spec
+++ b/rune/dist/rpm/rune.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: rune
-Version: 0.6.0
+Version: 0.6.1
 Release: %{centos_base_release}%{?dist}
 Summary: CLI tool for spawning and running enclaves in containers according to the OCI specification.
 
@@ -57,6 +57,9 @@ install -p -m 644 %{name}/LICENSE %{buildroot}%{_defaultlicensedir}/%{name}-%{ve
 %{BIN_DIR}/%{name}
 
 %changelog
+* Mon May 24 2021 Shirong Hao <shirong@linux.alibaba.com> - 0.6.1
+- Update to version 0.6.1
+
 * Sun Feb 07 2021 Shirong Hao <shirong@linux.alibaba.com> - 0.6.0
 - Update to version 0.6.0
 

--- a/sgx-tools/dist/deb/debian/changelog
+++ b/sgx-tools/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+sgx-tools (0.6.1-1) unstable; urgency=low
+
+  * Update to version 0.6.1.
+
+ -- Shirong Hao <shirong@linux.alibaba.com>  Mon, 24 May 2021 07:25:20 +0000
+
 sgx-tools (0.6.0-1) unstable; urgency=low
 
   * Update to version 0.6.0.

--- a/sgx-tools/dist/rpm/sgx-tools.spec
+++ b/sgx-tools/dist/rpm/sgx-tools.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: sgx-tools
-Version: 0.6.0
+Version: 0.6.1
 Release: %{centos_base_release}%{?dist}
 Summary: sgx-tools is a commandline tool, used to interact Intel SGX aesm service.
 
@@ -52,6 +52,9 @@ install -p -m 755 %{name}/%{name} %{buildroot}%{BIN_DIR}
 %{BIN_DIR}/%{name}
 
 %changelog
+* Mon May 24 2021 Shirong Hao <shirong@linux.alibaba.com> - 0.6.1
+- Update to version 0.6.1
+
 * Sun Feb 07 2021 Shirong Hao <shirong@linux.alibaba.com> - 0.6.0
 - Update to version 0.6.0
 


### PR DESCRIPTION
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>