### PR TITLE
enclave-tls: fix version number does not start with digit error

### DIFF
--- a/enclave-tls/dist/Makefile
+++ b/enclave-tls/dist/Makefile
@@ -31,7 +31,7 @@ deb: deb/debian/changelog
 package: rpm/enclave_tls.spec.in deb/debian/changelog.in
 ifeq (/etc/debian_version, $(wildcard /etc/debian_version))
 	date=`date "+%a, %d %b %Y %H:%M:%S"` && \
-	sed "1i\enclave_tls ($(ENCLAVE_TLS_VERSION)-1) unstable; urgency=low\n\n  * Update to version $(ENCLAVE_TLS_VERSION).\n\n -- $(ENCLAVE_TLS_MAINTAINER)  $$date +0000\n" deb/debian/changelog.in > deb/debian/changelog;
+	sed "1i\enclave-tls ($(ENCLAVE_TLS_VERSION)-1) unstable; urgency=low\n\n  * Update to version $(ENCLAVE_TLS_VERSION).\n\n -- $(ENCLAVE_TLS_MAINTAINER)  $$date +0000\n" deb/debian/changelog.in > deb/debian/changelog;
 	make deb
 else ifeq (/etc/redhat-release, $(wildcard /etc/redhat-release))
 	sed 's/Version: %{ENCLAVE_TLS_VERSION}/Version: $(ENCLAVE_TLS_VERSION)/' rpm/enclave_tls.spec.in > rpm/enclave_tls.spec && egrep -q '^\* .+ - $(ENCLAVE_TLS_VERSION)' rpm/enclave_tls.spec || { \


### PR DESCRIPTION
This patch resolves the following error:

make deb
make[2]: Entering directory '/root/yijuan/ic_test/inclavare-containers-0.6.4/enclave-tls/dist'
dpkg-buildpackage: warning:     debian/changelog(l1): badly formatted heading line
LINE: enclave_tls (0.6.4-1) unstable; urgency=low
dpkg-buildpackage: warning:     debian/changelog(l2): found blank line where expected first heading
dpkg-buildpackage: warning:     debian/changelog(l3): found change data where expected first heading
LINE:   * Update to version 0.6.4.
dpkg-buildpackage: warning: unknown information field '' in input data in parsed version of changelog
dpkg-buildpackage: info: source package unknown
dpkg-buildpackage: info: source version unknown
dpkg-buildpackage: error: version number does not start with digit

Fixes: #1515
Signed-off-by: Yijuan Huang <yijuan.huang@intel.com>