### PR TITLE
rats-tls: only install enclave-tls sdk files to /opt/enclave-tls

### DIFF
--- a/rats-tls/cmake/CMakeUninstall.cmake.in
+++ b/rats-tls/cmake/CMakeUninstall.cmake.in
@@ -20,12 +20,23 @@ foreach(file ${files})
     endif()
 endforeach()
 
-if(EXISTS "@ENCLAVE_TLS_INSTALL_PATH@")
-        exec_program("rm" ARGS "-rf  @ENCLAVE_TLS_INSTALL_PATH@"
+if(EXISTS "@ENCLAVE_TLS_INSTALL_LIB_PATH@")
+        exec_program("rm" ARGS "-rf  @ENCLAVE_TLS_INSTALL_LIB_PATH@"
                 OUTPUT_VARIABLE rm_out
                 RETURN_VALUE rm_retval
                 )
                 if(NOT "${rm_retval}" STREQUAL 0)
-                        message(FATAL_ERROR "Problem when removing @ENCLAVE_TLS_INSTALL_PATH@")
+                        message(FATAL_ERROR "Problem when removing @ENCLAVE_TLS_INSTALL_LIB_PATH@")
                 endif()
 endif()
+
+if(EXISTS "@ENCLAVE_TLS_INSTALL_INCLUDE_PATH@")
+        exec_program("rm" ARGS "-rf  @ENCLAVE_TLS_INSTALL_INCLUDE_PATH@"
+                OUTPUT_VARIABLE rm_out
+                RETURN_VALUE rm_retval
+                )
+                if(NOT "${rm_retval}" STREQUAL 0)
+                        message(FATAL_ERROR "Problem when removing @ENCLAVE_TLS_INSTALL_INCLUDE_PATH@")
+                endif()
+endif()
+

--- a/rats-tls/cmake/CustomInstallDirs.cmake
+++ b/rats-tls/cmake/CustomInstallDirs.cmake
@@ -1,23 +1,23 @@
-# enclave_tls
-set(ENCLAVE_TLS_INSTALL_PATH "/opt/enclave-tls")
+# /usr/local
+set(ENCLAVE_TLS_INSTALL_PATH "/usr/local")
 
-# encalve_tls/lib
-set(ENCLAVE_TLS_INSTALL_LIB_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib")
+# lib/enclave_tls
+set(ENCLAVE_TLS_INSTALL_LIB_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib/enclave-tls")
 
-# enclave_tls/lib/crypto-wrappers
-set(ENCLAVE_TLS_INSTALL_LIBCW_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib/crypto-wrappers")
+# enclave_tls/crypto-wrappers
+set(ENCLAVE_TLS_INSTALL_LIBCW_PATH "${ENCLAVE_TLS_INSTALL_LIB_PATH}/crypto-wrappers")
 
-# enclave_tls/lib/attesters
-set(ENCLAVE_TLS_INSTALL_LIBA_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib/attesters")
+# enclave_tls/attesters
+set(ENCLAVE_TLS_INSTALL_LIBA_PATH "${ENCLAVE_TLS_INSTALL_LIB_PATH}/attesters")
 
-# enclave_tls/lib/verifiers
-set(ENCLAVE_TLS_INSTALL_LIBV_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib/verifiers")
+# enclave_tls/verifiers
+set(ENCLAVE_TLS_INSTALL_LIBV_PATH "${ENCLAVE_TLS_INSTALL_LIB_PATH}/verifiers")
 
-# enclave_tls/lib/tls-wrappers
-set(ENCLAVE_TLS_INSTALL_LIBTW_PATH "${ENCLAVE_TLS_INSTALL_PATH}/lib/tls-wrappers")
+# enclave_tls/tls-wrappers
+set(ENCLAVE_TLS_INSTALL_LIBTW_PATH "${ENCLAVE_TLS_INSTALL_LIB_PATH}/tls-wrappers")
 
-# enclave_tls/include
-set(ENCLAVE_TLS_INSTALL_INCLUDE_PATH "${ENCLAVE_TLS_INSTALL_PATH}/include")
+# include/enclave_tls
+set(ENCLAVE_TLS_INSTALL_INCLUDE_PATH "${ENCLAVE_TLS_INSTALL_PATH}/include/enclave-tls")
 
 # enclave_tls/sample
 set(ENCLAVE_TLS_INSTALL_BIN_PATH "/usr/share/enclave-tls/samples")

--- a/rats-tls/src/include/internal/attester.h
+++ b/rats-tls/src/include/internal/attester.h
@@ -10,7 +10,7 @@
 #include <enclave-tls/attester.h>
 #include "internal/core.h"
 
-#define ENCLAVE_ATTESTERS_DIR "/opt/enclave-tls/lib/attesters/"
+#define ENCLAVE_ATTESTERS_DIR "/usr/local/lib/enclave-tls/attesters/"
 
 extern enclave_tls_err_t etls_enclave_attester_load_all(void);
 extern enclave_tls_err_t etls_enclave_attester_load_single(const char *);

--- a/rats-tls/src/include/internal/crypto_wrapper.h
+++ b/rats-tls/src/include/internal/crypto_wrapper.h
@@ -10,7 +10,7 @@
 #include <enclave-tls/crypto_wrapper.h>
 #include "internal/core.h"
 
-#define CRYPTO_WRAPPERS_DIR "/opt/enclave-tls/lib/crypto-wrappers/"
+#define CRYPTO_WRAPPERS_DIR "/usr/local/lib/enclave-tls/crypto-wrappers/"
 
 extern enclave_tls_err_t etls_crypto_wrapper_load_all(void);
 extern enclave_tls_err_t etls_crypto_wrapper_load_single(const char *);

--- a/rats-tls/src/include/internal/tls_wrapper.h
+++ b/rats-tls/src/include/internal/tls_wrapper.h
@@ -10,7 +10,7 @@
 #include <enclave-tls/tls_wrapper.h>
 #include "internal/core.h"
 
-#define TLS_WRAPPERS_DIR "/opt/enclave-tls/lib/tls-wrappers/"
+#define TLS_WRAPPERS_DIR "/usr/local/lib/enclave-tls/tls-wrappers/"
 
 extern enclave_tls_err_t etls_tls_wrapper_load_all(void);
 extern enclave_tls_err_t etls_tls_wrapper_load_single(const char *);

--- a/rats-tls/src/include/internal/verifier.h
+++ b/rats-tls/src/include/internal/verifier.h
@@ -10,7 +10,7 @@
 #include <enclave-tls/verifier.h>
 #include "internal/core.h"
 
-#define ENCLAVE_VERIFIERS_DIR "/opt/enclave-tls/lib/verifiers/"
+#define ENCLAVE_VERIFIERS_DIR "/usr/local/lib/enclave-tls/verifiers/"
 
 extern enclave_tls_err_t etls_enclave_verifier_load_all(void);
 extern enclave_tls_err_t etls_enclave_verifier_load_single(const char *);


### PR DESCRIPTION
Fixes: #958 #911 