### PR TITLE
epm & enclave-tls: bump the versions of deb and rpm to 0.6.3

### DIFF
--- a/enclave-tls/dist/deb/debian/changelog
+++ b/enclave-tls/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+enclave-tls (0.6.3-1) unstable; urgency=low
+
+  * update to version 0.6.3.
+
+ -- Liang Yang <liang3.yang@intel.com>  Mon, 30 Aug 2021 17:05:55 +0000
+
 enclave-tls (0.6.2-1) unstable; urgency=low
 
   * update to version 0.6.2.

--- a/enclave-tls/dist/rpm/enclave_tls.spec
+++ b/enclave-tls/dist/rpm/enclave_tls.spec
@@ -23,7 +23,7 @@
 %global ENCLAVE_TLS_INCDIR /opt/enclave-tls/include
 
 Name: enclave-tls
-Version: 0.6.2
+Version: 0.6.3
 Release: %{centos_base_release}%{?dist}
 Summary: enclave-tls is a protocol to establish secure and trusted channel by integrating enclave attestation with transport layer security.
 
@@ -84,6 +84,9 @@ rm -rf %{ENCLAVE_TLS_ROOTDIR} $(dirname %{ENCLAVE_TLS_BINDIR})
 %{ENCLAVE_TLS_LIBDIR}/verifiers/libverifier*.so*
 
 %changelog
+* Mon Aug 30 2021 Liang Yang <liang3.yang@intel.com> - 0.6.3
+- Update to version 0.6.3.
+
 * Wed Jun 30 2021 Liang Yang <liang3.yang@intel.com> - 0.6.2
 - Update to version 0.6.2.
 

--- a/epm/dist/deb/debian/changelog
+++ b/epm/dist/deb/debian/changelog
@@ -1,3 +1,9 @@
+epm (0.6.3-1) unstable; urgency=low
+
+  * Update to version 0.6.3.
+
+ -- Liang Yang <liang3.yang@intel.com>  Mon, 30 Aug 2021 17:02:00 +0000
+
 epm (0.6.2-1) unstable; urgency=low
 
   * Update to version 0.6.2.

--- a/epm/dist/rpm/epm.spec
+++ b/epm/dist/rpm/epm.spec
@@ -8,7 +8,7 @@
 %undefine _missing_build_ids_terminate_build
 
 Name: epm
-Version: 0.6.2
+Version: 0.6.3
 Release: %{centos_base_release}%{?dist}
 Summary: epm for Inclavare Containers(runE)
 Group: Development/Tools
@@ -99,6 +99,9 @@ systemctl stop epm
 %{EPM_BIN_DIR}/epm
 
 %changelog
+* Mon Aug 30 2021 Liang Yang <liang3.yang@intel.com> - 0.6.3
+- Update to version 0.6.3
+
 * Wed Jun 30 2021 Liang Yang <liang3.yang@intel.com> - 0.6.2
 - Update to version 0.6.2
 


### PR DESCRIPTION
Signed-off-by: Liang Yang <liang3.yang@intel.com>