### PR TITLE
CONTRIBUTING.md: add the step to install clang-format for CentOS8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,14 @@ For Ubuntu:
 sudo apt-get install -y clang-format-9
 ```
 
-For CentOS:
+For CentOS 7:
 ```shell
 sudo yum install -y clang
+```
+
+For CentOS 8:
+```shell
+sudo yum install -y git-clang-format
 ```
 
 2. Format C code style using the following command:


### PR DESCRIPTION
Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>