### PR TITLE
inclavared: bump the versions of deb and rpm to 0.6.3

### DIFF
--- a/inclavared/dist/deb/debian/changelog
+++ b/inclavared/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+inclavared (0.6.3-1) unstable; urgency=low
+
+  * Update to version 0.6.3.
+
+ -- Zhou Liang <liang.a.zhou@linux.alibaba.com>  Fri, 27 Aug 2021 14:04:00 +0000
+
 inclavared (0.6.2-1) unstable; urgency=low
 
   * Update to version 0.6.2.

--- a/inclavared/dist/rpm/inclavared.spec
+++ b/inclavared/dist/rpm/inclavared.spec
@@ -5,7 +5,7 @@
 %global BIN_DIR /usr/local/bin
 
 Name: inclavared
-Version: 0.6.2
+Version: 0.6.3
 Release: %{centos_base_release}%{?dist}
 Summary: inclavared is a coordinator which creates a m-TLS(Mutal Transport Layer Security) connection between stub enclave and other enclaves with remote attestation.
 
@@ -45,6 +45,9 @@ install -p -m 755 %{name}/bin/%{name} %{buildroot}%{BIN_DIR}
 %{BIN_DIR}/%{name}
 
 %changelog
+* Fri Aug 27 2021 Zhou Liang <liang.a.zhou@linux.alibaba.com> - 0.6.3
+- Update to version 0.6.3
+
 * Wed Jun 30 2021 Zhou Liang <liang.a.zhou@linux.alibaba.com> - 0.6.2
 - Update to version 0.6.2
 


### PR DESCRIPTION
Signed-off-by: Zhou Liang <liang.a.zhou@linux.alibaba.com>

Tried and can make package successfully both on ubuntu and CentOS successfully.