### PR TITLE
docs: update repo url to https://mirrors.openanolis.cn

### DIFF
--- a/.github/workflows/manually_repository_setup.yml
+++ b/.github/workflows/manually_repository_setup.yml
@@ -105,8 +105,8 @@ jobs:
       run: |
         docker exec test-deb bash -c "apt-get update;
         apt-get install -y gnupg wget;
-        echo 'deb [arch=amd64] https://mirrors.openanolis.org/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list;
-        wget -qO - https://mirrors.openanolis.org/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | apt-key add -;
+        echo 'deb [arch=amd64] https://mirrors.openanolis.cn/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list;
+        wget -qO - https://mirrors.openanolis.cn/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | apt-key add -;
         apt-get update;
         apt-get install -y rune"
 
@@ -119,10 +119,10 @@ jobs:
         [inclavare-containers]
         name=inclavare-containers
         enabled=1
-        baseurl=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/
+        baseurl=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/
         gpgcheck=1
         repo_gpgcheck=1
-        gpgkey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
-        gpgcakey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
+        gpgkey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
+        gpgcakey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
         EOF"
         docker exec test-rpm bash -c "yum --showduplicate list -y rune; yum install -y rune"

--- a/.github/workflows/nightly-aliyunlinux-sgx2.yml
+++ b/.github/workflows/nightly-aliyunlinux-sgx2.yml
@@ -43,11 +43,11 @@ jobs:
           [inclavare-containers]
           name=inclavare-containers
           enabled=1
-          baseurl=https://mirrors.openanolis.org/inclavare-containers/alinux2-repo/
+          baseurl=https://mirrors.openanolis.cn/inclavare-containers/alinux2-repo/
           gpgcheck=1
           repo_gpgcheck=1
-          gpgkey=https://mirrors.openanolis.org/inclavare-containers/alinux2-repo/RPM-GPG-KEY-rpm-sign
-          gpgcakey=https://mirrors.openanolis.org/inclavare-containers/alinux2-repo/RPM-GPG-KEY-rpm-sign-ca
+          gpgkey=https://mirrors.openanolis.cn/inclavare-containers/alinux2-repo/RPM-GPG-KEY-rpm-sign
+          gpgcakey=https://mirrors.openanolis.cn/inclavare-containers/alinux2-repo/RPM-GPG-KEY-rpm-sign-ca
           EOF
           sudo yum install -y gcc gcc-c++ \
             libsgx-ae-le libsgx-ae-pce libsgx-ae-qe3 libsgx-ae-qve \

--- a/docs/create_a_confidential_computing_kubernetes_cluster_with_inclavare_containers.md
+++ b/docs/create_a_confidential_computing_kubernetes_cluster_with_inclavare_containers.md
@@ -25,11 +25,11 @@ cat << EOF >/etc/yum.repos.d/inclavare-containers.repo
 [inclavare-containers]
 name=inclavare-containers
 enabled=1
-baseurl=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/
+baseurl=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
-gpgcakey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
+gpgkey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
+gpgcakey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
 EOF
 ```
 
@@ -40,15 +40,15 @@ EOF
 sudo apt-get install -y gnupg wget
 
 # add the repository to your sources
-echo 'deb [arch=amd64] https://mirrors.openanolis.org/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+echo 'deb [arch=amd64] https://mirrors.openanolis.cn/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 
 # add the key to the list of trusted keys used by the apt to authenticate packages
-wget -qO - https://mirrors.openanolis.org/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | sudo apt-key add -
+wget -qO - https://mirrors.openanolis.cn/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | sudo apt-key add -
 
 # set a higher priority to epm to avoid conflicts with another epm package which reside in `mirrors.cloud.aliyuncs.com`
 cat << EOF >/etc/apt/preferences.d/inclavare-containers
 Package: epm
-Pin: origin mirrors.openanolis.org
+Pin: origin mirrors.openanolis.cn
 Pin-Priority: 1000
 EOF
 

--- a/inclavare-containers.io/content/en/guides/create-k8s-inclavare-containers/index.md
+++ b/inclavare-containers.io/content/en/guides/create-k8s-inclavare-containers/index.md
@@ -33,11 +33,11 @@ cat << EOF >/etc/yum.repos.d/inclavare-containers.repo
 [inclavare-containers]
 name=inclavare-containers
 enabled=1
-baseurl=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/
+baseurl=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
-gpgcakey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
+gpgkey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
+gpgcakey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
 EOF
 ```
 
@@ -48,10 +48,10 @@ EOF
 sudo apt-get install -y gnupg wget
 
 # add the repository to your sources
-echo 'deb [arch=amd64] https://mirrors.openanolis.org/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+echo 'deb [arch=amd64] https://mirrors.openanolis.cn/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 
 # add the key to the list of trusted keys used by the apt to authenticate packages
-wget -qO - https://mirrors.openanolis.org/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | sudo apt-key add -
+wget -qO - https://mirrors.openanolis.cn/inclavare-containers/deb-repo/DEB-GPG-KEY.key  | sudo apt-key add -
 
 # update the apt
 sudo apt-get update

--- a/inclavare-containers.io/content/en/guides/qucik-start/index.md
+++ b/inclavare-containers.io/content/en/guides/qucik-start/index.md
@@ -35,11 +35,11 @@ This user guide provides the steps to run Occlum with Docker and OCI Runtime `ru
     [inclavare-containers]
     name=inclavare-containers
     enabled=1
-    baseurl=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/
+    baseurl=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/
     gpgcheck=1
     repo_gpgcheck=1
-    gpgkey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
-    gpgcakey=https://mirrors.openanolis.org/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
+    gpgkey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign
+    gpgcakey=https://mirrors.openanolis.cn/inclavare-containers/rpm-repo/RPM-GPG-KEY-rpm-sign-ca
     EOF
     ```
 
@@ -51,12 +51,12 @@ This user guide provides the steps to run Occlum with Docker and OCI Runtime `ru
   - For Ubuntu 18.04-server:
     1. Add the repository to your sources.
     ```shell
-    echo 'deb [arch=amd64] https://mirrors.openanolis.org/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+    echo 'deb [arch=amd64] https://mirrors.openanolis.cn/inclavare-containers/deb-repo bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
     ```
 
     2. Add the key to the list of trusted keys used by the apt to authenticate packages.
     ```shell
-    wget -qO - https://mirrors.openanolis.org/inclavare-containers/deb-repo/DEB-GPG-KEY.key | apt-key add -
+    wget -qO - https://mirrors.openanolis.cn/inclavare-containers/deb-repo/DEB-GPG-KEY.key | apt-key add -
     ```
 
     3. Update the apt and install the packages.


### PR DESCRIPTION
The url of https://mirrors.openanolis.org is replaced by https://mirrors.openanolis.cn.

Fixes: #1461
Signed-off-by: Shirong Hao <shirong@linux.alibaba.com>