### PR TITLE
CI/CD: stop dnf-makecache.timer service when install centos dependency

### DIFF
--- a/.github/workflows/pr_epm.yml
+++ b/.github/workflows/pr_epm.yml
@@ -138,9 +138,14 @@ jobs:
         cd /root/inclavare-containers/${{ matrix.tag }};
         dpkg -i *.deb'
 
+    # dnf-makecache.timer service is running by default which periodically runs dnf makecache --timer with
+    # deleting the lock file in /var/cache/dnf/, and if we do the yum install command at the same time,
+    # system will not found lock file in /var/cache/dnf/. Stop dnf-makecache.timer srvice can solve this problem.
+    # In addition, systemd process needs time to start.
     - name: Install centos dependency
       if: ${{ contains(matrix.tag, 'centos') }}
-      run: docker exec $inclavare_test bash -c 'cd /root/inclavare-containers/${{ matrix.tag }};
+      run: docker exec $inclavare_test bash -c 'sleep 20 && systemctl stop dnf-makecache.timer;
+        cd /root/inclavare-containers/${{ matrix.tag }};
         yum -y install yum-utils wget iptables protobuf-c;
         wget  -c https://download.01.org/intel-sgx/latest/linux-latest/distro/centos8.2-server/sgx_rpm_local_repo.tgz;
         tar xzf sgx_rpm_local_repo.tgz;


### PR DESCRIPTION
This patch fix the error:
[Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'

We have systemd dnf-makecache.timer running (its set up by default) which periodically
runs `dnf makecache --timer`, and if we do our command `yum install -y wget` at the same
time while the makecache is running with deleting the lock file in /var/cache/dnf/,
both transactions run at the same time and everything breaks. This is the reason why
the very irregular occurrence since we have to hit the exact time the timer starts makecache.

Please see https://bugzilla.redhat.com/show_bug.cgi?id=1814337 for more information.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>
Signed-off-by: Liang Yang <liang3.yang@intel.com>