### PR TITLE
enclave-tls: extract oid definition into a global header file

### DIFF
--- a/enclave-tls/src/include/enclave-tls/oid.h
+++ b/enclave-tls/src/include/enclave-tls/oid.h
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021 Intel Corporation
+ * Copyright (c) 2020-2021 Alibaba Cloud
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef _OID_H
+#define _OID_H
+
+#define ias_response_body_oid           "1.2.840.113741.1337.2"
+#define ias_root_cert_oid               "1.2.840.113741.1337.3"
+#define ias_leaf_cert_oid               "1.2.840.113741.1337.4"
+#define ias_report_signature_oid        "1.2.840.113741.1337.5"
+#define ecdsa_quote_oid                 "1.2.840.113741.1337.6"
+#define la_report_oid                   "1.2.840.113741.1337.14"
+
+#endif

--- a/enclave-tls/src/tls_wrappers/openssl/openssl.h
+++ b/enclave-tls/src/tls_wrappers/openssl/openssl.h
@@ -27,13 +27,6 @@ typedef struct {
 	SSL *ssl;
 } openssl_ctx_t;
 
-#define ias_response_body_oid	 "1.2.840.113741.1337.2"
-#define ias_root_cert_oid	 "1.2.840.113741.1337.3"
-#define ias_leaf_cert_oid	 "1.2.840.113741.1337.4"
-#define ias_report_signature_oid "1.2.840.113741.1337.5"
-#define ecdsa_quote_oid		 "1.2.840.113741.1337.6"
-#define la_report_oid		 "1.2.840.113741.1337.14"
-
 static inline void print_openssl_err(SSL *ssl, int ret)
 {
 	char buf[128];

--- a/enclave-tls/src/tls_wrappers/openssl/un_negotiate.c
+++ b/enclave-tls/src/tls_wrappers/openssl/un_negotiate.c
@@ -10,6 +10,7 @@
 #include <enclave-tls/log.h>
 #include <enclave-tls/err.h>
 #include <enclave-tls/tls_wrapper.h>
+#include <enclave-tls/oid.h>
 #include "per_thread.h"
 #include "openssl.h"
 


### PR DESCRIPTION
Fixes: #1115
Signed-off-by: Liang Yang <liang3.yang@intel.com>