### PR TITLE
rats-tls: set DT_LNK value to avoid compiling error under SGX mode

### DIFF
--- a/rats-tls/src/attesters/internal/etls_enclave_attester_load_all.c
+++ b/rats-tls/src/attesters/internal/etls_enclave_attester_load_all.c
@@ -18,6 +18,7 @@
 #include <sgx_error.h>
 #include "etls_t.h"
 #define DT_REG 8
+#define DT_LNK 10
 #endif
 // clang-format on
 

--- a/rats-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_all.c
+++ b/rats-tls/src/crypto_wrappers/internal/etls_crypto_wrapper_load_all.c
@@ -19,6 +19,7 @@
 #include <sgx_error.h>
 #include "etls_t.h"
 #define DT_REG 8
+#define DT_LNK 10
 #endif
 // clang-format on
 

--- a/rats-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_all.c
+++ b/rats-tls/src/tls_wrappers/internal/etls_tls_wrapper_load_all.c
@@ -19,6 +19,7 @@
 #include <sgx_error.h>
 #include "etls_t.h"
 #define DT_REG 8
+#define DT_LNK 10
 #endif
 // clang-format on
 

--- a/rats-tls/src/verifiers/internal/etls_enclave_verifier_load_all.c
+++ b/rats-tls/src/verifiers/internal/etls_enclave_verifier_load_all.c
@@ -18,6 +18,7 @@
 #include <sgx_error.h>
 #include "etls_t.h"
 #define DT_REG 8
+#define DT_LNK 10
 #endif
 // clang-format on
 


### PR DESCRIPTION
Fixes: #1356
Signed-off-by: Liang Yang <liang3.yang@intel.com>