### PR TITLE
hack: add three patchs to support SEV(-ES) attestation

### DIFF
--- a/hack/sev-attestation/0001-KVM-X86-Introduce-KVM_HC_VM_HANDLE-hypercall.patch
+++ b/hack/sev-attestation/0001-KVM-X86-Introduce-KVM_HC_VM_HANDLE-hypercall.patch
@@ -1,0 +1,96 @@
+From 018d981e973bb58690e4426fbd1f684bd9a9f763 Mon Sep 17 00:00:00 2001
+From: Shirong Hao <shirong@linux.alibaba.com>
+Date: Thu, 23 Dec 2021 14:37:49 +0800
+Subject: [PATCH 1/3] KVM: X86: Introduce KVM_HC_VM_HANDLE hypercall
+
+This hypercall is used by the SEV guest get the firmware handle.
+
+Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>
+---
+ arch/x86/include/asm/kvm_host.h |  1 +
+ arch/x86/kvm/svm/svm.c          | 11 +++++++++++
+ arch/x86/kvm/x86.c              |  7 ++++++-
+ include/uapi/linux/kvm_para.h   |  1 +
+ 4 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
+index 2164b9f4c7b0..fe745f4e6954 100644
+--- a/arch/x86/include/asm/kvm_host.h
++++ b/arch/x86/include/asm/kvm_host.h
+@@ -1493,6 +1493,7 @@ struct kvm_x86_ops {
+ 	int (*complete_emulated_msr)(struct kvm_vcpu *vcpu, int err);
+ 
+ 	void (*vcpu_deliver_sipi_vector)(struct kvm_vcpu *vcpu, u8 vector);
++	int (*vm_handle)(struct kvm *kvm);
+ };
+ 
+ struct kvm_x86_nested_ops {
+diff --git a/arch/x86/kvm/svm/svm.c b/arch/x86/kvm/svm/svm.c
+index d0f68d11ec70..c0eb310cb4c3 100644
+--- a/arch/x86/kvm/svm/svm.c
++++ b/arch/x86/kvm/svm/svm.c
+@@ -4576,6 +4576,16 @@ static int svm_vm_init(struct kvm *kvm)
+ 	return 0;
+ }
+ 
++static int sev_vm_handle(struct kvm *kvm)
++{
++	struct kvm_sev_info *sev = &to_kvm_svm(kvm)->sev_info;
++
++	if (!sev_guest(kvm))
++		return -ENOTTY;
++
++	return sev->handle;
++}
++
+ static struct kvm_x86_ops svm_x86_ops __initdata = {
+ 	.name = "kvm_amd",
+ 
+@@ -4705,6 +4715,7 @@ static struct kvm_x86_ops svm_x86_ops __initdata = {
+ 	.complete_emulated_msr = svm_complete_emulated_msr,
+ 
+ 	.vcpu_deliver_sipi_vector = svm_vcpu_deliver_sipi_vector,
++	.vm_handle = sev_vm_handle,
+ };
+ 
+ static struct kvm_x86_init_ops svm_init_ops __initdata = {
+diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
+index 0cf1082455df..24acf0f2a539 100644
+--- a/arch/x86/kvm/x86.c
++++ b/arch/x86/kvm/x86.c
+@@ -8906,7 +8906,7 @@ int kvm_emulate_hypercall(struct kvm_vcpu *vcpu)
+ 		a3 &= 0xFFFFFFFF;
+ 	}
+ 
+-	if (static_call(kvm_x86_get_cpl)(vcpu) != 0) {
++	if (static_call(kvm_x86_get_cpl)(vcpu) != 0 && nr != KVM_HC_VM_HANDLE) {
+ 		ret = -KVM_EPERM;
+ 		goto out;
+ 	}
+@@ -8965,6 +8965,11 @@ int kvm_emulate_hypercall(struct kvm_vcpu *vcpu)
+ 		vcpu->arch.complete_userspace_io = complete_hypercall_exit;
+ 		return 0;
+ 	}
++	case KVM_HC_VM_HANDLE:
++		ret = -KVM_ENOSYS;
++		if (kvm_x86_ops.vm_handle)
++			ret = kvm_x86_ops.vm_handle(vcpu->kvm);
++		break;
+ 	default:
+ 		ret = -KVM_ENOSYS;
+ 		break;
+diff --git a/include/uapi/linux/kvm_para.h b/include/uapi/linux/kvm_para.h
+index 960c7e93d1a9..b64469a12707 100644
+--- a/include/uapi/linux/kvm_para.h
++++ b/include/uapi/linux/kvm_para.h
+@@ -30,6 +30,7 @@
+ #define KVM_HC_SEND_IPI		10
+ #define KVM_HC_SCHED_YIELD		11
+ #define KVM_HC_MAP_GPA_RANGE		12
++#define KVM_HC_VM_HANDLE		13
+ 
+ /*
+  * hypercalls use architecture specific
+-- 
+2.27.0
+

--- a/hack/sev-attestation/0002-KVM-SVM-move-the-implementation-of-sev_get_attestati.patch
+++ b/hack/sev-attestation/0002-KVM-SVM-move-the-implementation-of-sev_get_attestati.patch
@@ -1,0 +1,196 @@
+From fbba85fc4d478ff120a76971982aaa6a823dae0f Mon Sep 17 00:00:00 2001
+From: Shirong Hao <shirong@linux.alibaba.com>
+Date: Mon, 8 Nov 2021 17:04:48 +0800
+Subject: [PATCH 2/3] KVM/SVM: move the implementation of
+ sev_get_attestation_report to ccp driver
+
+The sev_get_attestation_report is called by qemu-kvm to get sev attestation report.
+However, getting the sev remote attestation report is a general function, there are
+needs for the host program to get the sev attestation report by interacting with
+/dev/sev device.
+
+Considering these needs, it is more reasonable to move the main implementation
+of sev_get_attestation_report into sev_do_get_report defined in the ccp driver.
+Any host program getting the guest firmware handle can directly interact with
+the sev device based on sev_do_get_report to get the sev attestation report.
+
+In addition, by moving the general code of sev_get_attestation_report to the ccp,
+move the check for sev fd in __sev_issue_cmd to the sev_get_attestation_report
+function is necessary.
+
+Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>
+---
+ arch/x86/kvm/svm/sev.c       | 49 ++++----------------------------
+ drivers/crypto/ccp/sev-dev.c | 55 ++++++++++++++++++++++++++++++++++++
+ include/linux/psp-sev.h      |  5 ++++
+ 3 files changed, 66 insertions(+), 43 deletions(-)
+
+diff --git a/arch/x86/kvm/svm/sev.c b/arch/x86/kvm/svm/sev.c
+index 7656a2c5662a..016acc96c5dc 100644
+--- a/arch/x86/kvm/svm/sev.c
++++ b/arch/x86/kvm/svm/sev.c
+@@ -1066,10 +1066,8 @@ static int sev_get_attestation_report(struct kvm *kvm, struct kvm_sev_cmd *argp)
+ {
+ 	void __user *report = (void __user *)(uintptr_t)argp->data;
+ 	struct kvm_sev_info *sev = &to_kvm_svm(kvm)->sev_info;
+-	struct sev_data_attestation_report data;
+ 	struct kvm_sev_attestation_report params;
+-	void __user *p;
+-	void *blob = NULL;
++	struct fd f;
+ 	int ret;
+ 
+ 	if (!sev_guest(kvm))
+@@ -1078,48 +1076,13 @@ static int sev_get_attestation_report(struct kvm *kvm, struct kvm_sev_cmd *argp)
+ 	if (copy_from_user(&params, (void __user *)(uintptr_t)argp->data, sizeof(params)))
+ 		return -EFAULT;
+ 
+-	memset(&data, 0, sizeof(data));
+-
+-	/* User wants to query the blob length */
+-	if (!params.len)
+-		goto cmd;
+-
+-	p = (void __user *)(uintptr_t)params.uaddr;
+-	if (p) {
+-		if (params.len > SEV_FW_BLOB_MAX_SIZE)
+-			return -EINVAL;
+-
+-		blob = kmalloc(params.len, GFP_KERNEL_ACCOUNT);
+-		if (!blob)
+-			return -ENOMEM;
+-
+-		data.address = __psp_pa(blob);
+-		data.len = params.len;
+-		memcpy(data.mnonce, params.mnonce, sizeof(params.mnonce));
+-	}
+-cmd:
+-	data.handle = sev->handle;
+-	ret = sev_issue_cmd(kvm, SEV_CMD_ATTESTATION_REPORT, &data, &argp->error);
+-	/*
+-	 * If we query the session length, FW responded with expected data.
+-	 */
+-	if (!params.len)
+-		goto done;
+-
+-	if (ret)
+-		goto e_free_blob;
++	f = fdget(sev->fd);
++	if (!f.file)
++		return -EBADF;
+ 
+-	if (blob) {
+-		if (copy_to_user(p, blob, params.len))
+-			ret = -EFAULT;
+-	}
++	ret = sev_do_get_report(report, &params, f.file, sev->handle, &argp->error);
+ 
+-done:
+-	params.len = data.len;
+-	if (copy_to_user(report, &params, sizeof(params)))
+-		ret = -EFAULT;
+-e_free_blob:
+-	kfree(blob);
++	fdput(f);
+ 	return ret;
+ }
+ 
+diff --git a/drivers/crypto/ccp/sev-dev.c b/drivers/crypto/ccp/sev-dev.c
+index e09925d86bf3..2ed8df322f6b 100644
+--- a/drivers/crypto/ccp/sev-dev.c
++++ b/drivers/crypto/ccp/sev-dev.c
+@@ -22,6 +22,7 @@
+ #include <linux/firmware.h>
+ #include <linux/gfp.h>
+ #include <linux/cpufeature.h>
++#include <linux/kvm.h>
+ 
+ #include <asm/smp.h>
+ 
+@@ -384,6 +385,60 @@ static int sev_ioctl_do_platform_status(struct sev_issue_cmd *argp)
+ 	return ret;
+ }
+ 
++int sev_do_get_report(void __user *report, struct kvm_sev_attestation_report *input, struct file *filep, u32 handle, u32 *error)
++{
++	struct sev_data_attestation_report data;
++	void __user *p;
++	void *blob = NULL;
++	int ret;
++
++	memset(&data, 0, sizeof(data));
++
++	/* User wants to query the blob length */
++	if (!input->len)
++		goto cmd;
++
++	p = (void __user *)(uintptr_t)input->uaddr;
++	if (p) {
++		if (input->len > SEV_FW_BLOB_MAX_SIZE)
++		return -EINVAL;
++
++		blob = kmalloc(input->len, GFP_KERNEL_ACCOUNT);
++		if (!blob)
++			return -ENOMEM;
++
++		data.address = __psp_pa(blob);
++		data.len = input->len;
++		memcpy(data.mnonce, input->mnonce, sizeof(input->mnonce));
++	}
++cmd:
++	data.handle = handle;
++	ret = sev_issue_cmd_external_user(filep, SEV_CMD_ATTESTATION_REPORT, &data, error);
++
++	/*
++	 * If we query the session length, FW responded with expected data.
++	 */
++	if (!input->len)
++		goto done;
++
++	if (ret)
++		goto e_free_blob;
++
++	if (blob) {
++		if (copy_to_user(p, blob, input->len))
++		ret = -EFAULT;
++	}
++
++done:
++	input->len = data.len;
++	if (copy_to_user(report, input, sizeof(*input)))
++		ret = -EFAULT;
++e_free_blob:
++	kfree(blob);
++	return ret;
++}
++EXPORT_SYMBOL_GPL(sev_do_get_report);
++
+ static int sev_ioctl_do_pek_pdh_gen(int cmd, struct sev_issue_cmd *argp, bool writable)
+ {
+ 	struct sev_device *sev = psp_master->sev_data;
+diff --git a/include/linux/psp-sev.h b/include/linux/psp-sev.h
+index d48a7192e881..f003fbdfd0b2 100644
+--- a/include/linux/psp-sev.h
++++ b/include/linux/psp-sev.h
+@@ -541,6 +541,8 @@ int sev_platform_init(int *error);
+  */
+ int sev_platform_status(struct sev_user_data_status *status, int *error);
+ 
++int sev_do_get_report(void __user *report, struct kvm_sev_attestation_report *input, struct file *filep, u32 handle, u32 *error);
++
+ /**
+  * sev_issue_cmd_external_user - issue SEV command by other driver with a file
+  * handle.
+@@ -649,6 +651,9 @@ sev_issue_cmd_external_user(struct file *filep, unsigned int id, void *data, int
+ 
+ static inline void *psp_copy_user_blob(u64 __user uaddr, u32 len) { return ERR_PTR(-EINVAL); }
+ 
++static inline int
++sev_do_get_report(void __user *report, struct kvm_sev_attestation_report *input, struct file *filep, u32 handle, u32 *error) { return -ENODEV; }
++
+ #endif	/* CONFIG_CRYPTO_DEV_SP_PSP */
+ 
+ #endif	/* __PSP_SEV_H__ */
+-- 
+2.27.0
+

--- a/hack/sev-attestation/0003-crypto-ccp-Implement-SEV_GET_REPORT-ioctl-command.patch
+++ b/hack/sev-attestation/0003-crypto-ccp-Implement-SEV_GET_REPORT-ioctl-command.patch
@@ -1,0 +1,97 @@
+From 9bfff04ea80f77e355f4f67af28f46ae5d2a03e5 Mon Sep 17 00:00:00 2001
+From: Shirong Hao <shirong@linux.alibaba.com>
+Date: Thu, 23 Dec 2021 14:54:55 +0800
+Subject: [PATCH 3/3] crypto: ccp: Implement SEV_GET_REPORT ioctl command
+
+The SEV_GET_REPORT command can be used by host program with guest
+firmware handle to import an attestation report.
+The command is defined in SEV spec section 6.8.
+
+Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>
+---
+ drivers/crypto/ccp/sev-dev.c | 19 ++++++++++++++++++-
+ include/uapi/linux/psp-sev.h | 17 +++++++++++++++++
+ 2 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/crypto/ccp/sev-dev.c b/drivers/crypto/ccp/sev-dev.c
+index 2ed8df322f6b..50fa9906d931 100644
+--- a/drivers/crypto/ccp/sev-dev.c
++++ b/drivers/crypto/ccp/sev-dev.c
+@@ -413,7 +413,10 @@ int sev_do_get_report(void __user *report, struct kvm_sev_attestation_report *in
+ 	}
+ cmd:
+ 	data.handle = handle;
+-	ret = sev_issue_cmd_external_user(filep, SEV_CMD_ATTESTATION_REPORT, &data, error);
++	if (!filep)
++		ret = __sev_do_cmd_locked(SEV_CMD_ATTESTATION_REPORT, &data, error);
++	else
++		ret = sev_issue_cmd_external_user(filep, SEV_CMD_ATTESTATION_REPORT, &data, error);
+ 
+ 	/*
+ 	 * If we query the session length, FW responded with expected data.
+@@ -439,6 +442,17 @@ int sev_do_get_report(void __user *report, struct kvm_sev_attestation_report *in
+ }
+ EXPORT_SYMBOL_GPL(sev_do_get_report);
+ 
++static int sev_ioctl_do_get_report(struct sev_issue_cmd *argp)
++{
++	void __user *report = (void __user *)(uintptr_t)argp->data;
++	struct sev_user_data_attestation_report input;
++
++	if (copy_from_user(&input, (void __user *)argp->data, sizeof(input)))
++		return -EFAULT;
++
++	return sev_do_get_report(report, (struct kvm_sev_attestation_report *)&input, NULL, input.handle, &argp->error);
++}
++
+ static int sev_ioctl_do_pek_pdh_gen(int cmd, struct sev_issue_cmd *argp, bool writable)
+ {
+ 	struct sev_device *sev = psp_master->sev_data;
+@@ -925,6 +939,9 @@ static long sev_ioctl(struct file *file, unsigned int ioctl, unsigned long arg)
+ 	case SEV_GET_ID2:
+ 		ret = sev_ioctl_do_get_id2(&input);
+ 		break;
++	case SEV_GET_REPORT:
++		ret = sev_ioctl_do_get_report(&input);
++		break;
+ 	default:
+ 		ret = -EINVAL;
+ 		goto out;
+diff --git a/include/uapi/linux/psp-sev.h b/include/uapi/linux/psp-sev.h
+index 91b4c63d5cbf..293e0a2d786b 100644
+--- a/include/uapi/linux/psp-sev.h
++++ b/include/uapi/linux/psp-sev.h
+@@ -28,6 +28,7 @@ enum {
+ 	SEV_PEK_CERT_IMPORT,
+ 	SEV_GET_ID,	/* This command is deprecated, use SEV_GET_ID2 */
+ 	SEV_GET_ID2,
++	SEV_GET_REPORT,
+ 
+ 	SEV_MAX,
+ };
+@@ -147,6 +148,22 @@ struct sev_user_data_get_id2 {
+ 	__u32 length;				/* In/Out */
+ } __packed;
+ 
++/**
++ * struct sev_user_data_attestation_report - ATTESTATION command parameters
++ *
++ * @mnonce: mnonce to compute HMAC
++ * @uaddr: physical address containing the attestation report
++ * @len: length of attestation report
++ * @handle: handle of the VM to process
++ */
++
++struct sev_user_data_attestation_report {
++       __u8 mnonce[16];                        /* In */
++       __u64 uaddr;                            /* In */
++       __u32 len;                              /* In/Out */
++       __u32 handle;                           /* In */
++};
++
+ /**
+  * struct sev_issue_cmd - SEV ioctl parameters
+  *
+-- 
+2.27.0
+


### PR DESCRIPTION
One patch supports to get sev guest firmware handle with hypercall.
Another patch supports to get sev attestation report by ioctl /dev/sev device.

Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>