### PR TITLE
shelter/dist: fix make package error in ubuntu

### DIFF
--- a/shelter/dist/deb/debian/rules
+++ b/shelter/dist/deb/debian/rules
@@ -8,6 +8,9 @@ export GO111MODULE := on
 %:
 	dh $@
 
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
 override_dh_auto_clean:
 
 override_dh_auto_build:


### PR DESCRIPTION
This patch is to fix the dpkg-shlibdep error: no dependency
information found for /opt/enclave-tls/lib/libenclave_tls.so.0
(used by debian/shelter/usr/local/bin/shelter).

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>