### PR TITLE
rune: fix the process name encoding error

### DIFF
--- a/rune/libenclave/init_linux.go
+++ b/rune/libenclave/init_linux.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containerd/console"
 	enclaveConfigs "github.com/inclavare-containers/rune/libenclave/configs"
 	"github.com/inclavare-containers/rune/libenclave/intelsgx/preload"
-	"github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
+	enclave_runtime_pal "github.com/inclavare-containers/rune/libenclave/internal/runtime/pal"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"

--- a/rune/libenclave/init_linux.go
+++ b/rune/libenclave/init_linux.go
@@ -102,8 +102,11 @@ func newContainerInit(t initType, pipe *os.File, consoleSocket *os.File, fifoFd 
 		case initSetns:
 			name = "runelet"
 		}
+
+		b := make([]byte, len(name)+1)
+		copy(b, name)
 		/* For debugging. */
-		unix.Prctl(unix.PR_SET_NAME, uintptr(unsafe.Pointer(&name)), 0, 0, 0)
+		unix.Prctl(unix.PR_SET_NAME, uintptr(unsafe.Pointer(&b[0])), 0, 0, 0)
 	}
 
 	switch t {


### PR DESCRIPTION
fix the init-runelet process name encoding error

before:
`2478530 root      20   0 1326600  12160    344 R 100.0   0.2   4:19.17 �= �U   `
after:
```
~/enclave/inclavare-containers ‹master*› » cat /proc/2481318/status 
Name:	init-runelet
Umask:	0022
State:	R (running)
Tgid:	2481318
Ngid:	0
Pid:	2481318
PPid:	2481294
```


Signed-off-by: LiFeng <lifeng68@huawei.com>