### PR TITLE
verdictd: add key manager module

### DIFF
--- a/verdictd/app/src/key_manager/directory_key_manager.rs
+++ b/verdictd/app/src/key_manager/directory_key_manager.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::io;
+
+const VERDICTD_KEY_PATH: &str = "/opt/verdictd/keys/";
+
+pub fn get_key(kid: &String) -> Result<Vec<u8>, io::Error> {
+    let path = VERDICTD_KEY_PATH.to_string() + kid;
+    println!("get key from keyFile: {}", path); 
+
+    let data = fs::read(path);
+    match data {
+        Ok(key) => Ok(key),
+        Err(e) => {
+            println!("Get kid:{}'s key failed, err: {}", kid, e.to_string());
+            Err(e)
+        }
+    }
+}
+
+pub fn set_key(kid: &String, key: &[u8]) -> std::io::Result<()> {
+    let path = VERDICTD_KEY_PATH.to_string() + kid;
+    println!("set key for keyFile: {}", path);
+
+    fs::write(path, key).expect("Unable to write file");
+    Ok(())
+}

--- a/verdictd/app/src/key_manager/mod.rs
+++ b/verdictd/app/src/key_manager/mod.rs
@@ -1,0 +1,1 @@
+pub mod directory_key_manager;

--- a/verdictd/app/src/main.rs
+++ b/verdictd/app/src/main.rs
@@ -9,6 +9,7 @@ use serde::{Serialize, Deserialize};
 use serde_json::json;
 use serde_json::Value;
 
+mod key_manager;
 mod enclave_tls;
 
 fn parse_aa_request_and_generate_response(request: &[u8]) -> Result<String, String> {


### PR DESCRIPTION
Signed-off-by: Zhou Liang <liang.a.zhou@linux.alibaba.com>
This simple key manager module will get key from /opt/verdictd/keys/ path according to input kid.