### PR TITLE
rats-tls: sovle compilation error under openssl1.0.x env

### DIFF
--- a/rats-tls/src/crypto_wrappers/openssl/openssl.h
+++ b/rats-tls/src/crypto_wrappers/openssl/openssl.h
@@ -12,7 +12,6 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/asn1.h>
-#include <openssl/store.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>


### PR DESCRIPTION
under openssl1.0.x, there is no store.h, so it will generate
compilation error as below:
fatal error: openssl/store.h: No such file or directory

Fixes: #1290
Signed-off-by: Liang Yang <liang3.yang@intel.com>